### PR TITLE
Implement `dirs` builtin flags

### DIFF
--- a/core/builtin.py
+++ b/core/builtin.py
@@ -540,11 +540,17 @@ def Dirs(argv, dir_stack):
   if arg.c:
     del dir_stack[:]
   elif arg.v:
-    for i, entry in enumerate(dir_stack):
-      print('%2d %s' % (i, entry))
+    temp_stack = dir_stack[:]
+    temp_stack.insert(0, os.getcwd())
+    for i, entry in enumerate(temp_stack):
+      print('%2d  %s' % (i, entry))
+    sys.stdout.flush()
   elif arg.p:
-    for entry in dir_stack:
+    temp_stack = dir_stack[:]
+    temp_stack.insert(0, os.getcwd())
+    for entry in temp_stack:
       print(entry)
+    sys.stdout.flush()
   else:
     PrintDirStack(dir_stack)
 

--- a/core/builtin.py
+++ b/core/builtin.py
@@ -484,9 +484,8 @@ def Cd(argv, mem):
 
 
 def PrintDirStack(dir_stack):
-  if dir_stack:
-    print(' '.join(dir_stack))
-
+  print(os.getcwd() + ((' ' + ' '.join(dir_stack)) if dir_stack else ''))
+  sys.stdout.flush()
 
 def Pushd(argv, dir_stack):
   num_args = len(argv)
@@ -498,13 +497,14 @@ def Pushd(argv, dir_stack):
     return 1
 
   dest_dir = argv[0]
+  current_dir = os.getcwd()
   try:
     os.chdir(dest_dir)
   except OSError as e:
     util.error("pushd: %r: %s", dest_dir, os.strerror(e.errno))
     return 1
 
-  dir_stack.append(os.getcwd())
+  dir_stack.append(current_dir)
   PrintDirStack(dir_stack)
   return 0
 

--- a/core/builtin.py
+++ b/core/builtin.py
@@ -483,9 +483,25 @@ def Cd(argv, mem):
   return 0
 
 
-def PrintDirStack(dir_stack):
-  print(os.getcwd() + ((' ' + ' '.join(dir_stack)) if dir_stack else ''))
-  sys.stdout.flush()
+WITH_PREFIX = 1
+WITHOUT_PREFIX = 2
+SINGLE_LINE = 3
+def PrintDirStack(dir_stack, mode = 3):
+  dirs = [os.getcwd()]
+  dirs.extend(dir_stack)
+  if mode == 1:
+    for i, entry in enumerate(dirs):
+      print('%2d  %s' % (i, entry))
+    sys.stdout.flush()
+  elif mode == 2:
+    for entry in dirs:
+      print(entry)
+    sys.stdout.flush()
+  elif mode == 3:
+    if dirs:
+      print(' '.join(dirs))
+      sys.stdout.flush()
+
 
 def Pushd(argv, dir_stack):
   num_args = len(argv)
@@ -540,20 +556,11 @@ def Dirs(argv, dir_stack):
   if arg.c:
     del dir_stack[:]
   elif arg.v:
-    temp_stack = dir_stack[:]
-    temp_stack.insert(0, os.getcwd())
-    for i, entry in enumerate(temp_stack):
-      print('%2d  %s' % (i, entry))
-    sys.stdout.flush()
+    PrintDirStack(dir_stack, WITH_PREFIX)
   elif arg.p:
-    temp_stack = dir_stack[:]
-    temp_stack.insert(0, os.getcwd())
-    for entry in temp_stack:
-      print(entry)
-    sys.stdout.flush()
+    PrintDirStack(dir_stack, WITHOUT_PREFIX)
   else:
-    PrintDirStack(dir_stack)
-
+    PrintDirStack(dir_stack, SINGLE_LINE)
   return 0
 
 

--- a/core/builtin.py
+++ b/core/builtin.py
@@ -486,22 +486,19 @@ def Cd(argv, mem):
 WITH_PREFIX = 1
 WITHOUT_PREFIX = 2
 SINGLE_LINE = 3
-def PrintDirStack(dir_stack, mode = 3):
+
+def PrintDirStack(dir_stack, mode):
   dirs = [os.getcwd()]
   dirs.extend(dir_stack)
-  if mode == 1:
+  if mode == WITH_PREFIX:
     for i, entry in enumerate(dirs):
       print('%2d  %s' % (i, entry))
-    sys.stdout.flush()
-  elif mode == 2:
+  elif mode == WITHOUT_PREFIX:
     for entry in dirs:
       print(entry)
-    sys.stdout.flush()
-  elif mode == 3:
-    if dirs:
-      print(' '.join(dirs))
-      sys.stdout.flush()
-
+  elif mode == SINGLE_LINE:
+    print(' '.join(dirs))
+  sys.stdout.flush()
 
 def Pushd(argv, dir_stack):
   num_args = len(argv)
@@ -521,7 +518,7 @@ def Pushd(argv, dir_stack):
     return 1
 
   dir_stack.append(current_dir)
-  PrintDirStack(dir_stack)
+  PrintDirStack(dir_stack, SINGLE_LINE)
   return 0
 
 
@@ -538,7 +535,7 @@ def Popd(argv, dir_stack):
     util.error("popd: %r: %s", dest_dir, os.strerror(e.errno))
     return 1
 
-  PrintDirStack(dir_stack)
+  PrintDirStack(dir_stack, SINGLE_LINE)
   return 0
 
 


### PR DESCRIPTION
This pull request contains the code for the `dirs` builtin flags: -v, -p, and -c. The `bash` implementation also has the -l flag, but that has not yet been written.