### PR TITLE
Use $(uname -m) for non-x86_64 support in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ pylibc() {
 
   # Wildcard to match any Python 3 version.
   shopt -s failglob
-  local so=$(echo build/lib.linux-x86_64-3.*/libc.cpython-3*.so)
+  local so=$(echo build/lib.linux-$(uname -m)-3.*/libc.cpython-3*.so)
 
   ln -s -f --verbose ../$so core/libc.so
 }


### PR DESCRIPTION
`build.sh` has a hardcoded `x86_64`. Replacing it with a call to `$(uname -m)` means that at least some of the tests pass on `armv6l`.