### PR TITLE
Some portability fixes

### DIFF
--- a/asdl/arith_ast.py
+++ b/asdl/arith_ast.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 arith_ast.py
 """

--- a/asdl/arith_ast_test.py
+++ b/asdl/arith_ast_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 arith_ast_test.py: Tests for arith_ast.py
 """

--- a/asdl/arith_parse.py
+++ b/asdl/arith_parse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """
 arith_parse.py: Parse shell-like and C-like arithmetic.

--- a/asdl/arith_parse_test.py
+++ b/asdl/arith_parse_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from asdl import tdop
 from asdl import arith_parse
 

--- a/asdl/asdl_demo.py
+++ b/asdl/asdl_demo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """
 asdl_demo.py

--- a/asdl/encode_test.py
+++ b/asdl/encode_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 encode_test.py: Tests for encode.py
 """

--- a/asdl/gen_cpp.py
+++ b/asdl/gen_cpp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """
 asdl_cpp.py

--- a/asdl/py_meta.py
+++ b/asdl/py_meta.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 py_meta.py
 

--- a/asdl/py_meta_test.py
+++ b/asdl/py_meta_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 py_meta_test.py: Tests for py_meta.py
 """

--- a/asdl/run.sh
+++ b/asdl/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Automation for ASDL.
 #

--- a/asdl/tdop.py
+++ b/asdl/tdop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 tdop.py
 """

--- a/benchmarks/awk-python.sh
+++ b/benchmarks/awk-python.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test awk vs Python speed.
 #

--- a/benchmarks/startup.sh
+++ b/benchmarks/startup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./startup.sh <function name>

--- a/bin/oil.py
+++ b/bin/oil.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Andy Chu. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bin/opy_.py
+++ b/bin/opy_.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 opy_.py
 """

--- a/build/actions.sh
+++ b/build/actions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Build actions used in the Makefile.
 #

--- a/build/app_deps.py
+++ b/build/app_deps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env python -S
 """
 py_deps.py
 

--- a/build/app_deps_test.py
+++ b/build/app_deps_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env python -S
 """
 app_deps_test.py: Tests for app_deps.py
 """

--- a/build/c_module_srcs.py
+++ b/build/c_module_srcs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 c_module_srcs.py
 """

--- a/build/c_module_toc.py
+++ b/build/c_module_toc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 c_module_toc.py
 """

--- a/build/common.sh
+++ b/build/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o nounset
 set -o pipefail

--- a/build/compile.sh
+++ b/build/compile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./compile.sh <function name>

--- a/build/config1.sh
+++ b/build/config1.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Use clang for the C compiler.
 #

--- a/build/make_zip.py
+++ b/build/make_zip.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env python -S
 """
 make_zip.py
 

--- a/build/prepare.sh
+++ b/build/prepare.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Do a full CPython build out of tree, so we can walk dependencies dynamically.
 #

--- a/build/pylibc.sh
+++ b/build/pylibc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Build Python extension modules.  We use symlinks instead of installing them
 # globally (or using virtualenv).
@@ -19,7 +19,7 @@ build() {
   shopt -s failglob
   local so=$(echo _build/pylibc/$arch/libc.so)
 
-  ln -s -f --verbose $so libc.so
+  ln -s -f -v $so libc.so
   file libc.so
 }
 

--- a/build/runpy_deps.py
+++ b/build/runpy_deps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env python -S
 """
 runpy_deps.py
 

--- a/build/setup.py
+++ b/build/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from distutils.core import setup, Extension
 
 module = Extension('libc',

--- a/build/stats.sh
+++ b/build/stats.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Stats about build artifacts.
 #

--- a/build/test.sh
+++ b/build/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./test.sh <function name>

--- a/build/testdata/future_import.py
+++ b/build/testdata/future_import.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 future_import.py
 """

--- a/build/testdata/hello.py
+++ b/build/testdata/hello.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 hello.py
 """

--- a/build/testdata/lib.py
+++ b/build/testdata/lib.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 lib.py
 """

--- a/core/args.py
+++ b/core/args.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 args.py - Flag, option, and arg parsing for the shell.
 

--- a/core/args_test.py
+++ b/core/args_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env python -S
 """
 args_test.py: Tests for args.py
 """

--- a/core/braces.py
+++ b/core/braces.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """
 braces.py

--- a/core/braces_test.py
+++ b/core/braces_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 braces_test.py: Tests for braces.py
 """

--- a/core/builtin.py
+++ b/core/builtin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Andy Chu. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/core/cmd_exec.py
+++ b/core/cmd_exec.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Andy Chu. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/core/cmd_exec_test.py
+++ b/core/cmd_exec_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Andy Chu. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/core/completion.py
+++ b/core/completion.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Andy Chu. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/core/completion_test.py
+++ b/core/completion_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Andy Chu. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/core/expr_eval.py
+++ b/core/expr_eval.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Andy Chu. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/core/glob_.py
+++ b/core/glob_.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 glob_.py
 """

--- a/core/glob_test.py
+++ b/core/glob_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 glob_test.py: Tests for glob.py
 """

--- a/core/id_kind.py
+++ b/core/id_kind.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Andy Chu. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/core/id_kind_gen.py
+++ b/core/id_kind_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Andy Chu. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/core/id_kind_test.py
+++ b/core/id_kind_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Andy Chu. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/core/lexer.py
+++ b/core/lexer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Andy Chu. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/core/lexer_test.py
+++ b/core/lexer_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 lexer_test.py: Tests for lexer.py
 """

--- a/core/process.py
+++ b/core/process.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Andy Chu. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/core/process_test.py
+++ b/core/process_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env python -S
 """
 process_test.py: Tests for process.py
 """

--- a/core/reader.py
+++ b/core/reader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Andy Chu. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/core/runtime.py
+++ b/core/runtime.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 core/runtime.py -- Parse runtime.asdl and dynamically create classes on this module.
 

--- a/core/shell_test.py
+++ b/core/shell_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Andy Chu. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/core/state.py
+++ b/core/state.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Andy Chu. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/core/state_test.py
+++ b/core/state_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env python -S
 """
 state_test.py: Tests for state.py
 """

--- a/core/tdop.py
+++ b/core/tdop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 tdop.py - Library for expression parsing.
 """

--- a/core/test_lib.py
+++ b/core/test_lib.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Andy Chu. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/core/ui.py
+++ b/core/ui.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Andy Chu. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/core/util.py
+++ b/core/util.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Andy Chu. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/core/util_test.py
+++ b/core/util_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Andy Chu. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/core/word_eval_test.py
+++ b/core/word_eval_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Andy Chu. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/core/word_test.py
+++ b/core/word_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 word_test.py: Tests for word.py
 """

--- a/deps.sh
+++ b/deps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Install development dependencies.
 #

--- a/native/libc.c
+++ b/native/libc.c
@@ -32,7 +32,11 @@ limitations under the License.
 
 #include <fnmatch.h>
 #include <glob.h>
-#include <regex.h>
+#ifdef __FreeBSD__
+#include <gnu/posix/regex.h>
+#else
+include <regex.h>
+#endif
 
 #include <Python.h>
 

--- a/native/libc_test.py
+++ b/native/libc_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Andy Chu. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/opy/build.sh
+++ b/opy/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./build.sh <function name>

--- a/opy/byterun/run.sh
+++ b/opy/byterun/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./run.sh <function name>

--- a/opy/byterun/test_basic.py
+++ b/opy/byterun/test_basic.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """Basic tests for Byterun."""
 

--- a/opy/byterun/test_exceptions.py
+++ b/opy/byterun/test_exceptions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """Test exceptions for Byterun."""
 

--- a/opy/byterun/test_functions.py
+++ b/opy/byterun/test_functions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """Test functions etc, for Byterun."""
 

--- a/opy/byterun/test_with.py
+++ b/opy/byterun/test_with.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """Test the with statement for Byterun."""
 
 from __future__ import print_function

--- a/opy/common.sh
+++ b/opy/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./common.sh <function name>

--- a/opy/compare.sh
+++ b/opy/compare.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./compare.sh <function name>

--- a/opy/compiler2/symbols_test.py
+++ b/opy/compiler2/symbols_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env python -S
 """
 symbols_test.py: Tests for symbols.py
 

--- a/opy/misc/ccompile.py
+++ b/opy/misc/ccompile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 ccompile.py - Compile with builtin compile() function, which uses compile.c.
 """

--- a/opy/misc/determinism.py
+++ b/opy/misc/determinism.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """
 determinism.py

--- a/opy/misc/pgen_ast.py
+++ b/opy/misc/pgen_ast.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 foil/pgen_ast.py -- Parse pgen.asdl and dynamically create classes on this
 module.

--- a/opy/misc/py_ast.py
+++ b/opy/misc/py_ast.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 Wrapper for Python.asdl.
 """

--- a/opy/misc/stdlib_compile.py
+++ b/opy/misc/stdlib_compile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """
 stdlib_compile.py

--- a/opy/opy_main.py
+++ b/opy/opy_main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 opy_main.py
 """

--- a/opy/pgen2/pgen.py
+++ b/opy/pgen2/pgen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2004-2005 Elemental Security, Inc. All Rights Reserved.
 # Licensed to PSF under a Contributor Agreement.
 

--- a/opy/run.sh
+++ b/opy/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./run.sh <function name>

--- a/opy/smoke.sh
+++ b/opy/smoke.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Smoke tests for OPy.
 #

--- a/opy/tests/genexpr.py
+++ b/opy/tests/genexpr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 Test for generator expressions.
 """

--- a/opy/tests/genexpr_simple.py
+++ b/opy/tests/genexpr_simple.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 Simpler test for generator expressions.
 """

--- a/opy/tools/compile.py
+++ b/opy/tools/compile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import sys
 import getopt
 

--- a/opy/tools/demo.py
+++ b/opy/tools/demo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """Print names of all methods defined in module
 

--- a/opy/tools/dumppyc.py
+++ b/opy/tools/dumppyc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import marshal
 import dis

--- a/opy/tools/regrtest.py
+++ b/opy/tools/regrtest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """Run the Python regression test using the compiler
 

--- a/opy/util_opy.py
+++ b/opy/util_opy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 util.py
 """

--- a/osh/arith_parse.py
+++ b/osh/arith_parse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 arith_parse.py - Parse shell arithmetic, which is based on C.
 """

--- a/osh/arith_parse_test.py
+++ b/osh/arith_parse_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Andy Chu. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/osh/ast_.py
+++ b/osh/ast_.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 osh/ast_.py -- Parse osh.asdl and dynamically create classes on this module.
 """

--- a/osh/bool_parse.py
+++ b/osh/bool_parse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Andy Chu. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/osh/bool_parse_test.py
+++ b/osh/bool_parse_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Andy Chu. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/osh/cmd_parse.py
+++ b/osh/cmd_parse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Andy Chu. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/osh/cmd_parse_test.py
+++ b/osh/cmd_parse_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 cmd_parse_test.py: Tests for cmd_parse.py
 """

--- a/osh/lex_test.py
+++ b/osh/lex_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 lex_test.py: Tests for lex.py
 """

--- a/osh/word_parse.py
+++ b/osh/word_parse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Andy Chu. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/osh/word_parse_test.py
+++ b/osh/word_parse_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2016 Andy Chu. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/count.sh
+++ b/scripts/count.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Count lines ofcode in various ways.
 #

--- a/scripts/refactor.sh
+++ b/scripts/refactor.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./refactor.sh <function name>

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Miscellaneous scripts that don't belong elsewhere.
 #

--- a/spec/01-bad-func.sh
+++ b/spec/01-bad-func.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # 
 # NOTE: The error message is different at interactive prompt:
 #

--- a/spec/02-bad-func.sh
+++ b/spec/02-bad-func.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 foo() 

--- a/spec/03-glob.sh
+++ b/spec/03-glob.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./03-glob.sh <function name>

--- a/spec/04-case-in-subshell.sh
+++ b/spec/04-case-in-subshell.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 foo=a
 case $foo in [0-9]) echo number;; [a-z]) echo letter;; esac

--- a/spec/05-unterminated-single.sh
+++ b/spec/05-unterminated-single.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo A
 echo B

--- a/spec/06-unterminated-double-long.sh
+++ b/spec/06-unterminated-double-long.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./06-unterminated-double-long.sh <function name>

--- a/spec/06-unterminated-double.sh
+++ b/spec/06-unterminated-double.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo A
 echo B

--- a/spec/07-unterminated-here-doc.sh
+++ b/spec/07-unterminated-here-doc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # bash issues a warning; dash lets you continue.
 

--- a/spec/08-dollar0.sh
+++ b/spec/08-dollar0.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo $0
 

--- a/spec/09-here-doc-compound.sh
+++ b/spec/09-here-doc-compound.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # COMPOUND here docs mixed with individual here docs
 # This shows it has to be a depth first search, but POST ORDER TRAVERSAL.
 while cat <<EOF1; read line; do echo "  -> line: '$line'"; cat <<EOF2; done <<EOF3

--- a/spec/09-here-doc.sh
+++ b/spec/09-here-doc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./09-here-doc.sh <function name>

--- a/spec/10-async.sh
+++ b/spec/10-async.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Testing compound statements with &.
 

--- a/spec/11-brace-redirect.sh
+++ b/spec/11-brace-redirect.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o nounset
 set -o pipefail

--- a/spec/12-command-sub-2.sh
+++ b/spec/12-command-sub-2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo $(echo foo)
 

--- a/spec/12-command-sub.sh
+++ b/spec/12-command-sub.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 
 sleep_test() {

--- a/spec/13-big-here-doc.sh
+++ b/spec/13-big-here-doc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./13-big-here-doc.sh <function name>

--- a/spec/14-parse-order.sh
+++ b/spec/14-parse-order.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./14-parse-order.sh <function name>

--- a/spec/15-subshell-error.sh
+++ b/spec/15-subshell-error.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit
 

--- a/spec/16-errexit.sh
+++ b/spec/16-errexit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./16-errexit.sh <function name>

--- a/spec/append.test.sh
+++ b/spec/append.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ### Append string to string
 s='abc'

--- a/spec/arith-context.test.sh
+++ b/spec/arith-context.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test arithmetic expressions in all their different contexts.
 

--- a/spec/arith.test.sh
+++ b/spec/arith.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Interesting interpretation of constants.
 #

--- a/spec/array-compat.test.sh
+++ b/spec/array-compat.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Arrays decay upon assignment (without splicing) and equality.  This will not
 # be true in Oil -- arrays will be first class.

--- a/spec/array.test.sh
+++ b/spec/array.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # TODO: Need a SETUP section.
 

--- a/spec/assign.test.sh
+++ b/spec/assign.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ### Env value doesn't persist
 FOO=foo printenv.py FOO

--- a/spec/assoc-zsh.test.sh
+++ b/spec/assoc-zsh.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Differences from bash:
 # - literal syntax alternates key-value

--- a/spec/assoc.test.sh
+++ b/spec/assoc.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # NOTE:
 # -declare -A is required.

--- a/spec/background-status.sh
+++ b/spec/background-status.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./background-status.sh <function name>

--- a/spec/background.test.sh
+++ b/spec/background.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Job control constructs:
 #   & terminator (instead of ;)

--- a/spec/bin/argv.py
+++ b/spec/bin/argv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 
 import sys

--- a/spec/bin/printenv.py
+++ b/spec/bin/printenv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 
 import os

--- a/spec/bin/read_from_fd.py
+++ b/spec/bin/read_from_fd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """
 read_from_fd.py

--- a/spec/bin/show_fd_table.py
+++ b/spec/bin/show_fd_table.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 show_fd_table.py -- Uses Linux-specific proc interface
 """

--- a/spec/bin/stdout_stderr.py
+++ b/spec/bin/stdout_stderr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """
 stdout_stderr.py

--- a/spec/blog1.test.sh
+++ b/spec/blog1.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Tests for the blog.
 #

--- a/spec/brace-expansion.test.sh
+++ b/spec/brace-expansion.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ### no expansion
 echo {foo}

--- a/spec/bugs.test.sh
+++ b/spec/bugs.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ### echo keyword
 echo done

--- a/spec/builtin-vars.test.sh
+++ b/spec/builtin-vars.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Tests for builtins having to do with variables: export, readonly, unset, etc.
 #

--- a/spec/builtins-special.test.sh
+++ b/spec/builtins-special.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # POSIX rule about special builtins pointed at:
 #

--- a/spec/builtins.test.sh
+++ b/spec/builtins.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ### echo dashes
 echo -

--- a/spec/case_.test.sh
+++ b/spec/case_.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test the case statement
 

--- a/spec/command-parsing.test.sh
+++ b/spec/command-parsing.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Some nonsensical combinations which can all be detected at PARSE TIME.
 # All shells allow these, but right now OSH disallowed.

--- a/spec/command-sub.test.sh
+++ b/spec/command-sub.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ### case
 foo=a; case $foo in [0-9]) echo number;; [a-z]) echo letter;; esac

--- a/spec/command_.test.sh
+++ b/spec/command_.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Miscellaneous tests for the command language.
 

--- a/spec/comments.sh
+++ b/spec/comments.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./comments.sh <function name>

--- a/spec/comments.test.sh
+++ b/spec/comments.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # NOTE: The test harness isn't good for this test; it strips lines that start
 # with #

--- a/spec/coproc.py
+++ b/spec/coproc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 coproc.py
 """

--- a/spec/coproc.sh
+++ b/spec/coproc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Demo of coprocesses
 #

--- a/spec/dbracket.test.sh
+++ b/spec/dbracket.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ### [[ glob matching, [[ has no glob expansion
 [[ foo.py == *.py ]] && echo true

--- a/spec/declare.sh
+++ b/spec/declare.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./declare.sh <function name>

--- a/spec/dparen.test.sh
+++ b/spec/dparen.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ### (( )) result
 (( 1 )) && echo True

--- a/spec/echo.sh
+++ b/spec/echo.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "$@"

--- a/spec/errexit.sh
+++ b/spec/errexit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./errexit.sh <function name>

--- a/spec/explore-parsing.test.sh
+++ b/spec/explore-parsing.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Tests that explore parsing corner cases.
 

--- a/spec/export.sh
+++ b/spec/export.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./export.sh <function name>

--- a/spec/extended-glob.test.sh
+++ b/spec/extended-glob.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This is an OPTION in bash, but not mksh (because the feature originated in
 # ksh).  So it's probably low priority.

--- a/spec/for-expr.test.sh
+++ b/spec/for-expr.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Constructs borrowed from ksh.  Hm I didn't realize zsh also implements these!
 # mksh implements most too.

--- a/spec/func-parsing.test.sh
+++ b/spec/func-parsing.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ### Incomplete Function
 # code: foo()

--- a/spec/func.test.sh
+++ b/spec/func.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ### Locals don't leak
 f() {

--- a/spec/glob.test.sh
+++ b/spec/glob.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # NOTE: Could move spec/03-glob.sh here.
 

--- a/spec/here-doc.test.sh
+++ b/spec/here-doc.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ### Here redirect with explicit descriptor
 # A space betwen 0 and <<EOF causes it to pass '0' as an arg to cat.

--- a/spec/history.sh
+++ b/spec/history.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./history.sh <function name>

--- a/spec/if_.test.sh
+++ b/spec/if_.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test the if statement
 

--- a/spec/let.test.sh
+++ b/spec/let.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # let arithmetic.
 

--- a/spec/line-number.sh
+++ b/spec/line-number.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Demo of line numbers, inspired by:
 #

--- a/spec/loop.test.sh
+++ b/spec/loop.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ### implicit for loop
 # This is like "for i in $@".

--- a/spec/osh-only.test.sh
+++ b/spec/osh-only.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ### debug-line builtin
 debug-line 'hi there'

--- a/spec/parse-errors.test.sh
+++ b/spec/parse-errors.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ### Bad var sub
 echo $%

--- a/spec/pipeline.test.sh
+++ b/spec/pipeline.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Tests for pipelines.
 # NOTE: Grammatically, ! is part of the pipeline:

--- a/spec/posix.test.sh
+++ b/spec/posix.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Cases from
 # http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html

--- a/spec/process-sub.test.sh
+++ b/spec/process-sub.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ### Process sub input
 f=_tmp/process-sub.txt

--- a/spec/quote.test.sh
+++ b/spec/quote.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Tests for quotes.
 

--- a/spec/readonly.sh
+++ b/spec/readonly.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./readonly.sh <function name>

--- a/spec/redirect.test.sh
+++ b/spec/redirect.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ### Leading redirect
 echo hello >$TMP/hello.txt  # temporary fix

--- a/spec/regex.test.sh
+++ b/spec/regex.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Only bash and zsh seem to implement [[ foo =~ '' ]]
 #

--- a/spec/runtime-errors.sh
+++ b/spec/runtime-errors.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   $SH ./runtime-errors.sh all

--- a/spec/scope.sh
+++ b/spec/scope.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Demo of variable scope.
 

--- a/spec/sh-options.test.sh
+++ b/spec/sh-options.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test set flags, sh flags.
 

--- a/spec/shell-grammar.test.sh
+++ b/spec/shell-grammar.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test cases for the grammar.  It uses pidgin shell because we don't have a
 # proper lexer in ANTLR (ANTLR's lexers don't have states anyway.)

--- a/spec/show-fd-table.sh
+++ b/spec/show-fd-table.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./show-fd-table.sh <function name>

--- a/spec/smoke.test.sh
+++ b/spec/smoke.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # For testing the Python sketch
 

--- a/spec/special-vars.test.sh
+++ b/spec/special-vars.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # NOTE:
 # - $! is tested in background.test.sh

--- a/spec/subshell.test.sh
+++ b/spec/subshell.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ### Subshell exit code
 ( false; )

--- a/spec/test-builtin.test.sh
+++ b/spec/test-builtin.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ### empty string is false.  Equivalent to -n.
 test 'a'  && echo true

--- a/spec/tilde.test.sh
+++ b/spec/tilde.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ### ~ expansion in assignment
 HOME=/home/bob

--- a/spec/unicode.sh
+++ b/spec/unicode.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./unicode.sh <function name>

--- a/spec/var-num.test.sh
+++ b/spec/var-num.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test $0 $1 $2
 

--- a/spec/var-op-other.test.sh
+++ b/spec/var-op-other.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test combination of var ops.
 

--- a/spec/var-op-strip.test.sh
+++ b/spec/var-op-strip.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ### Remove const suffix
 v=abcd

--- a/spec/var-op-test.test.sh
+++ b/spec/var-op-test.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ### Lazy Evaluation of Alternative
 i=0

--- a/spec/var-ref.test.sh
+++ b/spec/var-ref.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Var refs are done with ${!a} and local/declare -n.
 #

--- a/spec/var-sub-quote.test.sh
+++ b/spec/var-sub-quote.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # 
 # Tests for the args in:
 #

--- a/spec/var-sub.test.sh
+++ b/spec/var-sub.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Corner cases in var sub.  Maybe rename this file.
 

--- a/spec/word-eval.test.sh
+++ b/spec/word-eval.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # word-eval.test.sh: Test the word evaluation pipeline in order.
 #

--- a/spec/word-split.test.sh
+++ b/spec/word-split.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # NOTE on bash bug:  After setting IFS to array, it never splits anymore?  Even
 # if you assign IFS again.

--- a/spec/xtrace.sh
+++ b/spec/xtrace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./xtrace.sh <function name>

--- a/test/gold.sh
+++ b/test/gold.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Run real shell code with osh and bash, and compare the results.
 #

--- a/test/lint.sh
+++ b/test/lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Run tools to maintain the coding style.
 #

--- a/test/osh2oil.sh
+++ b/test/osh2oil.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./osh-to-oil-test.sh <function name>

--- a/test/publish.sh
+++ b/test/publish.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./publish.sh <function name>

--- a/test/sh_spec.py
+++ b/test/sh_spec.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """
 sh_spec.py -- Test framework to compare shells.

--- a/test/sh_spec_test.py
+++ b/test/sh_spec_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 sh_spec_test.py: Tests for sh_spec.py
 """

--- a/test/smoke.sh
+++ b/test/smoke.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Sanity checks for the shell.
 #

--- a/test/spec-runner.sh
+++ b/test/spec-runner.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Run tests against multiple shells with the sh_spec framework.
 #

--- a/test/spec.sh
+++ b/test/spec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./spec-file.sh <function name>
@@ -7,18 +7,23 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-readonly DASH=/bin/dash
-readonly BASH=/bin/bash
-readonly MKSH=/bin/mksh
-readonly ZSH=/usr/bin/zsh  # Ubuntu puts it here
+readonly DASH=$(which dash 2>/dev/null || echo /bin/sh)
+readonly BASH=$(which bash)
+readonly MKSH=$(which mksh)
+readonly ZSH=$(which zsh)
 readonly BUSYBOX_ASH=_tmp/shells/ash
 
-# TODO: Does it make sense to copy the binary to an unrelated to directory,
-# like /tmp?  /tmp/{oil.ovm,osh}.
-readonly OSH_BIN=_bin/osh
+if test -f _bin/osh; then
+  # TODO: Does it make sense to copy the binary to an unrelated to directory,
+  # like /tmp?  /tmp/{oil.ovm,osh}.
+  readonly OSH_BIN=_bin/osh
 
-# HACK that relies on word splitting.  TODO: Use ${OSH[@]} everywhere
-readonly OSH="bin/osh $OSH_BIN"
+  # HACK that relies on word splitting.  TODO: Use ${OSH[@]} everywhere
+  readonly OSH="bin/osh $OSH_BIN"
+else
+  readonly OSH="bin/osh"
+fi
+
 
 # ash and dash are similar, so not including ash by default.  zsh is not quite
 # POSIX.

--- a/test/unit.sh
+++ b/test/unit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Run unit tests.  Sets PYTHONPATH.
 #

--- a/test/wild.sh
+++ b/test/wild.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Run the osh parser on shell scripts found in the wild.
 #

--- a/test/wild2.sh
+++ b/test/wild2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Wild tests that actually run code.
 #

--- a/tools/osh2oil_test.py
+++ b/tools/osh2oil_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 osh2oil_test.py: Tests for osh2oil.py
 """


### PR DESCRIPTION
- include correct regex header on FreeBSD
- use `#!/usr/bin/env` instead of hardcoded Linux paths
- find shells with `which`

`test/spec.sh smoke` works on FreeBSD with this patch, but the `spec-runner.sh` is way too full of linuxisms and GNUisms for me to fix without losing functionality (e.g. `time --output … --format …` — BSD time has `-o` for output file, but no custom format option whatsoever. BSD xargs has no `--verbose`. `nproc` is linux only. etc. etc. etc.)