### PR TITLE
Remove trailiing whitespace from *.py and *.c files

### DIFF
--- a/asdl/asdl_.py
+++ b/asdl/asdl_.py
@@ -218,7 +218,7 @@ class Type(AST):
 
 class _CompoundType(AST):
     """Either a Product or Constructor.
-    
+
     encode.py and format.py need a reflection API.
     """
 

--- a/asdl/format.py
+++ b/asdl/format.py
@@ -445,7 +445,7 @@ def _PrintTreeObj(node, f, indent, max_col):
       f.write('\n')  # separate fields
 
     f.write(ind + node.right)
- 
+
 
 def PrintTree(node, f, indent=0, max_col=100):
   """Second step of printing: turn homogeneous tree into a colored string.

--- a/asdl/py_meta.py
+++ b/asdl/py_meta.py
@@ -240,7 +240,7 @@ def MakeTypes(module, root, type_lookup):
       sum_type = typ
       if asdl.is_simple(sum_type):
         # An object without fields, which can be stored inline.
-        
+
         # Create a class called foo_e.  Unlike the CompoundObj case, it doesn't
         # have subtypes.  Instead if has attributes foo_e.Bar, which Bar is an
         # instance of foo_e.

--- a/asdl/tdop.py
+++ b/asdl/tdop.py
@@ -127,7 +127,7 @@ class ParserSpec(object):
 
   def Null(self, bp, nud, tokens):
     """Register a token that doesn't take anything on the left.
-    
+
     Examples: constant, prefix operator, error.
     """
     for token in tokens:

--- a/benchmarks/pytrace.py
+++ b/benchmarks/pytrace.py
@@ -20,7 +20,7 @@ class Tracer(object):
   # Limit to 10M events by default.
   def __init__(self, max_events=10e6):
     self.pid = os.getpid()
-    # append 
+    # append
     self.event_strs = cStringIO.StringIO()
 
     # After max_events we stop recording
@@ -45,7 +45,7 @@ class Tracer(object):
     name = frame.f_code.co_name
     filename = frame.f_code.co_filename
     if event_type in ('call', 'c_call'):
-      self.depth += 1 
+      self.depth += 1
 
     record = '%s%s\t%s\t%s\t%s\t%s\n' % ('  ' * self.depth,
         event_type, filename, frame.f_lineno, name, arg)

--- a/bin/oil.py
+++ b/bin/oil.py
@@ -451,7 +451,7 @@ def OshCommandMain(argv):
   TODO:
   - oshc --help
 
-  oshc deps 
+  oshc deps
     --path: the $PATH to use to find executables.  What about libraries?
 
     NOTE: we're leaving out su -c, find, xargs, etc.?  Those should generally

--- a/build/quick_ref.py
+++ b/build/quick_ref.py
@@ -288,7 +288,7 @@ def Pages(f, text_out):
         print('<pre>')
 
         prev_topics = topics
-        
+
       else:
         # Three or more should be a heading, not a comment.
         if line.startswith('###'):

--- a/build/testdata/hello.py
+++ b/build/testdata/hello.py
@@ -20,7 +20,7 @@ if not os.getenv('_OVM_DEPS'):
 
 import lib
 
-#import zipfile 
+#import zipfile
 
 import zipimport
 

--- a/core/args.py
+++ b/core/args.py
@@ -13,7 +13,7 @@ Differences from getopt/optparse:
 - maybe: integrate with usage
 - maybe: integrate with flags
 
-optparse: 
+optparse:
   - has option groups
 
 NOTES about builtins:
@@ -373,7 +373,7 @@ class BuiltinFlags(object):
       print(ch)
 
   def ShortFlag(self, short_name, arg_type=None):
-    """ 
+    """
     This is very similar to ShortFlag for FlagsAndOptions, except we have
     separate arity0 and arity1 dicts.
     """
@@ -439,7 +439,7 @@ class BuiltinFlags(object):
     # So look up the first one
 
     # NOTE about -:
-    # 'set -' ignores it, vs set 
+    # 'set -' ignores it, vs set
     # 'unset -' or 'export -' seems to treat it as a variable name
 
     state = _ArgState(argv)

--- a/core/args_test.py
+++ b/core/args_test.py
@@ -80,7 +80,7 @@ class ArgsTest(unittest.TestCase):
     self.assertEqual(3, i)
 
     # Now this is an arg.  Gah.
-    argv = ['+o', 'pipefail', 'errexit'] 
+    argv = ['+o', 'pipefail', 'errexit']
     arg, i = s.Parse(argv)
     self.assertEqual([('pipefail', False)], arg.opt_changes)
     self.assertEqual(['errexit'], argv[i:])

--- a/core/braces.py
+++ b/core/braces.py
@@ -53,7 +53,7 @@ def _BraceDetect(w):
     # alternatives, with optional prefix and suffix.
     brace_expr = part* '{' alt ',' alt (',' alt)* '}' part*
 
-  Problem this grammar: it's not LL(1) 
+  Problem this grammar: it's not LL(1)
   Is it indirect left-recursive?
   What's the best way to handle it?  LR(1) parser?
 

--- a/core/completion.py
+++ b/core/completion.py
@@ -648,7 +648,7 @@ class RootCompleter(object):
 class ReadlineCompleter(object):
   def __init__(self, root_comp, status_out, debug=False):
     self.root_comp = root_comp
-    self.status_out = status_out 
+    self.status_out = status_out
     self.debug = debug
 
     self.comp_iter = None  # current completion being processed

--- a/core/expr_eval.py
+++ b/core/expr_eval.py
@@ -152,7 +152,7 @@ def EvalLhs(node, arith_ev, mem, exec_opts):
   #log('lhs_expr NODE %s', node)
   assert isinstance(node, ast.lhs_expr), node
   if node.tag == lhs_expr_e.LhsName:  # a = b
-    # Problem: It can't be an array?  
+    # Problem: It can't be an array?
     # a=(1 2)
     # (( a++ ))
     lval = runtime.LhsName(node.name)
@@ -325,7 +325,7 @@ class ArithEvaluator(_ExprEvaluator):
         new_int = old_int ^ rhs
       else:
         raise AssertionError(op_id)  # shouldn't get here
- 
+
       self._Store(lval, new_int)
       return new_int
 

--- a/core/id_kind.py
+++ b/core/id_kind.py
@@ -121,7 +121,7 @@ class IdSpec(object):
 
   def AddBoolBinaryForBuiltin(self, token_name, kind, bool_arg_type_e):
     """For [ = ] [ == ] and [ != ].
-    
+
     These operators are NOT added to the lexer.  The are "lexed" as StringWord.
     """
     token_name = 'BoolBinary_%s' % token_name
@@ -363,7 +363,7 @@ def AddKinds(spec):
       'OneChar', 'Stop', 'Hex',
       # Two variants of Octal: \377, and \0377.
       'Octal3', 'Octal4',
-      'Unicode4', 'Unicode8', 'Literals', 
+      'Unicode4', 'Unicode8', 'Literals',
       'BadBackslash',  # \D or trailing \
   ])
 
@@ -379,7 +379,7 @@ def AddKinds(spec):
 
 # Shared between [[ and test/[.
 _UNARY_STR_CHARS = 'zn'  # -z -n
-_UNARY_OTHER_CHARS = 'otvR'  # -o is overloaded 
+_UNARY_OTHER_CHARS = 'otvR'  # -o is overloaded
 _UNARY_PATH_CHARS = 'abcdefghLprsSuwxOGN'  # -a is overloaded
 
 _BINARY_PATH = ['ef', 'nt', 'ot']
@@ -425,7 +425,7 @@ def SetupTestBuiltin(Id, Kind, id_spec,
   - =~ doesn't exist
   - && -> -a, || -> -o
   - ( ) -> Op_LParen (they don't appear above)
-  """ 
+  """
   for letter in _UNARY_STR_CHARS + _UNARY_OTHER_CHARS + _UNARY_PATH_CHARS:
     token_name = 'BoolUnary_%s' % letter
     unary_lookup['-' + letter] = getattr(Id, token_name)

--- a/core/id_kind_gen.py
+++ b/core/id_kind_gen.py
@@ -105,7 +105,7 @@ def main(argv):
     else:
       with open(labels) as f:
         label_lines = f.readlines()
-     
+
     from collections import defaultdict
 
     id_by_kind_index = defaultdict(list)  # Kind name -> [list of Id names]

--- a/core/legacy.py
+++ b/core/legacy.py
@@ -16,13 +16,13 @@ Idea: This is discouraged/legacy, so write it in Oil rather than C++?
 Problem: Need both classes and algebraic data types.
 
 Do we have different splitters?  Awk splitter might be useful.  Regex
-splitter later.  CSV splitter?  
+splitter later.  CSV splitter?
 LiteralSlice.
 
 Other kinds of splitters:
 
 - RegexSplitter
-- CsvSplitter 
+- CsvSplitter
 - TSV2Splitter -- this transforms because of # \u0065 in JSON.  So it's not a
   pure slice, but neither is IFS splitting because of backslashes.
 - AwkSplitter
@@ -30,7 +30,7 @@ Other kinds of splitters:
   - does perl have a spilt context?
 
 with SPLIT_REGEX = / digit+ / {
-  echo $#  
+  echo $#
   echo $len(argv)
   echo $1 $2
   echo @argv
@@ -81,7 +81,7 @@ def _SpansToParts(s, spans):
 
 class SplitContext(object):
   """ A polymorphic interface to field splitting.
-  
+
   It respects a STACK of IFS values, for example:
 
   echo $x  # uses default shell IFS
@@ -160,7 +160,7 @@ class SplitContext(object):
     IGNORED can be used for two reasons:
     1. The slice is a delimiter.
     2. The slice is a a backslash escape.
-    
+
     Example: If you have one\:two, then there are four slices.  Only the
     backslash one is ignored.  In 'one:two', then you have three slices.  The
     colon is ignored.
@@ -243,7 +243,7 @@ class NullSplitter(_BaseSplitter):
 CH_DE_WHITE, CH_DE_GRAY, CH_BLACK, CH_BACKSLASH = range(4)
 
 # Nodes are states
-(ST_INVALID, ST_START, ST_DE_WHITE1, ST_DE_GRAY, ST_DE_WHITE2, 
+(ST_INVALID, ST_START, ST_DE_WHITE1, ST_DE_GRAY, ST_DE_WHITE2,
  ST_BLACK, ST_BACKSLASH) = range(7)
 
 # Actions control what spans to emit.
@@ -373,7 +373,7 @@ class IfsSplitter(_BaseSplitter):
         spans.append((span_e.Backslash, i))  # \
 
       else:
-        pass  # Emit nothing 
+        pass  # Emit nothing
 
       state = new_state
       i += 1
@@ -384,7 +384,7 @@ class IfsSplitter(_BaseSplitter):
     elif state == ST_BACKSLASH:
       span_type = span_e.Backslash
     elif state in (ST_DE_WHITE1, ST_DE_GRAY, ST_DE_WHITE2):
-      span_type = span_e.Delim 
+      span_type = span_e.Delim
     else:
       raise AssertionError(state)  # shouldn't be in START state
     spans.append((span_type, n))

--- a/core/lexer_gen.py
+++ b/core/lexer_gen.py
@@ -76,11 +76,11 @@ def _CharClassLiteral(arg):
   if arg == 0:
     s = r'\x00'           # "\x00"
   elif arg == ord('\n'):
-    s = r'\n' 
+    s = r'\n'
   elif arg == ord('\r'):
-    s = r'\r' 
+    s = r'\r'
   elif arg == ord('\t'):
-    s = r'\t' 
+    s = r'\t'
   elif arg in CHAR_CLASS_META_CODES:
     s = '\\' + chr(arg)
   else:
@@ -92,11 +92,11 @@ def _Literal(arg):
   if arg == 0:
     s = r'\x00'           # "\000"
   elif arg == ord('\n'):
-    s = r'\n' 
+    s = r'\n'
   elif arg == ord('\r'):
-    s = r'\r' 
+    s = r'\r'
   elif arg == ord('\t'):
-    s = r'\t' 
+    s = r'\t'
   elif arg in LITERAL_META_CODES:
     s = '\\' + chr(arg)
   else:
@@ -142,7 +142,7 @@ def TranslateTree(re_tree, f, in_char_class=False):
 
     elif name == 'negate':  # ^ in [^a-z]
       assert arg is None
-      f.write('^') 
+      f.write('^')
 
     elif name == 'literal':  # Quote \ and " in re2c syntax
       # TODO: it matters if we're inside a character class

--- a/core/libstr.py
+++ b/core/libstr.py
@@ -88,15 +88,15 @@ def NumOfUtf8Chars(bytes):
       if (byte_as_int >> 7) == 0b0:
         i += 1
       elif (byte_as_int >> 5) == 0b110:
-        _CheckContinuationByte(bytes[i+1]) 
+        _CheckContinuationByte(bytes[i+1])
         i += 2
       elif (byte_as_int >> 4) == 0b1110:
-        _CheckContinuationByte(bytes[i+1]) 
-        _CheckContinuationByte(bytes[i+2]) 
+        _CheckContinuationByte(bytes[i+1])
+        _CheckContinuationByte(bytes[i+2])
         i += 3
       elif (byte_as_int >> 3) == 0b11110:
-        _CheckContinuationByte(bytes[i+1]) 
-        _CheckContinuationByte(bytes[i+2]) 
+        _CheckContinuationByte(bytes[i+1])
+        _CheckContinuationByte(bytes[i+2])
         _CheckContinuationByte(bytes[i+3])
         i += 4
       else:

--- a/core/process.py
+++ b/core/process.py
@@ -452,7 +452,7 @@ class Process(Job):
     #log('STARTED process %s, pid = %d', self, pid)
 
     # Invariant, after the process is started, it stores its PID.
-    self.pid = pid 
+    self.pid = pid
     return pid
 
   def WaitUntilDone(self, waiter):

--- a/core/reader_test.py
+++ b/core/reader_test.py
@@ -40,7 +40,7 @@ class ReaderTest(unittest.TestCase):
     for a in [a1, a2, a3]:
       a.PushSource('reader_test.py')
 
-    for r in [r1, r2, r3]: 
+    for r in [r1, r2, r3]:
       print(r)
       # Lines are added to the arena with a line_id.
       self.assertEqual((0, 'one\n'), r.GetLine())

--- a/core/test_builtin.py
+++ b/core/test_builtin.py
@@ -23,7 +23,7 @@ _OTHER_LOOKUP = meta.TEST_OTHER_LOOKUP
 
 class _StringWordEmitter(object):
   """For test/[, we need a word parser that returns StringWord.
-  
+
   The BoolParser calls word.BoolId(w), and deals with Kind.BoolUnary,
   Kind.BoolBinary, etc.  This is instead of CompoundWord/TokenWord (as in the
   [[ case.

--- a/core/util.py
+++ b/core/util.py
@@ -84,7 +84,7 @@ class FatalRuntimeError(_ErrorWithLocation):
 
 class ErrExitFailure(FatalRuntimeError):
   """For set -e.
-  
+
   Travels between WordEvaluator and Executor.
   """
   pass

--- a/devtools/completion.py
+++ b/devtools/completion.py
@@ -27,7 +27,7 @@ def ParsePythonTest(f):
     if match:
       current_test = match.group(1)
       continue
-  
+
     match = METHOD_RE.match(line)
     if match and current_test is not None:
       print('%s.%s' % (current_test, match.group(1)))

--- a/native/libc.c
+++ b/native/libc.c
@@ -329,7 +329,7 @@ static PyMethodDef methods[] = {
    "an error."},
   {"fnmatch", func_fnmatch, METH_VARARGS,
    "Return whether a string matches a pattern."},
-  // We need this since Python's glob doesn't have char classes. 
+  // We need this since Python's glob doesn't have char classes.
   {"glob", func_glob, METH_VARARGS,
    "Return a list of files that match a pattern."},
   {"regex_parse", func_regex_parse, METH_VARARGS,

--- a/opy/byterun/pyvm2.py
+++ b/opy/byterun/pyvm2.py
@@ -34,7 +34,7 @@ def debug(msg, *args):
 
 
 def debug1(msg, *args):
-  if args: 
+  if args:
     msg = msg % args
   print(msg, file=sys.stderr)
 
@@ -50,7 +50,7 @@ class GuestException(Exception):
     NOTE: I added this because the host traceback was conflated with the guest
     traceback.
     """
-  
+
     def __init__(self, exctype, value, frames):
         self.exctype = exctype
         if isinstance(value, GuestException):
@@ -952,7 +952,7 @@ class VirtualMachine(object):
                     defaults, func.func_closure, self)
         else:
             byterun_func = func
-         
+
         #debug1('  Calling: %s', byterun_func)
         retval = byterun_func(*posargs, **namedargs)
         self.push(retval)

--- a/opy/byterun/test_basic.py
+++ b/opy/byterun/test_basic.py
@@ -25,7 +25,7 @@ class TestIt(vmtest.VmTestCase):
                 xyz+=1
                 print("Midst:",xyz)
 
-            
+
             print "Pre:",xyz
             abc()
             print "Post:",xyz

--- a/opy/callgraph.py
+++ b/opy/callgraph.py
@@ -141,9 +141,9 @@ def _Walk(obj, cls, ref, syms):
   #if obj.__name__ in ('write', 'get', 'Parse'):
   #  log('OBJ %s %d', obj, id(obj))
   #  pass
-   
+
   # Oh is the namedtuple_ crap because of the Block class byterun/pyobj?
-  
+
   if module_name is None or module_name in (
       'namedtuple_Arguments', 'namedtuple_ArgSpec',
       'namedtuple_Block'):
@@ -210,7 +210,7 @@ def _Walk(obj, cls, ref, syms):
 
       elif op == 'LOAD_ATTR':
         #if last_val is not None and isinstance(last_val, types.ModuleType):
-        if last_val is not None: 
+        if last_val is not None:
           #log('%s %s', op, var)
           val = _GetAttr(last_val, var)
           ref.append(var)
@@ -219,7 +219,7 @@ def _Walk(obj, cls, ref, syms):
           # methods, which have unique addresses.
           # Examples: WAIT_SPEC.Parse, sys.stdout.write
 
-          # BUG: os.fork and sys.stdout.write are the same? 
+          # BUG: os.fork and sys.stdout.write are the same?
           # I thought os.fork is types.BuiltinFunctionType, and
           # sys.stdout.write is types.BuiltinMethodType, but why not?
 
@@ -407,7 +407,7 @@ class Symbols(object):
 
     # Still missing: non-enum ASDL types?  Why?  CompoundObj?
     # command_e is there, but command and SimpleCommmand aren't.
-    # it's because we do 
+    # it's because we do
     # ast.command_e vs. ast.SimpleCommand
     # in both cases ast is a osh/meta _AsdlModule?
 

--- a/opy/compiler2/dis_tool.py
+++ b/opy/compiler2/dis_tool.py
@@ -51,7 +51,7 @@ def to_hexstr(bytes_value, level=0, wrap=False):
 # TODO: Do this in a cleaner way.  Right now I'm avoiding modifying the
 # consts module.
 def build_flags_def(consts, co_flags_def):
-  for name in dir(consts): 
+  for name in dir(consts):
     if name.startswith('CO_'):
       co_flags_def[name] = getattr(consts, name)
 

--- a/opy/compiler2/ovm_codegen.py
+++ b/opy/compiler2/ovm_codegen.py
@@ -166,7 +166,7 @@ class CodeGenerator(ASTVisitor):
     def visitBreak(self, node):
         print('Break')
         if not self.setups:
-            raise SyntaxError("'break' outside loop (%s, %d)" % 
+            raise SyntaxError("'break' outside loop (%s, %d)" %
                               (self.ctx.filename, node.lineno))
         self.set_lineno(node)
 
@@ -260,7 +260,7 @@ class CodeGenerator(ASTVisitor):
 
     def visitCompare(self, node):
         print('Compare')
-        # I guess this is 1 < x < y < 3 
+        # I guess this is 1 < x < y < 3
         self.visit(node.expr)
         cleanup = self.newBlock()
         for op, code in node.ops[:-1]:

--- a/opy/compiler2/pycodegen.py
+++ b/opy/compiler2/pycodegen.py
@@ -1258,7 +1258,7 @@ class _FunctionCodeGenerator(CodeGenerator):
         return True
 
     def FindLocals(self):
-        func = self.func 
+        func = self.func
 
         lnf = LocalNameFinder(set(self.func.argnames))
         lnf.Dispatch(func.code)

--- a/opy/compiler2/symbols_test.py
+++ b/opy/compiler2/symbols_test.py
@@ -9,7 +9,7 @@ import sys
 import symtable
 
 from . import symbols
-from . import transformer 
+from . import transformer
 
 
 def list_eq(l1, l2):

--- a/opy/compiler2/transformer.py
+++ b/opy/compiler2/transformer.py
@@ -40,7 +40,7 @@ def Init(sym):
 
   Args:
     sym: module
-  
+
   The stdlib module is generated from pgen.c's output data.  pgen2 derives it
   from the grammar directly.
 

--- a/opy/misc/stdlib_compile.py
+++ b/opy/misc/stdlib_compile.py
@@ -22,7 +22,7 @@ def getPycHeader(filename):
   #mtime = os.path.getmtime(filename)
   mtime = 0  # to make it deterministic for now
   mtime = struct.pack('<i', int(mtime))
-  return imp.get_magic() + mtime 
+  return imp.get_magic() + mtime
 
 
 def compileAndWrite(in_path, out_path, compile_func):

--- a/opy/testdata/speed_main.py
+++ b/opy/testdata/speed_main.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-import sys 
+import sys
 import speed
 
 n = int(sys.argv[1])

--- a/osh/bool_parse.py
+++ b/osh/bool_parse.py
@@ -253,7 +253,7 @@ class BoolParser(object):
         if not self._Next(): return None
         return ast.BoolBinary(op, left, right)
       else:
-        # [[ foo ]] 
+        # [[ foo ]]
         w = self.cur_word
         if not self._Next(): return None
         return ast.WordTest(w)

--- a/osh/lex.py
+++ b/osh/lex.py
@@ -342,7 +342,7 @@ LEXER_DEF[lex_mode_e.BASH_REGEX] = [
   C('|', Id.Lit_Chars),
 ] + [
   # Avoid "unreachable rule error"
-  (is_regex, pat, re_list) for 
+  (is_regex, pat, re_list) for
   (is_regex, pat, re_list) in _UNQUOTED
   if not (is_regex == False and pat in ('(', ')', '|'))
 ]

--- a/osh/match.py
+++ b/osh/match.py
@@ -63,7 +63,7 @@ class _MatchOshToken_Slow(object):
     re_list = self.lexer_def[lex_mode]
 
     return _LongestMatch(re_list, line, start_pos)
-  
+
 
 def _MatchOshToken_Fast(lex_mode, line, start_pos):
   """Returns (Id, end_pos)."""

--- a/osh/word_parse.py
+++ b/osh/word_parse.py
@@ -930,7 +930,7 @@ class WordParser(object):
         return None
 
       if w.tag == word_e.TokenWord:
-        word_id = word.CommandId(w) 
+        word_id = word.CommandId(w)
         if word_id == Id.Right_ArrayLiteral:
           break
         # Unlike command parsing, array parsing allows embedded \n.

--- a/test/jsontemplate.py
+++ b/test/jsontemplate.py
@@ -147,7 +147,7 @@ _SECTION_RE = re.compile(r'(repeated)?\s*section\s+(.+)')
 SIMPLE_FUNC, ENHANCED_FUNC = 0, 1
 
 # Templates are a third kind of function, but only for formatters currently
-TEMPLATE_FORMATTER = 2  
+TEMPLATE_FORMATTER = 2
 
 
 class FunctionRegistry(object):
@@ -212,7 +212,7 @@ class CallableRegistry(FunctionRegistry):
 
 class PrefixRegistry(FunctionRegistry):
   """Lookup functions with arguments.
-  
+
   The function name is identified by a prefix.  The character after the prefix,
   usually a space, is considered the argument delimiter (similar to sed/perl's
   s/foo/bar s|foo|bar syntax).
@@ -245,7 +245,7 @@ class PrefixRegistry(FunctionRegistry):
 
 class _TemplateRef(object):
   """A reference from one template to another.
-  
+
   The _TemplateRef sits statically in the program tree as one of the formatters.
   At runtime, _DoSubstitute calls Resolve() with the group being used.
   """
@@ -745,7 +745,7 @@ def _Reverse(x):
   strings too.
   """
   return list(reversed(x))
-  
+
 
 def _Pairs(data):
   """dictionary -> list of pairs"""
@@ -813,7 +813,7 @@ _DEFAULT_FORMATTERS = {
     'js-string': None,
 
     'reverse': _Reverse,
-    
+
     # Given a dictinonary, returns a *list* of key-value pairs.  Used for
     # section formatters.  See jsontemplate_test.py for usage.
     #
@@ -1527,7 +1527,7 @@ class Template(object):
 
 class Trace(object):
   """Trace of execution for JSON Template.
-  
+
   This object should be passed into the execute/expand() function.
 
   Useful for debugging, especially for templates which reference other
@@ -1582,7 +1582,7 @@ def MakeTemplateGroup(group):
   This function *mutates* all the templates, so you shouldn't call it multiple
   times on a single Template() instance.  It's possible to put a single template
   in multiple groups by creating multiple Template() instances from it.
-  
+
   Args:
     group: dictionary of template name -> compiled Template instance
   """
@@ -1827,7 +1827,7 @@ def expand_with_style(template, style, data, body_subtree='body'):
 
   Args:
     template: Template instance for the inner "page content"
-    style: Template instance for the outer "page style"  
+    style: Template instance for the outer "page style"
     data: Data dictionary, with a 'body' key (or body_subtree
   """
   if template.has_defines:

--- a/test/sh_spec.py
+++ b/test/sh_spec.py
@@ -162,7 +162,7 @@ class Tokenizer(object):
 #
 # -- Code is either literal lines, or a commented out code: value.
 # code = PLAIN_LINE*
-#      | '## code:'  VALUE 
+#      | '## code:'  VALUE
 #
 # -- Key value pairs can be single- or multi-line
 # key_value = '##' KEY ':' VALUE
@@ -173,10 +173,10 @@ class Tokenizer(object):
 #             key_value*
 #             code
 #             key_value*
-# 
+#
 # -- Should be a blank line after each test case.  Leading comments and code
 # -- are OK.
-# test_file = (COMMENT | PLAIN_LINE)* (test_case '\n')*  
+# test_file = (COMMENT | PLAIN_LINE)* (test_case '\n')*
 
 
 def AddMetadataToCase(case, qualifier, shells, name, value):
@@ -258,7 +258,7 @@ def ParseCodeLines(tokens, case):
 
 def ParseTestCase(tokens):
   """Parse a single test case and return it.
-  
+
   If at EOF, return None.
   """
   line_num, kind, item = tokens.peek()
@@ -381,7 +381,7 @@ def CreateAssertions(case, sh_label):
       # code is 0.
       a = EqualAssertion('status', 0)
       assertions.append(a)
-    
+
   #print 'SHELL', shell
   #pprint.pprint(case)
   #print(assertions)
@@ -947,7 +947,7 @@ def main(argv):
     return 0
 
   allowed = opts.osh_failures_allowed
-  all_count = stats['num_failed'] 
+  all_count = stats['num_failed']
   osh_count = stats['osh_num_failed']
   if allowed == 0:
     log('')

--- a/test/sh_spec_test.py
+++ b/test/sh_spec_test.py
@@ -53,14 +53,14 @@ class ShSpecTest(unittest.TestCase):
 
     types = [type_ for line_num, type_, value in TOKENS1]
     self.assertEqual(
-        [ TEST_CASE_BEGIN, PLAIN_LINE, PLAIN_LINE, 
+        [ TEST_CASE_BEGIN, PLAIN_LINE, PLAIN_LINE,
           KEY_VALUE, KEY_VALUE, KEY_VALUE,
           EOF], types)
 
     #pprint.pprint(TOKENS2)
     types2 = [type_ for line_num, type_, value in TOKENS2]
     self.assertEqual(
-        [ TEST_CASE_BEGIN, PLAIN_LINE, PLAIN_LINE, 
+        [ TEST_CASE_BEGIN, PLAIN_LINE, PLAIN_LINE,
           KEY_VALUE, KEY_VALUE,
           KEY_VALUE_MULTILINE, PLAIN_LINE, PLAIN_LINE,
           KEY_VALUE_MULTILINE, PLAIN_LINE, PLAIN_LINE, END_MULTILINE,

--- a/test/wild_report.py
+++ b/test/wild_report.py
@@ -564,7 +564,7 @@ def main(argv):
 
       with open(raw_base + '__parse.stderr.txt') as f:
         st['parse_stderr'] = f.read()
-      
+
       osh2oil_task_path = raw_base + '__osh2oil.task.txt'
       st['osh2oil_failed'], st['osh2oil_proc_secs'] = _ReadTaskFile(
           osh2oil_task_path)

--- a/tools/deps.py
+++ b/tools/deps.py
@@ -127,7 +127,7 @@ class DepsVisitor(Visitor):
 
         # Should we mark them behind 'sudo'?  e.g. "sudo apt install"?
         self.progs_used[argv1] = True
-        
+
     elif cls is ast.FuncDef:
       self.funcs_defined[node.name] = True
 

--- a/web/table/csv2html.py
+++ b/web/table/csv2html.py
@@ -10,7 +10,7 @@ Attempts to read foo_schema.csv.  If not it assumes everything is a string.
 
 Things it handles:
 
-- table-sort.js integration <colgroup> 
+- table-sort.js integration <colgroup>
   - <table id="foo"> for making columns sortable
   - for choosing the comparator to use!
   - for highlighting on sort
@@ -140,7 +140,7 @@ class Schema:
   def ColumnPrecision(self, index):
     col_name = self.col_names[index]
     return self.precision_lookup.get(col_name, 1)  # default is arbitrary
-  
+
 
 def PrintRow(row, schema):
   """Print a CSV row as HTML, using the given formatting.
@@ -201,7 +201,7 @@ def PrintRow(row, schema):
       s = '<a href="%s">%s</a>' % (cgi.escape(href), cgi.escape(cell_str))
     else:
       s = cgi.escape(cell_str)
-    
+
     print(s, end=' ')
     print('</td>')
 


### PR DESCRIPTION
I managed to make a mess out of the previous pull request so here it is again.
The first pass for formatting the project code.
The travis idea for dealing with whitespace, also good to check the gitignore...
```sh
if git --no-pager grep -P '\s+$' -- *.{c,py}; then
  # do something
fi