### PR TITLE
Implement cd -P and -L; respect --

### DIFF
--- a/core/builtin.py
+++ b/core/builtin.py
@@ -533,7 +533,7 @@ def Cd(argv, mem, dir_stack):
 
   # Set $PWD.
   if arg.P:
-    state.SetGlobalString(mem, 'PWD', os.readlink(dest_dir))
+    state.SetGlobalString(mem, 'PWD', os.path.realpath(dest_dir))
   else: # `-L` is the default behavior; no need to check it
     # TODO: ensure that if multiple flags are provided, the *last* one overrides
     # the others

--- a/core/builtin.py
+++ b/core/builtin.py
@@ -532,12 +532,12 @@ def Cd(argv, mem, dir_stack):
     return 1
 
   # Set $PWD.
-  if arg.P:
-    state.SetGlobalString(mem, 'PWD', os.path.realpath(dest_dir))
-  else: # `-L` is the default behavior; no need to check it
-    # TODO: ensure that if multiple flags are provided, the *last* one overrides
-    # the others
-    state.SetGlobalString(mem, 'PWD', dest_dir)
+  # `-L` is the default behavior; no need to check it
+  # TODO: ensure that if multiple flags are provided, the *last* one overrides
+  # the others
+  pwd = os.path.realpath(dest_dir) if arg.P else dest_dir
+  state.SetGlobalString(mem, 'PWD', pwd)
+
   dir_stack.Reset()  # for pushd/popd/dirs
 
   return 0

--- a/core/builtin.py
+++ b/core/builtin.py
@@ -322,7 +322,7 @@ def Jobs(argv, job_state):
 # - If there are more words than names, the remaining words and their
 # intervening delimiters are assigned to the last name.
 # - If there are fewer words read from the input stream than names, the
-# remaining names are assigned empty values. 
+# remaining names are assigned empty values.
 # - The characters in the value of the IFS variable are used to split the line
 # into words using the same rules the shell uses for expansion (described
 # above in Word Splitting).
@@ -484,11 +484,24 @@ def Shift(argv, mem):
 
   return mem.Shift(n)
 
+CD_SPEC = _Register('cd')
+CD_SPEC.ShortFlag('-L')
+CD_SPEC.ShortFlag('-P')
 
 def Cd(argv, mem, dir_stack):
-  # TODO: Parse flags, error checking, etc.
+  arg, i = CD_SPEC.Parse(argv)
+  # TODO: error checking, etc.
+
+  if arg.L:
+      # TODO: what should this do?
+      # `-L` is the default behavior.
+      # Whichever of `L` or `P` comes *last* determines the actual behavior.
+      pass
+  if arg.P:
+      # TODO `-P` should *not* follow symlinks.
+      raise NotImplementedError
   try:
-    dest_dir = argv[0]
+      dest_dir = argv[i]
   except IndexError:
     val = mem.GetVar('HOME')
     if val.tag == value_e.Undef:
@@ -830,7 +843,7 @@ def _ResolveNames(names, funcs, path_val):
     results.append(kind)
 
   return results
-    
+
 
 COMMAND_SPEC = _Register('command')
 COMMAND_SPEC.ShortFlag('-v')
@@ -1088,7 +1101,7 @@ def Umask(argv):
     # NOTE: dash disables interrupts around the two umask() calls, but that
     # shouldn't be a concern for us.  Signal handlers won't call umask().
     mask = os.umask(0)
-    os.umask(mask)  # 
+    os.umask(mask)  #
     print('0%03o' % mask)  # octal format
     return 0
 

--- a/core/builtin.py
+++ b/core/builtin.py
@@ -492,16 +492,8 @@ def Cd(argv, mem, dir_stack):
   arg, i = CD_SPEC.Parse(argv)
   # TODO: error checking, etc.
 
-  if arg.L:
-      # TODO: what should this do?
-      # `-L` is the default behavior.
-      # Whichever of `L` or `P` comes *last* determines the actual behavior.
-      pass
-  if arg.P:
-      # TODO `-P` should *not* follow symlinks.
-      raise NotImplementedError
   try:
-      dest_dir = argv[i]
+    dest_dir = argv[i]
   except IndexError:
     val = mem.GetVar('HOME')
     if val.tag == value_e.Undef:
@@ -539,7 +531,13 @@ def Cd(argv, mem, dir_stack):
     util.error("cd %r: %s", dest_dir, os.strerror(e.errno))
     return 1
 
-  state.SetGlobalString(mem, 'PWD', dest_dir)  # Set $PWD.
+  # Set $PWD.
+  if arg.P:
+    state.SetGlobalString(mem, 'PWD', os.readlink(dest_dir))
+  else: # `-L` is the default behavior; no need to check it
+    # TODO: ensure that if multiple flags are provided, the *last* one overrides
+    # the others
+    state.SetGlobalString(mem, 'PWD', dest_dir)
   dir_stack.Reset()  # for pushd/popd/dirs
 
   return 0

--- a/spec/builtins.test.sh
+++ b/spec/builtins.test.sh
@@ -65,7 +65,7 @@ lnk="$TMP"/cd-symlink
 mkdir -p "$targ"
 ln -s "$targ" "$lnk"
 cd "$lnk"
-test $(pwd) = "$TMP/cd-symlink" && echo OK
+test ${PWD} = "$TMP/cd-symlink" && echo OK
 # stdout: OK
 
 ### cd to symlink with `-L`
@@ -74,7 +74,7 @@ lnk="$TMP"/cd-symlink
 mkdir -p "$targ"
 ln -s "$targ" "$lnk"
 cd -L "$lnk"
-test $(pwd) = "$TMP/cd-symlink" && echo OK
+test ${PWD} = "$TMP/cd-symlink" && echo OK
 # stdout: OK
 
 ### cd to symlink with `-P`
@@ -83,7 +83,7 @@ lnk="$TMP"/cd-symlink
 mkdir -p "$targ"
 ln -s "$targ" "$lnk"
 cd -P "$lnk"
-test $(pwd) = "$TMP/cd-symtarget" && echo OK
+test ${PWD} = "$TMP/cd-symtarget" && echo OK
 # stdout: OK
 
 ### pushd/popd

--- a/spec/builtins.test.sh
+++ b/spec/builtins.test.sh
@@ -60,20 +60,22 @@ echo $PWD
 # stdout: /
 
 ### cd to symlink with `-L`
-targ=$TMP/cd-symtarget
-lnk=$TMP/cd-symlink
-mkdir -p $targ
-ln -s $targ $link
-cd -L $dir
+TMP=/tmp    # XXX - why unset?
+targ="$TMP"/cd-symtarget
+lnk="$TMP"/cd-symlink
+mkdir -p "$targ"
+ln -s "$targ" "$lnk"
+cd -L "$lnk"
 test $(pwd) = "$TMP/cd-symlink" && echo OK
 # stdout: OK
 
 ### cd to symlink with `-P`
-targ=$TMP/cd-symtarget
-lnk=$TMP/cd-symlink
-mkdir -p $targ
-ln -s $targ $link
-cd -P $dir
+TMP=/tmp    # XXX - why unset?
+targ="$TMP"/cd-symtarget
+lnk="$TMP"/cd-symlink
+mkdir -p "$targ"
+ln -s "$targ" "$lnk"
+cd -P "$lnk"
 test $(pwd) = "$TMP/cd-symtarget" && echo OK
 # stdout: OK
 

--- a/spec/builtins.test.sh
+++ b/spec/builtins.test.sh
@@ -60,51 +60,51 @@ echo $PWD
 # stdout: /
 
 ### cd to non-symlink with `-P`
-targ="$TMP"/cd-symtarget
-lnk="$TMP"/cd-symlink
-mkdir -p "$targ"
-ln -s "$targ" "$lnk"
-cd -P "$targ"
-test "$PWD" = "$TMP/cd-symtarget" && echo OK
-cd "$TMP"
-rmdir "$targ"
-rm "$lnk"
+targ=$TMP/cd-symtarget
+lnk=$TMP/cd-symlink
+mkdir -p $targ
+ln -s $targ $lnk
+cd -P $targ
+test $PWD = "$TMP/cd-symtarget" && echo OK
+cd $TMP
+rmdir $targ
+rm $lnk
 # stdout: OK
 
 ### cd to symlink default behavior
-targ="$TMP"/cd-symtarget
-lnk="$TMP"/cd-symlink
-mkdir -p "$targ"
-ln -s "$targ" "$lnk"
-cd "$lnk"
-test "$PWD" = "$TMP/cd-symlink" && echo OK
-cd "$TMP"
-rmdir "$targ"
-rm "$lnk"
+targ=$TMP/cd-symtarget
+lnk=$TMP/cd-symlink
+mkdir -p $targ
+ln -s $targ $lnk
+cd $lnk
+test $PWD = "$TMP/cd-symlink" && echo OK
+cd $TMP
+rmdir $targ
+rm $lnk
 # stdout: OK
 
 ### cd to symlink with `-L`
-targ="$TMP"/cd-symtarget
-lnk="$TMP"/cd-symlink
-mkdir -p "$targ"
-ln -s "$targ" "$lnk"
-cd -L "$lnk"
-test "$PWD" = "$TMP/cd-symlink" && echo OK
-cd "$TMP"
-rmdir "$targ"
-rm "$lnk"
+targ=$TMP/cd-symtarget
+lnk=$TMP/cd-symlink
+mkdir -p $targ
+ln -s $targ $lnk
+cd -L $lnk
+test $PWD = "$TMP/cd-symlink" && echo OK
+cd $TMP
+rmdir $targ
+rm $lnk
 # stdout: OK
 
 ### cd to symlink with `-P`
-targ="$TMP"/cd-symtarget
-lnk="$TMP"/cd-symlink
-mkdir -p "$targ"
-ln -s "$targ" "$lnk"
-cd -P "$lnk"
-test "$PWD" = "$TMP/cd-symtarget" && echo OK
-cd "$TMP"
-rmdir "$targ"
-rm "$lnk"
+targ=$TMP/cd-symtarget
+lnk=$TMP/cd-symlink
+mkdir -p $targ
+ln -s $targ $lnk
+cd -P $lnk
+test $PWD = "$TMP/cd-symtarget" && echo OK
+cd $TMP
+rmdir $targ
+rm $lnk
 # stdout: OK
 
 ### pushd/popd

--- a/spec/builtins.test.sh
+++ b/spec/builtins.test.sh
@@ -54,6 +54,29 @@ cd-nonexistent
 status=0
 ## END
 
+### cd permits double bare dash
+cd -- /
+echo $PWD
+# stdout: /
+
+### cd to symlink with `-L`
+targ=$TMP/cd-symtarget
+lnk=$TMP/cd-symlink
+mkdir -p $targ
+ln -s $targ $link
+cd -L $dir
+test $(pwd) = "$TMP/cd-symlink" && echo OK
+# stdout: OK
+
+### cd to symlink with `-P`
+targ=$TMP/cd-symtarget
+lnk=$TMP/cd-symlink
+mkdir -p $targ
+ln -s $targ $link
+cd -P $dir
+test $(pwd) = "$TMP/cd-symtarget" && echo OK
+# stdout: OK
+
 ### pushd/popd
 set -o errexit
 cd /

--- a/spec/builtins.test.sh
+++ b/spec/builtins.test.sh
@@ -65,7 +65,10 @@ lnk="$TMP"/cd-symlink
 mkdir -p "$targ"
 ln -s "$targ" "$lnk"
 cd -P "$targ"
-test ${PWD} = "$TMP/cd-symtarget" && echo OK
+test "$PWD" = "$TMP/cd-symtarget" && echo OK
+cd "$TMP"
+rmdir "$targ"
+rm "$lnk"
 # stdout: OK
 
 ### cd to symlink default behavior
@@ -74,7 +77,10 @@ lnk="$TMP"/cd-symlink
 mkdir -p "$targ"
 ln -s "$targ" "$lnk"
 cd "$lnk"
-test ${PWD} = "$TMP/cd-symlink" && echo OK
+test "$PWD" = "$TMP/cd-symlink" && echo OK
+cd "$TMP"
+rmdir "$targ"
+rm "$lnk"
 # stdout: OK
 
 ### cd to symlink with `-L`
@@ -83,7 +89,10 @@ lnk="$TMP"/cd-symlink
 mkdir -p "$targ"
 ln -s "$targ" "$lnk"
 cd -L "$lnk"
-test ${PWD} = "$TMP/cd-symlink" && echo OK
+test "$PWD" = "$TMP/cd-symlink" && echo OK
+cd "$TMP"
+rmdir "$targ"
+rm "$lnk"
 # stdout: OK
 
 ### cd to symlink with `-P`
@@ -92,7 +101,10 @@ lnk="$TMP"/cd-symlink
 mkdir -p "$targ"
 ln -s "$targ" "$lnk"
 cd -P "$lnk"
-test ${PWD} = "$TMP/cd-symtarget" && echo OK
+test "$PWD" = "$TMP/cd-symtarget" && echo OK
+cd "$TMP"
+rmdir "$targ"
+rm "$lnk"
 # stdout: OK
 
 ### pushd/popd

--- a/spec/builtins.test.sh
+++ b/spec/builtins.test.sh
@@ -59,6 +59,15 @@ cd -- /
 echo $PWD
 # stdout: /
 
+### cd to non-symlink with `-P`
+targ="$TMP"/cd-symtarget
+lnk="$TMP"/cd-symlink
+mkdir -p "$targ"
+ln -s "$targ" "$lnk"
+cd -P "$targ"
+test ${PWD} = "$TMP/cd-symtarget" && echo OK
+# stdout: OK
+
 ### cd to symlink default behavior
 targ="$TMP"/cd-symtarget
 lnk="$TMP"/cd-symlink

--- a/spec/builtins.test.sh
+++ b/spec/builtins.test.sh
@@ -59,8 +59,16 @@ cd -- /
 echo $PWD
 # stdout: /
 
+### cd to symlink default behavior
+targ="$TMP"/cd-symtarget
+lnk="$TMP"/cd-symlink
+mkdir -p "$targ"
+ln -s "$targ" "$lnk"
+cd "$lnk"
+test $(pwd) = "$TMP/cd-symlink" && echo OK
+# stdout: OK
+
 ### cd to symlink with `-L`
-TMP=/tmp    # XXX - why unset?
 targ="$TMP"/cd-symtarget
 lnk="$TMP"/cd-symlink
 mkdir -p "$targ"
@@ -70,7 +78,6 @@ test $(pwd) = "$TMP/cd-symlink" && echo OK
 # stdout: OK
 
 ### cd to symlink with `-P`
-TMP=/tmp    # XXX - why unset?
 targ="$TMP"/cd-symtarget
 lnk="$TMP"/cd-symlink
 mkdir -p "$targ"

--- a/test/spec.sh
+++ b/test/spec.sh
@@ -268,7 +268,7 @@ if_() {
 }
 
 builtins() {
-  sh-spec spec/builtins.test.sh --osh-failures-allowed 2 \
+  sh-spec spec/builtins.test.sh --osh-failures-allowed 1 \
     ${REF_SHELLS[@]} $OSH "$@"
 }
 

--- a/test/spec.sh
+++ b/test/spec.sh
@@ -268,7 +268,7 @@ if_() {
 }
 
 builtins() {
-  sh-spec spec/builtins.test.sh --osh-failures-allowed 1 \
+  sh-spec spec/builtins.test.sh --osh-failures-allowed 2 \
     ${REF_SHELLS[@]} $OSH "$@"
 }
 


### PR DESCRIPTION
Fixes #86 (at least for `cd`, which is the example given in the description).

Currently the only supported arguments are `-L` and `-P`. These are the only arguments required for POSIX compliance, but others do exist (e.g. my version of Bash has `-e` and, of all things, `-@`).

Adds three spec tests for checking how `cd` interacts with symlinks. The new spec tests all pass.

I do not know if `args.py` supports a way to ensure that "mode" arguments can be overridden. In this case, `cd -P -L` should behave like `cd -L`, but I don't know how to implement that.