### PR TITLE
Fix comment errors

### DIFF
--- a/test/sh_spec.py
+++ b/test/sh_spec.py
@@ -80,8 +80,8 @@ def log(msg, *args):
 
 
 # EXAMPLES:
-## stdout: foo
-## stdout-json: ""
+# stdout: foo
+# stdout-json: ""
 #
 # In other words, it could be (name, value) or (qualifier, name, value)
 
@@ -98,7 +98,7 @@ END_MULTILINE_RE = re.compile(r'''
 ''', re.VERBOSE)
 
 # Line types
-TEST_CASE_BEGIN = 0  # Starts with ###
+TEST_CASE_BEGIN = 0  # Starts with ####
 KEY_VALUE = 1  # Metadata
 KEY_VALUE_MULTILINE = 2  # STDOUT STDERR
 END_MULTILINE = 3  # STDOUT STDERR

--- a/test/sh_spec.py
+++ b/test/sh_spec.py
@@ -80,8 +80,8 @@ def log(msg, *args):
 
 
 # EXAMPLES:
-# stdout: foo
-# stdout-json: ""
+## stdout: foo
+## stdout-json: ""
 #
 # In other words, it could be (name, value) or (qualifier, name, value)
 


### PR DESCRIPTION
There are some small mistakes in some of the comments that have
been overlooked from the commit that reformatted the spec tests.
This commit amends those errors for consistent documentation.