### PR TITLE
Make more shebangs compatible

### DIFF
--- a/build/doc.sh
+++ b/build/doc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage:
 #   ./run.sh <function name>

--- a/build/quick_ref.py
+++ b/build/quick_ref.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 quick_ref.py
 """


### PR DESCRIPTION
Several of the tests continue to refer to /usr/bin/python. I don't
know of a way to fix these, as they call python -S and IIRC shebangs
can only include one parameter…