### PR TITLE
Tests: portability improvements and additional test

### DIFF
--- a/spec/show-fd-table.sh
+++ b/spec/show-fd-table.sh
@@ -13,7 +13,7 @@ show-fd-table() {
   echo "   function in pid $$"
   # Make it truly parallel
   sleep 0.5
-  /usr/bin/time --output /tmp/$$.txt -- spec/bin/show_fd_table.py "$@"
+  /usr/bin/env time --output /tmp/$$.txt -- spec/bin/show_fd_table.py "$@"
 }
 
 # Trying to recreate spec-runner problem with file descriptors.
@@ -25,7 +25,7 @@ main() {
   echo
 
   # File descriptor 3 is open!
-  /usr/bin/time --output /tmp/task.txt -- spec/bin/show_fd_table.py 
+  /usr/bin/env time --output /tmp/task.txt -- spec/bin/show_fd_table.py
   echo
 
   # Cannot reproduce problem.  What's the deal with descriptors 8 and 9?  Oh

--- a/spec/var-sub-quote.test.sh
+++ b/spec/var-sub-quote.test.sh
@@ -14,6 +14,11 @@
 # LexState.OUTER.  If we have "${}", then it's parsed as LexState.DQ.  That
 # makes sense I guess.  Vim's syntax highlighting is throwing me off.
 
+### :- with empty alternative
+foo=
+argv.py "${foo:-}"
+# stdout: ['']
+
 ### :-
 empty=''
 argv.py ${empty:-a} ${Unset:-b}

--- a/test/spec-runner.sh
+++ b/test/spec-runner.sh
@@ -62,7 +62,7 @@ run-task-with-status() {
   shift
 
   # --quiet suppresses a warning message
-  /usr/bin/time \
+  /usr/bin/env time \
     --output $out_file \
     --format '%x %e' \
     -- "$@" || true  # suppress failure

--- a/test/spec.sh
+++ b/test/spec.sh
@@ -37,7 +37,7 @@ readonly REF_SHELLS=($DASH $BASH $MKSH)
 install-shells() {
   sudo apt-get install busybox-static mksh zsh
   mkdir -p _tmp/shells
-  ln -s -f --verbose /bin/busybox $BUSYBOX_ASH
+  ln -s -f --verbose "$(which busybox)" $BUSYBOX_ASH
 }
 
 # TODO: Maybe do this before running all tests.


### PR DESCRIPTION
Hope you don't mind me lumping this all up in one PR, if that's a problem I can split it.

This improves portability to the point that the tests will run on NixOS; there's still a multitude of failures caused by the assumption that ls lives in /bin, but it's a start :)