### PR TITLE
[builtins] add relative path joining for cd

### DIFF
--- a/core/builtin.py
+++ b/core/builtin.py
@@ -544,7 +544,14 @@ def Cd(argv, mem, dir_stack):
   # '-L' is the default behavior; no need to check it
   # TODO: ensure that if multiple flags are provided, the *last* one overrides
   # the others
-  pwd = libc.realpath(dest_dir) if arg.P else dest_dir
+
+  # if we are cd'ing relatively: we do a join and fix any '..'s
+  # else: do a replace
+  if dest_dir[0] != '/':
+    pwd = os.path.normpath(os.path.join(pwd.s, dest_dir))
+  else:
+    pwd = libc.realpath(dest_dir) if arg.P else dest_dir
+
   state.SetGlobalString(mem, 'PWD', pwd)
 
   dir_stack.Reset()  # for pushd/popd/dirs


### PR DESCRIPTION
this is related to issue #182. After looking at line 215 of [cd.c in dash](https://git.kernel.org/pub/scm/utils/dash/dash.git/tree/src/cd.c#n215), I 
decided to try their first piece of logic: join if relative, else replace and now tests pass. 

TESTPLAN: tested with test/spec.sh builtins, all pass except 'set umask symbolically'
