### PR TITLE
parse glob to AST

### DIFF
--- a/asdl/pretty.py
+++ b/asdl/pretty.py
@@ -7,7 +7,6 @@ try:
   import fastlex
 except ImportError:
   fastlex = None
-fastlex = None   # XXX(aleks): tests don't work otherwise
 
 # Word characters, - and _, as well as path name characters . and /.
 PLAIN_WORD_RE = r'[a-zA-Z0-9\-_./]+'

--- a/asdl/pretty.py
+++ b/asdl/pretty.py
@@ -7,6 +7,7 @@ try:
   import fastlex
 except ImportError:
   fastlex = None
+fastlex = None
 
 # Word characters, - and _, as well as path name characters . and /.
 PLAIN_WORD_RE = r'[a-zA-Z0-9\-_./]+'

--- a/asdl/pretty.py
+++ b/asdl/pretty.py
@@ -7,7 +7,7 @@ try:
   import fastlex
 except ImportError:
   fastlex = None
-fastlex = None
+fastlex = None   # XXX(aleks): tests don't work otherwise
 
 # Word characters, - and _, as well as path name characters . and /.
 PLAIN_WORD_RE = r'[a-zA-Z0-9\-_./]+'

--- a/build/codegen.sh
+++ b/build/codegen.sh
@@ -32,8 +32,8 @@ source build/common.sh
 # _devbuild/gen/
 #    osh-types.h - lex_mode_e for now
 #    id_kind.h - id_e for now
-#    osh-lex.re2c.c  
-#    osh-lex.c  
+#    osh-lex.re2c.c
+#    osh-lex.c
 
 download-re2c() {
   mkdir -p _deps

--- a/build/dev.sh
+++ b/build/dev.sh
@@ -109,6 +109,7 @@ minimal() {
   gen-types-asdl
   gen-osh-asdl
   gen-runtime-asdl
+  gen-glob-asdl
   pylibc
 }
 

--- a/build/dev.sh
+++ b/build/dev.sh
@@ -50,6 +50,13 @@ gen-runtime-asdl() {
   echo "Wrote $out"
 }
 
+gen-glob-asdl() {
+  local out=_devbuild/gen/glob_asdl.py
+  local import='from osh.meta import GLOB_TYPE_LOOKUP as TYPE_LOOKUP'
+  PYTHONPATH=. asdl/gen_python.py osh/glob.asdl "$import" > $out
+  echo "Wrote $out"
+}
+
 # TODO: should fastlex.c be part of the dev build?  It means you need re2c
 # installed?  I don't think it makes sense to have 3 builds, so yes I think we
 # can put it here for simplicity.

--- a/core/glob_test.py
+++ b/core/glob_test.py
@@ -6,9 +6,7 @@ glob_test.py: Tests for glob.py
 
 import re
 import unittest
-import os
 
-import libc
 from asdl import py_meta
 from core import glob_
 from osh.meta import glob as g

--- a/core/glob_test.py
+++ b/core/glob_test.py
@@ -6,6 +6,7 @@ glob_test.py: Tests for glob.py
 
 import re
 import unittest
+import os
 
 import libc
 from asdl import py_meta
@@ -94,32 +95,6 @@ class GlobEscapeTest(unittest.TestCase):
     result = r2.sub('X', 'a-b-c', count=1)
     self.assertEqual('X-b-c', result)
 
-  def testGlobToExtendedRegex(self):
-    CASES = [
-        # glob input, (regex, err)
-        ('*.py', '.*\.py', None),
-        ('*.?', '.*\..', None),
-        ('<*>', '<.*>', None),
-
-        #('\\*', '\\*', None),  # not a glob, a string
-        # Hard case: a literal * and then a glob
-        #('\\**', '\\**', None),
-        #('c:\\foo', 'c:\\\\foo', None),
-
-        ('abc', None, None),  # not a glob
-
-        # TODO: These should be parsed
-        ('[[:space:]]', None, True),
-        ('[abc]', None, True),
-        ('[abc\[]', None, True),
-    ]
-    for glob, expected_regex, expected_err in CASES:
-      regex, err = glob_.GlobToExtendedRegex(glob)
-      self.assertEqual(expected_regex, regex,
-          '%s: expected %r, got %r' % (glob, expected_regex, regex))
-      self.assertEqual(expected_err, err,
-          '%s: expected %r, got %r' % (glob, expected_err, err))
-
   def assertASTEqual(self, expected_ast, ast):
     """Asserts that 2 ASDL-defined ASTs are equal."""
     expected_is_node = isinstance(expected_ast, py_meta.CompoundObj)
@@ -141,53 +116,54 @@ class GlobEscapeTest(unittest.TestCase):
       else:
         self.assertASTEqual(exp_slot, slot)
 
-  def testGlobToAST(self):
+  def testGlobParser(self):
     CASES = [
-        # (glob input, expected ast, has error)
-        ('*.py', [g.Star()] + [g.Literal(c) for c in '.py'], False),
-        ('*.?', [g.Star(), g.Literal('.'), g.QMark()], False),
-        ('<*>', [g.Literal('<'), g.Star(), g.Literal('>')], False),
+        # (glob input, expected AST, expected extended regexp, has error)
+        ('*.py', [g.Star()] + [g.Literal(c) for c in '.py'], '.*\.py', False),
+        ('*.?', [g.Star(), g.Literal('.'), g.QMark()], '.*\..', False),
+        ('<*>', [g.Literal('<'), g.Star(), g.Literal('>')], '<.*>', False),
+        ('\**+', [g.Literal('*'), g.Star(), g.Literal('+')], '\*.*\+', False),
+        ('\**', [g.Literal('*'), g.Star()], '\*.*', False),
 
         # not globs
-        ('abc', None, False),
-        ('\\*', None, False),
-        ('c:\\foo', None, False),
+        ('abc', None, None, False),
+        ('\\*', None, None, False),
+        ('c:\\foo', None, None, False),
+        ('strange]one', None, None, False),
 
         # character class globs
-        ('[[:space:]]', [g.CharClassExpr(False, '[:space:]')], False),
-        ('[abc]', [g.CharClassExpr(False, 'abc')], False),
-        ('[abc\[]', [g.CharClassExpr(False, 'abc[')], False),
-        ('[!not]', [g.CharClassExpr(True, 'not')], False),
-        ('[!*?!\]\[]', [g.CharClassExpr(True, '*?!][')], False),
-
-        # a literal * and then a glob
-        ('\\**', [g.EscapedChar('*'), g.Star()], False),
+        ('[[:space:]abc]', [g.CharClassExpr(False, '[:space:]abc')], '[[:space:]abc]', False),
+        ('[abc]', [g.CharClassExpr(False, 'abc')], '[abc]', False),
+        ('[\a\b\c]', [g.CharClassExpr(False, '\a\b\c')], '[\a\b\c]', False),
+        ('[abc\[]', [g.CharClassExpr(False, 'abc\[')], '[abc\[]', False),
+        ('[!not]', [g.CharClassExpr(True, 'not')], '[^not]', False),
+        ('[^also_not]', [g.CharClassExpr(True, 'also_not')], '[^also_not]', False),
+        ('[]closed_bracket]', [g.CharClassExpr(False, ']closed_bracket')], '[]closed_bracket]', False),
+        ('[!]closed_bracket]', [g.CharClassExpr(True, ']closed_bracket')], '[^]closed_bracket]', False),
+        ('[!*?!\\[]', [g.CharClassExpr(True, '*?!\[')], '[^*?!\\[]', False),
+        ('[!\]foo]', [g.CharClassExpr(True, '\]foo')], '[^\]foo]', False),
+        ('wow[[[[]]]]', ([g.Literal(c) for c in 'wow'] +
+                         [g.CharClassExpr(False, '[[[')] +
+                         [g.Literal(c) for c in ']]']), 'wow[[[[]\]\]\]', False),
 
         # invalid globs
-        ('bad_close]', None, True),
-        ('too_nested[[[]]]', None, True),
-        ('not_closed[a-z', None, True),
+        ('not_closed[a-z', None, None, True),
+        ('[[:spa[ce:]]', None, None, True),
     ]
-    for glob, expected_parts, expected_err in CASES:
+    for glob, expected_parts, expected_ere, expected_err in CASES:
       if expected_parts:
         expected_ast = g.glob(expected_parts)
       else:
         expected_ast = None
 
-      ast, err = glob_.GlobParser().Parse(glob)
+      parser = glob_.GlobParser()
+      ast, err = parser.Parse(glob)
+      ere = parser.ASTToExtendedRegex(ast)
+
       self.assertASTEqual(expected_ast, ast)
+      self.assertEqual(expected_ere, ere)
       self.assertEqual(expected_err, err is not None,
           '%s: expected %r, got %r' % (glob, expected_err, err))
-
-  def disabled_testPatSubRegexesLibc(self):
-    r = libc.regex_parse('^(.*)git.*(.*)')
-    print(r)
-
-    # It matches.  But we need to get the positions out!
-    print(libc.regex_match('^(.*)git.*(.*)', '~/git/oil'))
-
-    # Or should we make a match in a loop?
-    # We have to keep advancing the string until there are no more matches.
 
 
 if __name__ == '__main__':

--- a/core/libstr.py
+++ b/core/libstr.py
@@ -2,7 +2,7 @@
 """
 libstr.py - String library functions that can be exposed with a saner syntax.
 
-Instead of 
+Instead of
 
 local y=${x//a*/b}
 
@@ -27,7 +27,7 @@ e_die = util.e_die
 # (1) PatSub: I think we fill in GlobToExtendedRegex, then use regcomp and
 # regexec.  in a loop.  fnmatch() does NOT given positions of matches.
 #
-# (2) Strip -- % %% # ## - 
+# (2) Strip -- % %% # ## -
 #
 # a. Fast path for constant strings.
 # b. Convert to POSIX extended regex, to see if it matches at ALL.  If it
@@ -108,7 +108,7 @@ def DoUnarySuffixOp(s, op, arg):
         return s[:i]
     else:
       return s
-    
+
   elif op.op_id == Id.VOp1_DPercent:  # longest suffix
     # 'abcd': match 'abc', 'bc', 'c', ...
     for i in xrange(0, n):
@@ -156,7 +156,7 @@ def PatSub(s, op, pat, replace_str):
   """Helper for ${x/pat/replace}."""
   #log('PAT %r REPLACE %r', pat, replace_str)
 
-  regex, err = glob_.GlobToExtendedRegex(pat)
+  regex, err = glob_.GlobParser().GlobToExtendedRegex(pat)
   if err:
     e_die("Can't convert glob to regex: %r", pat)
 

--- a/osh/cmd_parse.py
+++ b/osh/cmd_parse.py
@@ -672,7 +672,7 @@ class CommandParser(object):
     """
     words = []
     # The span_id of any semi-colon, so we can remove it.
-    semi_spid = const.NO_INTEGER  
+    semi_spid = const.NO_INTEGER
 
     while True:
       if not self._Peek(): return None

--- a/osh/glob.asdl
+++ b/osh/glob.asdl
@@ -22,7 +22,6 @@ module glob {
   -- Example: *.[ch] is Star, Literal('.'), CharClassExpr(False, 'ch')
   glob_part =
     Literal(string s)
-  | EscapedChar(string c)  -- \* \? \[
   | Star    -- * is 0 or more characters, like the regex .*
   | QMark   -- ? is a single character
   | CharClassExpr(bool negated, string body)

--- a/osh/glob.asdl
+++ b/osh/glob.asdl
@@ -2,8 +2,8 @@
 --
 -- NOTE: This schema is currently unused.  It would be useful for parsing
 -- and translating globs to Python's regex engine, which supports non-greedy
--- matches.  But we don't want to depend on Python regexes, so we use a 
--- quadratic loop like bash/mksh.  This is unfortunate, but strings are 
+-- matches.  But we don't want to depend on Python regexes, so we use a
+-- quadratic loop like bash/mksh.  This is unfortunate, but strings are
 -- generally short.
 --
 -- The schema could still be used for some kind of automatic glob translation.
@@ -20,14 +20,14 @@ module glob {
   glob = (glob_part* parts)
 
   -- Example: *.[ch] is Star, Literal('.'), CharClass(False, ...)
-  glob_part = 
-    Literal(string s) 
+  glob_part =
+    Literal(string s)
   | EscapedChar(string c)  -- \* \? \[
-  | Star    -- * is 0 or more characters, like the regex .* 
+  | Star    -- * is 0 or more characters, like the regex .*
   | QMark   -- ? is a single character
   | BracketExpr(bool negated, char_clause* clauses)
 
-  char_clause = 
+  char_clause =
     LiteralChar(string c)
     -- NOTE: Name conflict with above.  Should be namespaced.
   | EscapedChar2(string c)  -- \! \-

--- a/osh/glob.asdl
+++ b/osh/glob.asdl
@@ -25,14 +25,15 @@ module glob {
   | EscapedChar(string c)  -- \* \? \[
   | Star    -- * is 0 or more characters, like the regex .*
   | QMark   -- ? is a single character
-  | BracketExpr(bool negated, char_clause* clauses)
+  | BracketExpr(bool negated, string body)
 
-  char_clause =
-    LiteralChar(string c)
-    -- NOTE: Name conflict with above.  Should be namespaced.
-  | EscapedChar2(string c)  -- \! \-
-  | CharRange(string begin, string end)  -- a-z 0-9
-  | CharClass(string name)  -- [:alpha:]
+  -- XXX: revist
+  -- char_clause =
+  --   LiteralChar(string c)
+  --   -- NOTE: Name conflict with above.  Should be namespaced.
+  -- | EscapedChar2(string c)  -- \! \-
+  -- | CharRange(string begin, string end)  -- a-z 0-9
+  -- | CharClass(string name)  -- [:alpha:]
 
   -- TODO:
   -- * Collating symbols are [. .]

--- a/osh/glob.asdl
+++ b/osh/glob.asdl
@@ -19,21 +19,13 @@ module glob {
 
   glob = (glob_part* parts)
 
-  -- Example: *.[ch] is Star, Literal('.'), CharClass(False, ...)
+  -- Example: *.[ch] is Star, Literal('.'), CharClassExpr(False, 'ch')
   glob_part =
     Literal(string s)
   | EscapedChar(string c)  -- \* \? \[
   | Star    -- * is 0 or more characters, like the regex .*
   | QMark   -- ? is a single character
-  | BracketExpr(bool negated, string body)
-
-  -- XXX: revist
-  -- char_clause =
-  --   LiteralChar(string c)
-  --   -- NOTE: Name conflict with above.  Should be namespaced.
-  -- | EscapedChar2(string c)  -- \! \-
-  -- | CharRange(string begin, string end)  -- a-z 0-9
-  -- | CharClass(string name)  -- [:alpha:]
+  | CharClassExpr(bool negated, string body)
 
   -- TODO:
   -- * Collating symbols are [. .]

--- a/osh/meta.py
+++ b/osh/meta.py
@@ -142,6 +142,26 @@ else:
 f.close()
 
 #
+# Instantiate osh/glob.asdl
+#
+
+f = util.GetResourceLoader().open('osh/glob.asdl')
+_asdl_module, _type_lookup = asdl.LoadSchema(f, APP_TYPES)
+
+glob = _AsdlModule()
+if 0:
+  py_meta.MakeTypes(_asdl_module, glob, _type_lookup)
+else:
+  # Exported for the generated code to use
+  GLOB_TYPE_LOOKUP = _type_lookup
+
+  # Get the types from elsewhere
+  from _devbuild.gen import glob_asdl
+  py_meta.AssignTypes(glob_asdl, glob)
+
+f.close()
+
+#
 # Instantiate core/runtime.asdl
 #
 


### PR DESCRIPTION
Zulip thread: https://oilshell.zulipchat.com/#narrow/stream/121540-oil-discuss
Github issue: https://github.com/oilshell/oil/issues/125

- [x] Use `osh/glob.asdl` to generate Python code that can represent a glob expression as an AST
- [x] Write a parser by hand to parse a glob expression directly into an AST
    - [ ] consider using `re2c` to generate a parser
- [ ] Convert the glob AST to a POSIX extended regex