### PR TITLE
Fixes typo in umask (symbolic) spec test causing shell and bash to fail.

### DIFF
--- a/spec/builtins.test.sh
+++ b/spec/builtins.test.sh
@@ -181,6 +181,6 @@ umask g-w,o-w
 echo two > $TMP/umask-two
 stat -c '%a' $TMP/umask-one $TMP/umask-two
 # status: 0
-# stdout-json: "664\n644\n"
+# stdout-json: "644\n644\n"
 # stderr-json: ""
 


### PR DESCRIPTION
There's a typo causing the spec test for symbolic umask to fail. This pull requests just fixes that typo.