### PR TITLE
Let's run tests on all new code submissions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
     # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
     - flake8 . --count --exclude=./Python-2.7.13 --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
-    - true  # pytest --capture=sys  # add other tests here
+    - test/lint.sh
 notifications:
     on_success: change
     on_failure: change  # `always` will be the setting once code changes slow down

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: python
+cache: pip
+python:
+    - 2.7
+    - 3.6
+    #- nightly
+    #- pypy
+    #- pypy3
+matrix:
+    allow_failures:
+        - python: 3.6
+install:
+    #- pip install -r requirements.txt
+    - pip install flake8  # pytest  # add another testing frameworks later
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --exclude=./Python-2.7.13 --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exclude=./Python-2.7.13 --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+    - true  # pytest --capture=sys  # add other tests here
+notifications:
+    on_success: change
+    on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
There seems to be nice test coverage so it would be a good idea to run those tests on all new code submissions.  This configuration will enable Travis CI to run [flake8](http://flake8.pycqa.org) tests on all pull requests before they are reviewed. We could also run the /test directory tests.  This allows contributors and maintainers to make sure no errors are introduced before new code is reviewed.  The owner of this repo would need to go to https://travis-ci.org/profile (log in via GitHub id) and flip the repository switch __on__ to enable free, automated testing of each pull request.