### PR TITLE
Use argv.py instead of argv in spec tests

### DIFF
--- a/spec/append.test.sh
+++ b/spec/append.test.sh
@@ -91,13 +91,13 @@ f
 f() {
   # NOTE: mksh doesn't like a=() after keyword.  Doesn't allow local arrays!
   local x+=(a b)
-  argv "${x[@]}"
+  argv.py "${x[@]}"
 
   y+=(c d)
-  argv "${y[@]}"
+  argv.py "${y[@]}"
 
   readonly z+=(e f)
-  argv "${z[@]}"
+  argv.py "${z[@]}"
 }
 f
 # stdout-json: "['a', 'b']\n['c', 'd']\n['e', 'f']\n"

--- a/spec/builtin-io.test.sh
+++ b/spec/builtin-io.test.sh
@@ -213,7 +213,7 @@ echo "[$x]"
 ### Read from empty file
 echo -n '' > $TMP/empty.txt
 read x < $TMP/empty.txt
-argv "status=$?" "$x"
+argv.py "status=$?" "$x"
 # stdout: ['status=1', '']
 # status: 0
 
@@ -264,14 +264,14 @@ echo $REPLY
 echo 'one\ two' > $TMP/readr.txt
 read escaped < $TMP/readr.txt
 read -r raw < $TMP/readr.txt
-argv "$escaped" "$raw"
+argv.py "$escaped" "$raw"
 # stdout: ['one two', 'one\\ two']
 
 ### read -r with other backslash escapes
 echo 'one\ two\x65three' > $TMP/readr.txt
 read escaped < $TMP/readr.txt
 read -r raw < $TMP/readr.txt
-argv "$escaped" "$raw"
+argv.py "$escaped" "$raw"
 # mksh respects the hex escapes here, but other shells don't!
 # stdout: ['one twox65three', 'one\\ two\\x65three']
 # BUG mksh/zsh stdout: ['one twoethree', 'one\\ twoethree']
@@ -282,7 +282,7 @@ tmp=$TMP/$(basename $SH)-readr.txt
 echo -e 'one\\\ntwo\n' > $tmp
 read escaped < $tmp
 read -r raw < $tmp
-argv "$escaped" "$raw"
+argv.py "$escaped" "$raw"
 # stdout: ['onetwo', 'one\\']
 # N-I dash stdout: ['-e onetwo', '-e one\\']
 
@@ -293,14 +293,14 @@ two three-\
 four five-\
 six
 EOF
-argv "$x" "$y" "$z"
+argv.py "$x" "$y" "$z"
 # stdout: ['one-two', 'three-four five-six', '']
 
 ### read -r with \n
 echo '\nline' > $TMP/readr.txt
 read escaped < $TMP/readr.txt
 read -r raw < $TMP/readr.txt
-argv "$escaped" "$raw"
+argv.py "$escaped" "$raw"
 # dash/mksh/zsh are bugs because at least the raw mode should let you read a
 # literal \n.
 # stdout: ['nline', '\\nline']

--- a/spec/command-sub.test.sh
+++ b/spec/command-sub.test.sh
@@ -70,12 +70,12 @@ argv.py $(echo 'hi there') "$(echo 'hi there')"
 
 ### Command Sub trailing newline removed
 s=$(python -c 'print "ab\ncd\n"')
-argv "$s"
+argv.py "$s"
 # stdout: ['ab\ncd']
 
 ### Command Sub trailing whitespace not removed
 s=$(python -c 'print "ab\ncd\n "')
-argv "$s"
+argv.py "$s"
 # stdout: ['ab\ncd\n ']
 
 ### Command Sub and exit code

--- a/spec/var-op-strip.test.sh
+++ b/spec/var-op-strip.test.sh
@@ -70,16 +70,16 @@ echo ${v#?}  # ? is a glob that stands for one character
 
 ### Bug fix: Test that you can remove everything with glob
 s='--x--'
-argv "${s%%-*}" "${s%-*}" "${s#*-}" "${s##*-}"
+argv.py "${s%%-*}" "${s%-*}" "${s#*-}" "${s##*-}"
 ## STDOUT:
 ['', '--x-', '-x--', '']
 ## END
 
 ### Test that you can remove everything with const
 s='abcd'
-argv "${s%%abcd}" "${s%abcd}" "${s#abcd}" "${s##abcd}"
+argv.py "${s%%abcd}" "${s%abcd}" "${s#abcd}" "${s##abcd}"
 # failure case:
-argv "${s%%abcde}" "${s%abcde}" "${s#abcde}" "${s##abcde}"
+argv.py "${s%%abcde}" "${s%abcde}" "${s#abcde}" "${s##abcde}"
 ## STDOUT:
 ['', '', '', '']
 ['abcd', 'abcd', 'abcd', 'abcd']

--- a/spec/var-sub-quote.test.sh
+++ b/spec/var-sub-quote.test.sh
@@ -105,12 +105,12 @@ argv.py "${Unset:-"a b" c}"
 # stdout: ['a b c']
 
 ### part_value tree with multiple words
-argv ${a:-${a:-"1 2" "3 4"}5 "6 7"}
+argv.py ${a:-${a:-"1 2" "3 4"}5 "6 7"}
 # stdout: ['1 2', '3 45', '6 7']
 
 ### part_value tree on RHS
 v=${a:-${a:-"1 2" "3 4"}5 "6 7"}
-argv "${v}"
+argv.py "${v}"
 # stdout: ['1 2 3 45 6 7']
 
 ### Var with multiple words: no quotes


### PR DESCRIPTION
Maybe my dev environment just isn't set up correctly, but `argv` alone doesn't work for me. Since some of the other spec tests use `argv.py` as well, I assume that's the correct command.