### PR TITLE
Adding `time` to the list of dependencies

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,8 @@ set -o errexit
 install-deps() {
   # python-dev: for pylibc
   # gawk: used by spec-runner.sh for the special match() function.
-  sudo apt-get install python3-dev gawk
+  # time: used to allow formatting of time output to be consisten across Ubutntu shells
+  sudo apt-get install python3-dev gawk time
 
   ./spec.sh install-shells
 }

--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ set -o errexit
 install-deps() {
   # python-dev: for pylibc
   # gawk: used by spec-runner.sh for the special match() function.
-  # time: used to allow formatting of time output to be consisten across Ubutntu shells
+  # time: used to collect the exit code and timing of a test
   sudo apt-get install python3-dev gawk time
 
   ./spec.sh install-shells


### PR DESCRIPTION
As documented [here](https://www.reddit.com/r/oilshell/comments/5xfyg0/if_you_have_debianubuntu_a_web_server_and_five/), I discovered that the bash builtin `time` on Ubuntu 14.04 does not work like the time binary from apt. This adds `time` as a dependency.