### PR TITLE
Handle parse failure on left-hand side of logical or

### DIFF
--- a/osh/bool_parse.py
+++ b/osh/bool_parse.py
@@ -156,6 +156,8 @@ class BoolParser(object):
     Expr    : Term (OR Expr)?
     """
     left = self.ParseTerm()
+    if not left:
+      return None  # TODO: An exception should handle this case.
     # [[ uses || while [ uses -o
     if self.op_id in (Id.Op_DPipe, Id.BoolUnary_o):
       if not self._Next(): return None


### PR DESCRIPTION
An example input that is falsely accepted otherwise is `[[ || 0 ]]`, which fails only later during evaluation when the left node is `None`.

I simply copied the error-handling logic from the logical and, comment and all. Exceptions would definitely be less easy to forget than returning `None` as a failure signal.