### PR TITLE
Use env python in shebang

### DIFF
--- a/asdl/const.py
+++ b/asdl/const.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 const.py
 """

--- a/asdl/gen_python.py
+++ b/asdl/gen_python.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 gen_python.py
 

--- a/benchmarks/fake_libc.py
+++ b/benchmarks/fake_libc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 fake_libc.py
 

--- a/benchmarks/pytrace.py
+++ b/benchmarks/pytrace.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 pytrace.py
 """

--- a/benchmarks/time.py
+++ b/benchmarks/time.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 time.py -- Replacement for coreutils 'time'.
 

--- a/benchmarks/virtual_memory.py
+++ b/benchmarks/virtual_memory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 virtual_memory.py
 """

--- a/core/legacy.py
+++ b/core/legacy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 legacy.py
 

--- a/core/lexer_gen.py
+++ b/core/lexer_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 lex_gen.py
 """

--- a/core/libstr.py
+++ b/core/libstr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 libstr.py - String library functions that can be exposed with a saner syntax.
 

--- a/core/test_builtin.py
+++ b/core/test_builtin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """
 test_builtin.py

--- a/core/word_compile.py
+++ b/core/word_compile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 word_compile.py
 

--- a/opy/compiler2/symbols_test.py
+++ b/opy/compiler2/symbols_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -S
+#!/usr/bin/python -S
 """
 symbols_test.py: Tests for symbols.py
 

--- a/osh/ast_gen.py
+++ b/osh/ast_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 ast_gen.py
 """

--- a/tools/csv_concat.py
+++ b/tools/csv_concat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 csv_concat.py
 """

--- a/web/table/csv2html.py
+++ b/web/table/csv2html.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 csv2html.py
 


### PR DESCRIPTION
You are unable to build oil on machines where the default is python 3.
This should allow you to override the python in your path to python 2 to be able to build.