### PR TITLE
Adds spec test for stdout and stderr redirection appending to a target.

### DIFF
--- a/spec/redirect.test.sh
+++ b/spec/redirect.test.sh
@@ -277,3 +277,14 @@ echo second 1>&8
 echo CONTENTS
 cat $TMP/rw.txt
 # stdout-json: "line=first\nCONTENTS\nfirst\nsecond\n"
+
+### &>> appends stdout and stderr
+echo "ok" > $TMP/f.txt
+stdout_stderr.py &>> $TMP/f.txt
+grep ok $TMP/f.txt >/dev/null && echo 'ok'
+grep STDOUT $TMP/f.txt >/dev/null && echo 'ok'
+grep STDERR $TMP/f.txt >/dev/null && echo 'ok'
+# stdout-json: "ok\nok\nok\n"
+# N-I dash stdout: STDOUT
+# N-I dash stderr: STDERR
+# N-I dash status: 1

--- a/spec/redirect.test.sh
+++ b/spec/redirect.test.sh
@@ -284,7 +284,11 @@ stdout_stderr.py &>> $TMP/f.txt
 grep ok $TMP/f.txt >/dev/null && echo 'ok'
 grep STDOUT $TMP/f.txt >/dev/null && echo 'ok'
 grep STDERR $TMP/f.txt >/dev/null && echo 'ok'
-# stdout-json: "ok\nok\nok\n"
+## STDOUT:
+ok
+ok
+ok
+## END
 # N-I dash stdout: STDOUT
 # N-I dash stderr: STDERR
 # N-I dash status: 1

--- a/test/spec.sh
+++ b/test/spec.sh
@@ -378,7 +378,7 @@ here-doc() {
 }
 
 redirect() {
-  sh-spec spec/redirect.test.sh --osh-failures-allowed 6 \
+  sh-spec spec/redirect.test.sh --osh-failures-allowed 7 \
     ${REF_SHELLS[@]} $OSH "$@"
 }
 


### PR DESCRIPTION
Just adding a spec test for stdout/stderr output redirection appending to a target (file, stream, device, etc). It's basically a copy pasta of the regular spec test for `&>` except that it puts some data into the target file before trying to append (so that it's evident that the subsequent operation appends to the file instead of overwriting it)