### PR TITLE
Fix unicode string length

### DIFF
--- a/core/word_eval.py
+++ b/core/word_eval.py
@@ -299,7 +299,7 @@ class _WordEvaluator(object):
     if op_id == Id.VSub_Pound:  # LENGTH
       if val.tag == value_e.Str:
         unicode_val = val.s.decode('utf-8')
-    	length = len(unicode_val)
+        length = len(unicode_val)
         # length = len(val.s)
       elif val.tag == value_e.StrArray:
         # There can be empty placeholder values in the array.

--- a/core/word_eval.py
+++ b/core/word_eval.py
@@ -298,7 +298,9 @@ class _WordEvaluator(object):
 
     if op_id == Id.VSub_Pound:  # LENGTH
       if val.tag == value_e.Str:
-        length = len(val.s)
+        unicode_val = val.s.decode('utf-8')
+    	length = len(unicode_val)
+        # length = len(val.s)
       elif val.tag == value_e.StrArray:
         # There can be empty placeholder values in the array.
         length = sum(1 for s in val.strs if s is not None)

--- a/spec/var-op-other.test.sh
+++ b/spec/var-op-other.test.sh
@@ -9,6 +9,13 @@ v=foo
 echo ${#v}
 # stdout: 3
 
+### Unicode string length (UTF-8)
+v=$'_\u03bc_'
+echo ${#v}
+## stdout: 3
+## BUG dash stdout: 9
+## BUG mksh stdout: 4
+
 ### Length of undefined variable
 echo ${#undef}
 # stdout: 0
@@ -158,4 +165,3 @@ echo ${foo:1:3}
 # BUG mksh stdout: -μ
 # N-I dash status: 2
 # N-I dash stdout-json: ""
-


### PR DESCRIPTION
The length operator ${#s} returns the number of code points now instead
of the number of bytes. Also added a test for this. Addresses #142.