### PR TITLE
Use #!/usr/bin/env for shebangs

### DIFF
--- a/Python-2.7.13/Tools/gdb/libpython.py
+++ b/Python-2.7.13/Tools/gdb/libpython.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 '''
 From gdb 7 onwards, gdb's build can be configured --with-python, allowing gdb
 to be extended with Python code e.g. for library-specific data visualizations,

--- a/asdl/cgi.py
+++ b/asdl/cgi.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 cgi.py - Copied from Python stdlib.
 

--- a/asdl/format_test.py
+++ b/asdl/format_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env -S python -S
 """
 format_test.py: Tests for format.py
 """

--- a/asdl/front_end.py
+++ b/asdl/front_end.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 front_end.py: Lexer and parser for the ASDL schema language.
 """

--- a/asdl/pretty.py
+++ b/asdl/pretty.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 pretty.py
 """

--- a/asdl/unpickle.py
+++ b/asdl/unpickle.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 unpickle.py: A subset of unpickling code from pickle.py.
 

--- a/asdl/unpickle_test.py
+++ b/asdl/unpickle_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env -S python -S
 """
 unpickle_test.py: Tests for unpickle.py
 """

--- a/asdl/visitor.py
+++ b/asdl/visitor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 visitor.py
 """

--- a/benchmarks/bytecode.R
+++ b/benchmarks/bytecode.R
@@ -1,4 +1,4 @@
-#!/usr/bin/Rscript
+#!/usr/bin/env Rscript
 #
 # bytecode.R -- Analyze output of opyc dis-tables.
 #

--- a/benchmarks/common.R
+++ b/benchmarks/common.R
@@ -1,4 +1,4 @@
-#!/usr/bin/Rscript
+#!/usr/bin/env Rscript
 #
 # common.R - Shared R functions.
 

--- a/benchmarks/native-code.R
+++ b/benchmarks/native-code.R
@@ -1,4 +1,4 @@
-#!/usr/bin/Rscript
+#!/usr/bin/env Rscript
 #
 # bytecode.R -- Analyze output of opyc dis-tables.
 #

--- a/benchmarks/report.R
+++ b/benchmarks/report.R
@@ -1,4 +1,4 @@
-#!/usr/bin/Rscript
+#!/usr/bin/env Rscript
 #
 # osh-parser.R -- Analyze output from shell scripts.
 #

--- a/benchmarks/testdata/functions
+++ b/benchmarks/testdata/functions
@@ -1564,7 +1564,7 @@ fakechroot" >> "$TARGET/var/lib/dpkg/diversions"
 
 	mv "$TARGET/usr/bin/ldd" "$TARGET/usr/bin/ldd.REAL"
 	cat << 'END' > "$TARGET/usr/bin/ldd"
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # fakeldd
 #

--- a/build/app_deps.py
+++ b/build/app_deps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env -S python -S
 from __future__ import print_function
 """
 py_deps.py

--- a/build/cpython_defs.py
+++ b/build/cpython_defs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 parse_cpython.py
 """

--- a/build/runpy_deps.py
+++ b/build/runpy_deps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env -S python -S
 from __future__ import print_function
 """
 runpy_deps.py

--- a/core/builtin_test.py
+++ b/core/builtin_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env -S python -S
 """
 builtin_test.py: Tests for builtin.py
 """

--- a/core/comp_builtins.py
+++ b/core/comp_builtins.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 comp_builtins.py - Completion builtins
 """

--- a/core/dev.py
+++ b/core/dev.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 dev.py - Devtools / introspection.
 """

--- a/core/legacy_test.py
+++ b/core/legacy_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env -S python -S
 """
 legacy_test.py: Tests for legacy.py
 """

--- a/core/lexer_gen_test.py
+++ b/core/lexer_gen_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env -S python -S
 """
 lexer_gen_test.py: Tests for lexer_gen.py
 """

--- a/core/libstr_test.py
+++ b/core/libstr_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env -S python -S
 """
 libstr_test.py: Tests for libstr.py
 """

--- a/core/main_loop.py
+++ b/core/main_loop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 main_loop.py
 

--- a/core/reader_test.py
+++ b/core/reader_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env -S python -S
 """
 reader_test.py: Tests for reader.py
 """

--- a/core/ui_test.py
+++ b/core/ui_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env -S python -S
 from __future__ import print_function
 """
 ui_test.py: Tests for ui.py

--- a/core/word_compile_test.py
+++ b/core/word_compile_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env -S python -S
 """
 word_compile_test.py: Tests for word_compile.py
 """

--- a/devtools/completion.py
+++ b/devtools/completion.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env -S python -S
 from __future__ import print_function
 """
 completion.py

--- a/opy/_regtest/src/asdl/format_test.py
+++ b/opy/_regtest/src/asdl/format_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env -S python -S
 """
 format_test.py: Tests for format.py
 """

--- a/opy/_regtest/src/asdl/visitor.py
+++ b/opy/_regtest/src/asdl/visitor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 visitor.py
 """

--- a/opy/_regtest/src/build/app_deps.py
+++ b/opy/_regtest/src/build/app_deps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env -S python -S
 from __future__ import print_function
 """
 py_deps.py

--- a/opy/_regtest/src/build/runpy_deps.py
+++ b/opy/_regtest/src/build/runpy_deps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env -S python -S
 from __future__ import print_function
 """
 runpy_deps.py

--- a/opy/_regtest/src/core/builtin_test.py
+++ b/opy/_regtest/src/core/builtin_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env -S python -S
 from __future__ import print_function
 """
 builtin_test.py: Tests for builtin.py

--- a/opy/_regtest/src/core/legacy_test.py
+++ b/opy/_regtest/src/core/legacy_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env -S python -S
 """
 legacy_test.py: Tests for legacy.py
 """

--- a/opy/_regtest/src/core/lexer_gen_test.py
+++ b/opy/_regtest/src/core/lexer_gen_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env -S python -S
 from __future__ import print_function
 """
 lexer_gen_test.py: Tests for lexer_gen.py

--- a/opy/_regtest/src/core/libstr_test.py
+++ b/opy/_regtest/src/core/libstr_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env -S python -S
 from __future__ import print_function
 """
 libstr_test.py: Tests for libstr.py

--- a/opy/_regtest/src/core/reader_test.py
+++ b/opy/_regtest/src/core/reader_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env -S python -S
 """
 reader_test.py: Tests for reader.py
 """

--- a/opy/_regtest/src/opy/callgraph.py
+++ b/opy/_regtest/src/opy/callgraph.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """
 callgraph.py

--- a/opy/_regtest/src/opy/callgraph_demo.py
+++ b/opy/_regtest/src/opy/callgraph_demo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """
 callgraph_demo.py

--- a/opy/_regtest/src/opy/callgraph_test.py
+++ b/opy/_regtest/src/opy/callgraph_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env -S python -S
 from __future__ import print_function
 """
 callgraph_test.py: Tests for callgraph.py

--- a/opy/_regtest/src/opy/compiler2/pyassem_test.py
+++ b/opy/_regtest/src/opy/compiler2/pyassem_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env -S python -S
 from __future__ import print_function
 """
 pyassem_test.py: Tests for pyassem.py

--- a/opy/_regtest/src/opy/compiler2/symbols_test.py
+++ b/opy/_regtest/src/opy/compiler2/symbols_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env -S python -S
 """
 symbols_test.py: Tests for symbols.py
 

--- a/opy/_regtest/src/osh/ast_lib.py
+++ b/opy/_regtest/src/osh/ast_lib.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 ast_lib.py
 

--- a/opy/_regtest/src/osh/meta.py
+++ b/opy/_regtest/src/osh/meta.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 meta.py
 

--- a/opy/_regtest/src/tools/deps.py
+++ b/opy/_regtest/src/tools/deps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """
 deps.py

--- a/opy/byterun/ovm.py
+++ b/opy/byterun/ovm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """
 ovm.py

--- a/opy/byterun/pyvm2_test.py
+++ b/opy/byterun/pyvm2_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 pyvm2_test.py: Tests for pyvm2.py
 """

--- a/opy/callgraph.py
+++ b/opy/callgraph.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """
 callgraph.py

--- a/opy/callgraph_test.py
+++ b/opy/callgraph_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env -S python -S
 from __future__ import print_function
 """
 callgraph_test.py: Tests for callgraph.py

--- a/opy/compiler2/consts_test.py
+++ b/opy/compiler2/consts_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env -S python -S
 """
 consts_test.py: Tests for consts.py
 """

--- a/opy/compiler2/ovm_codegen.py
+++ b/opy/compiler2/ovm_codegen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """
 ovm_codegen.py

--- a/opy/compiler2/pyassem_test.py
+++ b/opy/compiler2/pyassem_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env -S python -S
 from __future__ import print_function
 """
 pyassem_test.py: Tests for pyassem.py

--- a/opy/compiler2/symbols_test.py
+++ b/opy/compiler2/symbols_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env -S python -S
 """
 symbols_test.py: Tests for symbols.py
 

--- a/opy/demo/class_scope.py
+++ b/opy/demo/class_scope.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 class Foo(object):
   a = 1

--- a/opy/demo/docstring.py
+++ b/opy/demo/docstring.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 module DOCSTRING
 """

--- a/opy/demo/four_var_kinds.py
+++ b/opy/demo/four_var_kinds.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 four_var_kinds.py
 

--- a/opy/gold/class_vs_closure.py
+++ b/opy/gold/class_vs_closure.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """
 class_vs_closure.py

--- a/opy/gold/fib_iterative.py
+++ b/opy/gold/fib_iterative.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """Iterative version if Fibonacci."""
 

--- a/opy/gold/fib_recursive.py
+++ b/opy/gold/fib_recursive.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """Recursive version if Fibonacci."""
 

--- a/opy/gold/generator_exception.py
+++ b/opy/gold/generator_exception.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """
 generator_exception.py

--- a/opy/gold/regex_compile.py
+++ b/opy/gold/regex_compile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """
 regex_compile.py

--- a/opy/gold/repr_method.py
+++ b/opy/gold/repr_method.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 
 

--- a/opy/lib/opcode_gen.py
+++ b/opy/lib/opcode_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """
 opcode_gen.py

--- a/opy/skeleton.py
+++ b/opy/skeleton.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 skeleton.py: The compiler pipeline.
 """

--- a/opy/testdata/hello_py2_print.py
+++ b/opy/testdata/hello_py2_print.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 print >>sys.stderr, 'hi'

--- a/opy/testdata/speed.py
+++ b/opy/testdata/speed.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 def do_sum(n):
   sum = 0
   for i in xrange(n):

--- a/opy/testdata/speed_main.py
+++ b/opy/testdata/speed_main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import sys
 import speed
 

--- a/opy/testdata/tuple_args.py
+++ b/opy/testdata/tuple_args.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """
 tuple_args.py: Testing out this little-known feature of Python, which compiler2

--- a/osh/ast_lib.py
+++ b/osh/ast_lib.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 ast_lib.py - Helpers for osh/osh.asdl
 """

--- a/osh/match.py
+++ b/osh/match.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 match.py - match with generated re2c code or Python regexes.
 """

--- a/osh/meta.py
+++ b/osh/meta.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 meta.py
 

--- a/test/report.R
+++ b/test/report.R
@@ -1,4 +1,4 @@
-#!/usr/bin/Rscript
+#!/usr/bin/env Rscript
 #
 # report.R
 

--- a/test/wild_report_test.py
+++ b/test/wild_report_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -S
+#!/usr/bin/env -S python -S
 """
 wild_report_test.py: Tests for wild_report.py
 """

--- a/tools/deps.py
+++ b/tools/deps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """
 deps.py

--- a/tools/readlink.py
+++ b/tools/readlink.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import print_function
 """
 readlink.py - Minimal implementation of readlink -f, e.g. for OS X.


### PR DESCRIPTION
This allows easier development with tools like nix-shell that put alternative Pythons on the PATH.