### PR TITLE
Update code comments to match new spec format

### DIFF
--- a/spec/builtins.test.sh
+++ b/spec/builtins.test.sh
@@ -209,7 +209,7 @@ umask | grep '[0-9]\+'  # check for digits
 ## status: 0
 
 #### set umask in octal
-rm $TMP/umask-one $TMP/umask-two
+rm -f $TMP/umask-one $TMP/umask-two
 umask 0002
 echo one > $TMP/umask-one
 umask 0022

--- a/test/sh_spec.py
+++ b/test/sh_spec.py
@@ -37,7 +37,7 @@ If one shell disagrees with others, that is generally a BUG.
 
 Example test case:
 
-### hello and fail
+#### hello and fail
 echo hello
 echo world
 exit 1
@@ -75,8 +75,8 @@ def log(msg, *args):
 
 
 # EXAMPLES:
-# stdout: foo
-# stdout-json: ""
+## stdout: foo
+## stdout-json: ""
 #
 # In other words, it could be (name, value) or (qualifier, name, value)
 
@@ -167,13 +167,13 @@ class Tokenizer(object):
 #
 # -- Code is either literal lines, or a commented out code: value.
 # code = (? line of code ?)*
-#      | '# code:'  VALUE 
+#      | '## code:'  VALUE 
 #
 # -- Description, then key-value pairs surrounding code.
-# test_case = '###' DESC
-#             ( '#' KEY ':' VALUE )*
+# test_case = '####' DESC
+#             ( '##' KEY ':' VALUE )*
 #             code
-#             ( '#' KEY ':' VALUE )*
+#             ( '##' KEY ':' VALUE )*
 # 
 # -- Should be a blank line after each test case.  Leading comments and code
 # -- are OK.


### PR DESCRIPTION
Missed the comments, so this just fixes that error.