### PR TITLE
Fix crash on empty for expression ((;;))

### DIFF
--- a/core/cmd_exec.py
+++ b/core/cmd_exec.py
@@ -997,17 +997,20 @@ class Executor(object):
 
     elif node.tag == command_e.ForExpr:
       status = 0
-      self.arith_ev.Eval(node.init)
+      init, cond, body, update = node.init, node.cond, node.body, node.update
+      if init:
+        self.arith_ev.Eval(init)
 
       self.loop_level += 1
       try:
         while True:
-          b = self.arith_ev.Eval(node.cond)
-          if not b:
-            break
+          if cond:
+            b = self.arith_ev.Eval(cond)
+            if not b:
+              break
 
           try:
-            status = self._Execute(node.body)
+            status = self._Execute(body)
           except _ControlFlow as e:
             if e.IsBreak():
               status = 0
@@ -1017,7 +1020,8 @@ class Executor(object):
             else:  # return needs to pop up more
               raise
 
-          self.arith_ev.Eval(node.update)
+          if update:
+            self.arith_ev.Eval(update)
 
       finally:
         self.loop_level -= 1

--- a/spec/for-expr.test.sh
+++ b/spec/for-expr.test.sh
@@ -42,3 +42,18 @@ done  # A construct borrowed from ksh93.
 ## N-I mksh status: 1
 ## N-I mksh stdout-json: ""
 
+### For loop with empty head
+a=1
+for ((;;)); do
+  if test $a = 4; then
+    break
+  fi
+  echo $((a++))
+done  # A construct borrowed from ksh93.
+## status: 0
+## STDOUT:
+1
+2
+3
+## N-I mksh status: 1
+## N-I mksh stdout-json: ""


### PR DESCRIPTION
Before this change
```bash
bin/osh -c 'for ((;;)) do done'
```
crashes with
```python
Traceback (most recent call last):
  ...
  File "core/cmd_exec.py", line 1000, in _Dispatch
    self.arith_ev.Eval(node.init)
  File "core/expr_eval.py", line 252, in Eval
    if node.tag == arith_expr_e.ArithVarRef:  # $(( x ))
AttributeError: 'NoneType' object has no attribute 'tag'
```
because there is no initializer expression.

Additionally (but unrelated to this bug), I'm not sure whether `do done` should be a valid loop body. `bash` doesn't accept it.