### PR TITLE
Implement the pwd builtin

### DIFF
--- a/core/builtin.py
+++ b/core/builtin.py
@@ -83,6 +83,7 @@ _NORMAL_BUILTINS = {
     "pushd": builtin_e.PUSHD,
     "popd": builtin_e.POPD,
     "dirs": builtin_e.DIRS,
+    "pwd": builtin_e.PWD,
 
     "source": builtin_e.SOURCE,  # note that . alias is special
 
@@ -624,6 +625,14 @@ def Dirs(argv, home_dir, dir_stack):
   _PrintDirStack(dir_stack, style, home_dir)
   return 0
 
+PWD_SPEC = _Register('pwd')
+PWD_SPEC.ShortFlag('-L')
+PWD_SPEC.ShortFlag('-P')
+
+def Pwd(argv, mem):
+  # XXX TODO add arg-parsing
+  print(mem.GetVar('PWD'))
+  return 0
 
 EXPORT_SPEC = _Register('export')
 EXPORT_SPEC.ShortFlag('-n')

--- a/core/builtin.py
+++ b/core/builtin.py
@@ -625,14 +625,25 @@ def Dirs(argv, home_dir, dir_stack):
   _PrintDirStack(dir_stack, style, home_dir)
   return 0
 
+
 PWD_SPEC = _Register('pwd')
 PWD_SPEC.ShortFlag('-L')
 PWD_SPEC.ShortFlag('-P')
 
+
 def Pwd(argv, mem):
-  # XXX TODO add arg-parsing
-  print(mem.GetVar('PWD').s)
+  arg, i = CD_SPEC.Parse(argv)
+
+  pwd = mem.GetVar('PWD').s
+
+  # `-L` is the default behavior; no need to check it
+  # TODO: ensure that if multiple flags are provided, the *last* one overrides
+  # the others
+  if arg.P:
+    pwd = os.path.realpath(pwd)
+  print(pwd)
   return 0
+
 
 EXPORT_SPEC = _Register('export')
 EXPORT_SPEC.ShortFlag('-n')

--- a/core/builtin.py
+++ b/core/builtin.py
@@ -323,7 +323,7 @@ def Jobs(argv, job_state):
 # - If there are more words than names, the remaining words and their
 # intervening delimiters are assigned to the last name.
 # - If there are fewer words read from the input stream than names, the
-# remaining names are assigned empty values. 
+# remaining names are assigned empty values.
 # - The characters in the value of the IFS variable are used to split the line
 # into words using the same rules the shell uses for expansion (described
 # above in Word Splitting).
@@ -632,7 +632,7 @@ PWD_SPEC.ShortFlag('-P')
 
 
 def Pwd(argv, mem):
-  arg, i = CD_SPEC.Parse(argv)
+  arg, i = PWD_SPEC.Parse(argv)
 
   pwd = mem.GetVar('PWD').s
 
@@ -850,7 +850,7 @@ def _ResolveNames(names, funcs, path_val):
     results.append(kind)
 
   return results
-    
+
 
 COMMAND_SPEC = _Register('command')
 COMMAND_SPEC.ShortFlag('-v')
@@ -1108,7 +1108,7 @@ def Umask(argv):
     # NOTE: dash disables interrupts around the two umask() calls, but that
     # shouldn't be a concern for us.  Signal handlers won't call umask().
     mask = os.umask(0)
-    os.umask(mask)  # 
+    os.umask(mask)  #
     print('0%03o' % mask)  # octal format
     return 0
 

--- a/core/builtin.py
+++ b/core/builtin.py
@@ -631,7 +631,7 @@ PWD_SPEC.ShortFlag('-P')
 
 def Pwd(argv, mem):
   # XXX TODO add arg-parsing
-  print(mem.GetVar('PWD'))
+  print(mem.GetVar('PWD').s)
   return 0
 
 EXPORT_SPEC = _Register('export')

--- a/core/cmd_exec.py
+++ b/core/cmd_exec.py
@@ -119,7 +119,7 @@ class Executor(object):
     """
     self.mem = mem
     self.fd_state = fd_state
-    self.status_lines = status_lines  
+    self.status_lines = status_lines
     # function space is different than var space.  Not hierarchical.
     self.funcs = funcs
     self.completion = completion
@@ -317,6 +317,9 @@ class Executor(object):
     elif builtin_id == builtin_e.DIRS:
       status = builtin.Dirs(argv, self.mem.GetVar('HOME'), self.dir_stack)
 
+    elif builtin_id == builtin_e.PWD:
+      status = builtin.Pwd(argv, self.mem)
+
     elif builtin_id in (builtin_e.SOURCE, builtin_e.DOT):
       status = self._Source(argv)
 
@@ -396,7 +399,7 @@ class Executor(object):
       elif node.tag == command_e.Assignment:
         span_id = self._SpanIdForAssignment(node)
         raise util.ErrExitFailure(
-            '[%d] assignment exited with status %d', os.getpid(), 
+            '[%d] assignment exited with status %d', os.getpid(),
             status, span_id=span_id, status=status)
 
       else:
@@ -863,7 +866,7 @@ class Executor(object):
           self.loop_level == 0):
         ok = False
         msg = 'Invalid control flow at top level'
-      
+
       if ok:
         raise _ControlFlow(tok, arg)
 
@@ -1129,7 +1132,7 @@ class Executor(object):
     check_errexit = True
 
     if redirects is None:  # evaluation error
-      status = 1  
+      status = 1
 
     elif redirects:
       if self.fd_state.Push(redirects, self.waiter):
@@ -1411,7 +1414,7 @@ class Executor(object):
 
 class Tracer(object):
   """A tracer for this process.
-  
+
   TODO: Connect it somehow to tracers for other processes.  So you can make an
   HTML report offline.
 
@@ -1421,7 +1424,7 @@ class Tracer(object):
     - argv and span ID of the SimpleCommand that corresponds to that
     - then print line number using arena
     - set -x doesn't print line numbers!  OH but you can do that with
-      PS4=$LINENO 
+      PS4=$LINENO
   """
   def __init__(self, exec_opts, mem, word_ev):
     """

--- a/core/runtime.asdl
+++ b/core/runtime.asdl
@@ -67,6 +67,7 @@ module runtime
   | TEST | BRACKET | GETOPTS
   | COMMAND | TYPE | HELP
   | DECLARE | TYPESET
+  | PWD
 
   -- word_eval.py: SliceParts is for ${a-} and ${a+}, Error is for ${a?}, and
   -- SliceAndAssign is for ${a=}.

--- a/opy/_regtest/src/_devbuild/gen/runtime_asdl.py
+++ b/opy/_regtest/src/_devbuild/gen/runtime_asdl.py
@@ -217,7 +217,6 @@ builtin_e.TYPE = builtin_e(31, 'TYPE')
 builtin_e.HELP = builtin_e(32, 'HELP')
 builtin_e.DECLARE = builtin_e(33, 'DECLARE')
 builtin_e.TYPESET = builtin_e(34, 'TYPESET')
-builtin_e.PWD = builtin_e(35, 'PWD')
 
 class effect_e(py_meta.SimpleObj):
   ASDL_TYPE = TYPE_LOOKUP.ByTypeName('effect')

--- a/opy/_regtest/src/_devbuild/gen/runtime_asdl.py
+++ b/opy/_regtest/src/_devbuild/gen/runtime_asdl.py
@@ -217,6 +217,7 @@ builtin_e.TYPE = builtin_e(31, 'TYPE')
 builtin_e.HELP = builtin_e(32, 'HELP')
 builtin_e.DECLARE = builtin_e(33, 'DECLARE')
 builtin_e.TYPESET = builtin_e(34, 'TYPESET')
+builtin_e.PWD = builtin_e(35, 'PWD')
 
 class effect_e(py_meta.SimpleObj):
   ASDL_TYPE = TYPE_LOOKUP.ByTypeName('effect')

--- a/spec/builtins.test.sh
+++ b/spec/builtins.test.sh
@@ -28,6 +28,21 @@ echo "old: $OLDPWD"
 cd -
 # stdout-json: "old: /\n/\n"
 
+### pwd
+cd /
+pwd
+# stdout: /
+
+### pwd -P
+mkdir -p $TMP/symtarg
+ln -s $TMP/symtarg $TMP/symlink
+cd $TMP/symlink
+basename $(pwd -P)
+cd $TMP
+rmdir $TMP/symtarg
+rm $TMP/symlink
+# stdout: symtarg
+
 ### cd with no arguments
 HOME=$TMP/home
 mkdir -p $HOME


### PR DESCRIPTION
A simple `pwd` builtin that emulates the other common shells by making `-L` the default (rather than `-P`, the default in the GNU coreutils binary).

Fixes #110.