### PR TITLE
Add compgen function to osh

### DIFF
--- a/core/builtin.py
+++ b/core/builtin.py
@@ -801,12 +801,14 @@ COMPGEN_SPEC.ShortFlag('-A', args.Str)
 def CompGen(argv, funcs):
   arg, i = COMPGEN_SPEC.Parse(argv)
   status = 0
+
   if arg.A:
-    for func_name in funcs:
+    for func_name in sorted(funcs.iteritems()):
       print(func_name)
   else:
     util.warn('*** command without -A not implemented ***')
     status = 1
+
   return status
 
 

--- a/core/builtin.py
+++ b/core/builtin.py
@@ -803,10 +803,14 @@ def CompGen(argv, funcs):
   status = 0
 
   if arg.A:
-    for func_name in sorted(funcs.iteritems()):
-      print(func_name)
+    if arg.A != 'function':
+        status = 1
+        raise args.UsageError('compgen: {}: invalid action name'.format(arg.A))
+    else:
+      for func_name,func_def in sorted(funcs.iteritems()):
+        print('{}'.format(func_name))
   else:
-    util.warn('*** command without -A not implemented ***')
+    util.warn('*** not implemented ***')
     status = 1
 
   return status

--- a/core/builtin.py
+++ b/core/builtin.py
@@ -877,7 +877,7 @@ def Command(argv, funcs, path_val):
         # This is for -v, -V is more detailed.
         print(arg)
   else:
-    util.warn('*** command without -v not not implemented ***')
+    util.warn('*** command without -v not implemented ***')
     status = 1
 
   return status

--- a/core/builtin.py
+++ b/core/builtin.py
@@ -794,6 +794,22 @@ def Shopt(argv, exec_opts):
   return 0
 
 
+COMPGEN_SPEC = _Register('compgen')
+COMPGEN_SPEC.ShortFlag('-A', args.Str)
+
+
+def Compgen(argv, funcs):
+  arg, i = COMPGEN_SPEC.Parse(argv)
+  status = 0
+  if arg.A:
+    for func_name in funcs:
+      print(func_name)
+  else:
+    util.warn('*** command without -A not implemented ***')
+    status = 1
+  return status
+
+
 UNSET_SPEC = _Register('unset')
 UNSET_SPEC.ShortFlag('-v')
 UNSET_SPEC.ShortFlag('-f')

--- a/core/builtin.py
+++ b/core/builtin.py
@@ -798,7 +798,7 @@ COMPGEN_SPEC = _Register('compgen')
 COMPGEN_SPEC.ShortFlag('-A', args.Str)
 
 
-def Compgen(argv, funcs):
+def CompGen(argv, funcs):
   arg, i = COMPGEN_SPEC.Parse(argv)
   status = 0
   if arg.A:

--- a/core/builtin.py
+++ b/core/builtin.py
@@ -805,10 +805,10 @@ def CompGen(argv, funcs):
   if arg.A:
     if arg.A != 'function':
         status = 1
-        raise args.UsageError('compgen: {}: invalid action name'.format(arg.A))
+        raise args.UsageError('compgen: %s: invalid action name' % arg.A)
     else:
-      for func_name,func_def in sorted(funcs.iteritems()):
-        print('{}'.format(func_name))
+      for func_name in sorted(funcs):
+        print(func_name)
   else:
     util.warn('*** command without -A not implemented ***')
     status = 1

--- a/core/builtin.py
+++ b/core/builtin.py
@@ -810,7 +810,7 @@ def CompGen(argv, funcs):
       for func_name,func_def in sorted(funcs.iteritems()):
         print('{}'.format(func_name))
   else:
-    util.warn('*** not implemented ***')
+    util.warn('*** command without -A not implemented ***')
     status = 1
 
   return status

--- a/core/cmd_exec.py
+++ b/core/cmd_exec.py
@@ -180,9 +180,6 @@ class Executor(object):
       util.error('Oil was not built with readline/completion.')
     return 0
 
-  #def _CompGen(self, argv):
-    #raise NotImplementedError
-
   def _EvalHelper(self, c_parser, source_name):
     self.arena.PushSource(source_name)
     try:

--- a/core/cmd_exec.py
+++ b/core/cmd_exec.py
@@ -180,8 +180,8 @@ class Executor(object):
       util.error('Oil was not built with readline/completion.')
     return 0
 
-  def _CompGen(self, argv):
-    raise NotImplementedError
+  #def _CompGen(self, argv):
+    #raise NotImplementedError
 
   def _EvalHelper(self, c_parser, source_name):
     self.arena.PushSource(source_name)
@@ -359,7 +359,7 @@ class Executor(object):
       status = self._Complete(argv)
 
     elif builtin_id == builtin_e.COMPGEN:
-      status = self._CompGen(argv)
+      status = builtin.CompGen(argv, self.funcs)
 
     elif builtin_id == builtin_e.COLON:  # special builtin like 'true'
       status = 0

--- a/spec/compgen.test.sh
+++ b/spec/compgen.test.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 
 #### Print function list
-env -i /bin/bash --norc --noprofile -c 'add () { expr 4 + 4; }; \
-                                        div () { expr 6 / 2; }; \
-                                        ek () { echo hello;} \
+env -i /bin/bash --norc --noprofile -c 'add () { expr 4 + 4; } \
+                                        && div () { expr 6 / 2; } \
+                                        && ek () { echo hello; } \
+                                        && __ec () { echo hi; } \
+                                        && _ab () { expr 10 % 3; } \
                                         && compgen -A function'
 ## status: 0
 ## STDOUT:
+__ec
+_ab
 add
 div
 ek

--- a/spec/compgen.test.sh
+++ b/spec/compgen.test.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 #### Print function list
-env -i /bin/bash --norc --noprofile -c 'add () { expr 4 + 4; } \
-                                        && div () { expr 6 / 2; } \
-                                        && ek () { echo hello; } \
-                                        && __ec () { echo hi; } \
-                                        && _ab () { expr 10 % 3; } \
-                                        && compgen -A function'
+env -i /bin/bash --norc --noprofile -c 'add () { expr 4 + 4; }; \
+                                        div () { expr 6 / 2; }; \
+                                        ek () { echo hello; }; \
+                                        __ec () { echo hi; }; \
+                                        _ab () { expr 10 % 3; }; \
+                                        compgen -A function'
 ## status: 0
 ## STDOUT:
 __ec

--- a/spec/compgen.test.sh
+++ b/spec/compgen.test.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 #### Print function list
-env -i /bin/bash --norc --noprofile -c 'add () { expr 4 + 4; }; \
-                                        div () { expr 6 / 2; }; \
-                                        ek () { echo hello; }; \
-                                        __ec () { echo hi; }; \
-                                        _ab () { expr 10 % 3; }; \
-                                        compgen -A function'
+add () { expr 4 + 4; }
+div () { expr 6 / 2; }
+ek () { echo hello; }
+__ec () { echo hi; }
+_ab () { expr 10 % 3; }
+compgen -A function
 ## status: 0
 ## STDOUT:
 __ec

--- a/spec/compgen.test.sh
+++ b/spec/compgen.test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+#### Print function list
+env -i /bin/bash --norc --noprofile -c 'add () { expr 4 + 4; }; \
+                                        div () { expr 6 / 2; }; \
+                                        ek () { echo hello;} \
+                                        && compgen -A function'
+## status: 0
+## STDOUT:
+add
+div
+ek
+## END

--- a/test/spec.sh
+++ b/test/spec.sh
@@ -604,4 +604,8 @@ shell-grammar() {
   sh-spec spec/shell-grammar.test.sh $BASH $MKSH $ZSH "$@"
 }
 
+compgen() {
+  sh-spec spec/compgen.test.sh $BASH $OSH "$@"
+}
+
 "$@"


### PR DESCRIPTION
This merge adds `compgen -A function` to osh. Not sure if `compgen` should be in `cmd_exec.py` or `builtins` so the previous is commented out.