### PR TITLE
Adds error handling to the `pushd` and `popd` builtins.

### DIFF
--- a/core/builtin.py
+++ b/core/builtin.py
@@ -492,6 +492,7 @@ def Pushd(argv, dir_stack):
     return 1
   elif num_args > 1:
     log("pushd: too many arguments")
+    return 1
 
   dest_dir = argv[0]
   if os.path.isdir(dest_dir):

--- a/core/builtin.py
+++ b/core/builtin.py
@@ -484,7 +484,6 @@ def Cd(argv, mem):
 
 
 def Pushd(argv, dir_stack):
-  dir_stack.append(os.getcwd())
   num_args = len(argv)
 
   if num_args <= 0:
@@ -501,6 +500,7 @@ def Pushd(argv, dir_stack):
     util.error("cd: %r: %s", dest_dir, os.strerror(e.errno))
     return 1
 
+  dir_stack.append(os.getcwd())
   return 0
 
 

--- a/core/builtin.py
+++ b/core/builtin.py
@@ -488,17 +488,17 @@ def Pushd(argv, dir_stack):
   num_args = len(argv)
 
   if num_args <= 0:
-    log("pushd: no other directory")
+    util.error('pushd: no other directory')
     return 1
   elif num_args > 1:
-    log("pushd: too many arguments")
+    util.error('pushd: too many arguments')
     return 1
 
   dest_dir = argv[0]
-  if os.path.isdir(dest_dir):
+  try:
     os.chdir(dest_dir)
-  else:
-    log("pushd: " + dest_dir + ": No such file or directory")
+  except OSError as e:
+    util.error("cd: %r: %s", dest_dir, os.strerror(e.errno))
     return 1
 
   return 0
@@ -508,13 +508,13 @@ def Popd(argv, dir_stack):
   try:
     dest_dir = dir_stack.pop()
   except IndexError:
-    log("popd: directory stack is empty")
+    log('popd: directory stack is empty')
     return 1
 
-  if os.path.isdir(dest_dir):
+  try:
     os.chdir(dest_dir)
-  else:
-    log("popd: " + dest_dir + ": No such file or directory")
+  except OSError as e:
+    util.error("cd: %r: %s", dest_dir, os.strerror(e.errno))
     return 1
 
   return 0

--- a/core/builtin.py
+++ b/core/builtin.py
@@ -485,8 +485,21 @@ def Cd(argv, mem):
 
 def Pushd(argv, dir_stack):
   dir_stack.append(os.getcwd())
+  num_args = len(argv)
+
+  if num_args <= 0:
+    log("pushd: no other directory")
+    return 1
+  elif num_args > 1:
+    log("pushd: too many arguments")
+
   dest_dir = argv[0]
-  os.chdir(dest_dir)  # TODO: error checking
+  if os.path.isdir(dest_dir):
+    os.chdir(dest_dir)
+  else:
+    log("pushd: " + dest_dir + ": No such file or directory")
+    return 1
+
   return 0
 
 
@@ -494,9 +507,15 @@ def Popd(argv, dir_stack):
   try:
     dest_dir = dir_stack.pop()
   except IndexError:
-    log('popd: directory stack is empty')
+    log("popd: directory stack is empty")
     return 1
-  os.chdir(dest_dir)  # TODO: error checking
+
+  if os.path.isdir(dest_dir):
+    os.chdir(dest_dir)
+  else:
+    log("popd: " + dest_dir + ": No such file or directory")
+    return 1
+
   return 0
 
 


### PR DESCRIPTION
`pushd` and `popd` were crashing when given malformed input or absent input. I've added some error handling to prevent those crashes. The error messages are the same as given by `pushd` and `popd` in bash.