### PR TITLE
Allow for multiple possible outcomes of spec tests

### DIFF
--- a/spec/alias.test.sh
+++ b/spec/alias.test.sh
@@ -128,3 +128,5 @@ shopt -s expand_aliases  # bash requires this
 alias e_.~x='echo'
 e_.~x X
 ## stdout: X
+## OK mksh status: 127
+## mksh R56 2017/08/08 only allows [][A-Za-z0-9_!%,.@:-] in aliases

--- a/spec/array.test.sh
+++ b/spec/array.test.sh
@@ -313,8 +313,8 @@ a=('123' '456')
 argv.py "${a[0]}" "${a[0][0]}"
 # stdout-json: ""
 # status: 2
-# OK mksh status: 1
-# bash is bad -- it IGNORES the bad subscript.
+# OK bash/mksh status: 1
+# old bash version is bad -- it IGNORES the bad subscript.
 # BUG bash status: 0
 # BUG bash stdout: ['123', '123']
 
@@ -323,8 +323,8 @@ a=('123' '456')
 echo "${#a[0]}" "${#a[0]/1/xxx}"
 # stdout-json: ""
 # status: 2
-# OK mksh status: 1
-# bash is bad -- it IGNORES the op at the end
+# OK bash/mksh status: 1
+# old bash version is bad -- it IGNORES the op at the end
 # BUG bash status: 0
 # BUG bash stdout: 3 3
 

--- a/spec/assoc.test.sh
+++ b/spec/assoc.test.sh
@@ -24,6 +24,8 @@ a=([aa]=b [foo]=bar ['a+1']=c)
 argv.py "${!a[@]}"
 # Is this invalid on associative arrays?  Makes no sense.
 # stdout: ['aa', 'foo', 'a+1']
+# PASS bash stdout: ['foo', 'aa', 'a+1']
+# bash changed the ordering at some point?
 
 ### $a gives nothing
 declare -A a

--- a/spec/builtin-test.test.sh
+++ b/spec/builtin-test.test.sh
@@ -223,6 +223,7 @@ test -h $TMP/symlink && echo symlink
 test -L $TMP/dangling && echo dangling
 test -h $TMP/dangling  && echo dangling
 test -f $TMP/dangling  || echo 'dangling is not file'
+rm $TMP/symlink  # interferes with builtins.test.sh otherwise
 ## STDOUT:
 no
 no

--- a/spec/builtin-trap.test.sh
+++ b/spec/builtin-trap.test.sh
@@ -107,6 +107,7 @@ g
 return-helper.sh
 profile [x y]
 ## END
+## N-I dash/mksh status: 42
 ## N-I dash/mksh STDOUT:
 --
 f

--- a/spec/errexit-strict.test.sh
+++ b/spec/errexit-strict.test.sh
@@ -36,8 +36,9 @@ echo status=$?
 zero
 ## END
 ## status: 1
-## N-I dash status: 2
-## N-I dash stdout-json: ""
+## N-I dash/mksh status: 2
+## N-I dash/mksh stdout-json: ""
+## N-I mksh status: 1
 ## N-I mksh stdout-json: ""
 ## N-I ash/bash status: 0
 ## N-I ash/bash STDOUT:

--- a/spec/errexit.test.sh
+++ b/spec/errexit.test.sh
@@ -167,6 +167,7 @@ echo 7
 1
 2
 ## END
+## OK dash/bash/mksh/ash status: 1
 ## OK dash/bash/mksh/ash STDOUT:
 1
 2
@@ -202,6 +203,7 @@ echo 7
 1
 2
 6
+## OK dash/bash/mksh/ash status: 1
 ## OK dash/bash/mksh/ash STDOUT:
 1
 2

--- a/spec/glob.test.sh
+++ b/spec/glob.test.sh
@@ -113,6 +113,7 @@ touch _tmp/foo.-
 echo _tmp/*.[[:punct:]] _tmp/*.[[:punct\:]]
 # stdout: _tmp/foo.- _tmp/*.[[:punct:]]
 # BUG mksh stdout: _tmp/*.[[:punct:]] _tmp/*.[[:punct:]]
+# BUG mksh stdout: _tmp/foo.- _tmp/foo.-
 
 ### Redirect to glob, not evaluated
 # This writes to *.F, not foo.F

--- a/spec/sh-options.test.sh
+++ b/spec/sh-options.test.sh
@@ -16,6 +16,7 @@ echo $-
 # stdout: u
 # status: 0
 # OK bash stdout: huB
+# OK bash stdout: huBs
 # OK mksh stdout: ush
 # N-I dash stdout-json: ""
 # N-I dash status: 2

--- a/spec/var-op-other.test.sh
+++ b/spec/var-op-other.test.sh
@@ -94,6 +94,7 @@ s=xx_xx_xx
 echo ${s//[[:alpha:]]/y} ${s//[^[:alpha:]]/-}
 # stdout: yy_yy_yy xx-xx-xx
 # N-I mksh stdout: xx_xx_xx xx_xx_xx
+# BUG mksh stdout: yy_yy_yy --_--_--
 # N-I dash status: 2
 # N-I dash stdout-json: ""
 

--- a/spec/var-ref.test.sh
+++ b/spec/var-ref.test.sh
@@ -38,6 +38,8 @@ echo ref ${!a}
 echo status=$?
 # stdout-json: "ref\nstatus=0\n"
 # BUG mksh stdout-json: "ref a\nstatus=0\n"
+# OK bash stdout: status=1
+
 ### pass array by reference
 show_value() {
   local -n array=$1

--- a/test/sh_spec_test.py
+++ b/test/sh_spec_test.py
@@ -72,26 +72,40 @@ class ShSpecTest(unittest.TestCase):
     pprint.pprint(CASE1)
     print()
 
-    expected = {'status': '0', 'stdout': 'v=None\n', 'qualifier': 'OK'}
-    self.assertEqual(expected, CASE1['bash'])
-    self.assertEqual(expected, CASE1['dash'])
-    self.assertEqual(expected, CASE1['mksh'])
-    self.assertEqual('2', CASE1['status'])
+    expected = {'qualifier': 'OK',
+                'shells': ['bash', 'dash', 'mksh'],
+                'status': '0',
+                'stdout': 'v=None\n'}
+    self.assertIn(expected, CASE1['outcomes'])
+    expected = {'qualifier': None,
+                'shells': None,
+                'status': '2'}
+    self.assertIn(expected, CASE1['outcomes'])
     self.assertEqual(
         'Env binding in readonly/declare disallowed', CASE1['desc'])
 
     print('CASE2')
     pprint.pprint(CASE2)
     print()
-    print(CreateAssertions(CASE2, 'bash'))
-    self.assertEqual('one\ntwo\n', CASE2['stdout'])
-    self.assertEqual(
-        {'qualifier': 'OK', 'stdout': 'dash1\ndash2\n'}, CASE2['dash'])
-    self.assertEqual(
-        {'qualifier': 'OK', 'stdout': 'mksh1\nmksh2\n'}, CASE2['mksh'])
+    print(CreateAssertions(CASE2['outcomes'][0], 'bash'))
+    expected = {'qualifier': None,
+                'shells': None,
+                'status': '1',
+                'stdout': 'one\ntwo\n',
+                'stderr-json': '""'}
+    self.assertIn(expected, CASE2['outcomes'])
+    expected = {'qualifier': 'OK',
+                'shells': ['dash'],
+                'stdout': 'dash1\ndash2\n'}
+    self.assertIn(expected, CASE2['outcomes'])
+    expected = {'qualifier': 'OK',
+                'shells': ['mksh'],
+                'stdout': 'mksh1\nmksh2\n'}
+    self.assertIn(expected, CASE2['outcomes'])
 
   def testCreateAssertions(self):
-    print(CreateAssertions(CASE1, 'bash'))
+    for outcome in CASE1['outcomes']:
+      print(CreateAssertions(outcome, 'bash'))
 
   def testRunCases(self):
     shells = [('bash', '/bin/bash'), ('osh', 'bin/osh')]


### PR DESCRIPTION
This doesn't address issue #42 directly, but does fix the mentioned failures on Ubuntu 17. In cases where different versions of the same shell behave differently, you can now just specify all known possibilities. Then the spec tests won't break when one of the other shells lands a bugfix.

The new test format assumes that status and stdout specifications are adjacent when they belong together, which was fortunately already the case for the existing tests. Specifying a different combination of shells or setting the same value multiple times creates a new separate outcome. I think it's an intuitive extension of the old test format.