### PR TITLE
byterun: Fix check for bound methods on falsy objects.

### DIFF
--- a/opy/byterun/pyvm2.py
+++ b/opy/byterun/pyvm2.py
@@ -830,7 +830,7 @@ class VirtualMachine(object):
             #debug('im_self %r', (func.im_self,))
             #debug('posargs %r', (posargs,))
 
-            if func.im_self:
+            if func.im_self is not None:
                 posargs.insert(0, func.im_self)
 
             #debug('posargs AFTER %r', (posargs,))


### PR DESCRIPTION
The test failures on core/glob_test, core/lexer_gen_test and
core/lex_test were caused by calling a method on a falsy object
and byterun incorrectly treating the `self` parameter as nonexistent.

(At least those tests pass after applying the fix, so I assume that must have been the only issue.)

core/process_test still fails, I will look at it tomorrow if possible.

By the way, I was quite confused by the shell scripts for testing opy, and I ended up manually running opyc on the respective test files. Could you provide some example of the way you typically call those scripts?