### PR TITLE
Make travis perform developer build, run {unit,spec} tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,6 @@ cache: pip
 python:
     - 2.7
 
-# TODO: remove on merge with master.
-branches:
-    only:
-        travis-ci # Where I'm trying to make the build and run the tests.
-
 addons:
     apt:
         packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,42 @@ language: python
 cache: pip
 python:
     - 2.7
+
+# TODO: remove on merge with master.
+branches:
+    only:
+        travis-ci # Where I'm trying to make the build and run the tests.
+
+addons:
+    apt:
+        packages:
+            # build/dev.sh ubuntu-deps
+            - python-dev
+            - gawk
+            - time
+            - libreadline-dev
+            # test/spec.sh install-shells
+            - busybox-static
+            - mksh
+            - zsh
+
+before_install:
+    - test/spec.sh link-busybox-ash
+    - mkdir -p _tmp
+
 install:
-    #- pip install -r requirements.txt
+    # - pip install -r requirements.txt
     - pip install flake8  # pytest  # add another testing frameworks later
+    - build/dev.sh minimal
+
 script:
     - test/lint.sh travis
+    # Unit tests
+    - test/unit.sh all
+    # Spec tests
+    - test/spec.sh smoke
+    - test/spec.sh all
+
 notifications:
     on_success: change
     on_failure: change  # `always` will be the setting once code changes slow down

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 Oil
 ===
 
+[![Build
+Status](https://travis-ci.org/oilshell/oil.svg)](https://travis-ci.org/oilshell/oil)
+
 Oil is a new Unix shell.  [Why Create a New Unix Shell?][why]
 
 [why]: http://www.oilshell.org/blog/2018/01/28.html
@@ -70,7 +73,7 @@ Directory Structure
     test/             # Test automation
       unit.sh         ## Types of test runner: unit, spec, wild, smoke
       spec.sh
-      wild.sh        
+      wild.sh
       smoke.sh
       sh_spec.py      # shell spec test framework
     spec/             # spec test cases
@@ -121,7 +124,7 @@ Directory Structure
           ...
         web/          # Static files, copy of $REPO_ROOT/web
           table/
-      
+
 
     # Dev Docs
 


### PR DESCRIPTION
Spent a shameful amount of time trying to see why it didn't build the shell.
(Please consider I hadn't worked with Travis before)

About VM's vs containers... I don't know if you explicitly prefer one over
the other. I chose to approach the problem using containers since they boot
considerably faster than VMs. If you'd rather use VMs, just
substitute the `addons.apt.packages` and `before_install` lines for:

```yml
sudo: required

before_install:
    - build/dev.sh ubuntu-deps
```
Again, the advantage I see of containers over VMs is that they boot faster. The
disadvantage is that now dependecies must be stated in `build/dev.sh` AND
`.travis.yml`.

I'll look into making the tarball and binary builds.
Any guidance is well-received.