### PR TITLE
Implement ${!ref} when $ref is like arr[1].

### DIFF
--- a/core/word_eval.py
+++ b/core/word_eval.py
@@ -301,7 +301,7 @@ class _WordEvaluator(object):
     else:
       raise NotImplementedError(id)
 
-  def _ApplyPrefixOp(self, val, op_id):
+  def _ApplyPrefixOp(self, val, op_id, token):
     """
     Returns:
       value
@@ -350,10 +350,10 @@ class _WordEvaluator(object):
           return self.mem.GetArgNum(arg_num)
         except ValueError:
           if not match.IsValidVarName(val.s):
-            # TODO: location information.
-            # Also note that bash doesn't consider this fatal.  It makes the
+            # Note that bash doesn't consider this fatal.  It makes the
             # command exit with '1', but we don't have that ability yet?
-            e_die('Bad variable name %r in var ref', val.s)
+            e_die('Got bad variable name %r from value of %r in indirect expansion',
+                  val.s, token.val, token=token)
           return self.mem.GetVar(val.s)
       elif val.tag == value_e.StrArray:
         indices = [str(i) for i, s in enumerate(val.strs) if s is not None]
@@ -554,7 +554,7 @@ class _WordEvaluator(object):
 
     if part.prefix_op:
       val = self._EmptyStrOrError(val)  # maybe error
-      val = self._ApplyPrefixOp(val, part.prefix_op)
+      val = self._ApplyPrefixOp(val, part.prefix_op, token=part.token)
       # NOTE: When applying the length operator, we can't have a test or
       # suffix afterward.  And we don't want to decay the array
 

--- a/spec/var-ref.test.sh
+++ b/spec/var-ref.test.sh
@@ -55,10 +55,15 @@ x=xx; xx=aaabcc
 xd=x
 check_err '${!!xd}'
 check_err '${!!x*}'
-a=(1 2)
+a=(asdf x)
 check_err '${!!a[*]}'
 check_err '${!#x}'
 check_err '${!#a[@]}'
+# And an array reference binds tighter in the syntax, so goes first;
+# there's no way to spell "indirection, then array reference".
+check_expand '${!a[1]}' xx
+b=(aoeu a)
+check_expand '${!b[1]}' asdf  # i.e. like !(b[1]), not (!b)[1]
 #
 # Allowed: apparently everything else.
 y=yy; yy=

--- a/spec/var-ref.test.sh
+++ b/spec/var-ref.test.sh
@@ -23,6 +23,21 @@ myfunc '?'  # osh doesn't do this dynamically
 ## stdout-json: "myfunc\n0\n"
 ## N-I mksh stdout-json: "ref\nref\n"
 
+#### var ref indexing into array
+f() {
+  printf ".%s" "${!1}"
+  echo
+}
+f a[0]
+b=(x)
+f b[0]
+## STDOUT:
+.
+.x
+## END
+## N-I dash status: 2
+## N-I dash stdout-json: ""
+
 #### declare -n and ${!a}
 declare -n a
 a=b

--- a/test/spec.sh
+++ b/test/spec.sh
@@ -591,7 +591,7 @@ extglob-match() {
 
 # ${!var} syntax -- oil should replace this with associative arrays.
 var-ref() {
-  sh-spec spec/var-ref.test.sh --osh-failures-allowed 6 \
+  sh-spec spec/var-ref.test.sh --osh-failures-allowed 7 \
     $BASH $MKSH $OSH_LIST "$@"
 }
 

--- a/test/spec.sh
+++ b/test/spec.sh
@@ -591,7 +591,7 @@ extglob-match() {
 
 # ${!var} syntax -- oil should replace this with associative arrays.
 var-ref() {
-  sh-spec spec/var-ref.test.sh --osh-failures-allowed 7 \
+  sh-spec spec/var-ref.test.sh --osh-failures-allowed 8 \
     $BASH $MKSH $OSH_LIST "$@"
 }
 

--- a/test/spec.sh
+++ b/test/spec.sh
@@ -591,7 +591,7 @@ extglob-match() {
 
 # ${!var} syntax -- oil should replace this with associative arrays.
 var-ref() {
-  sh-spec spec/var-ref.test.sh --osh-failures-allowed 8 \
+  sh-spec spec/var-ref.test.sh --osh-failures-allowed 9 \
     $BASH $MKSH $OSH_LIST "$@"
 }
 


### PR DESCRIPTION
This is enough to make bash-completion begin to work! Seems to have a bit of debug/warning spew, but the functionality is there now, for filename completion and for compopt. After
```
$ bin/osh
osh$ . ~/src/bash-completion/bash_completion
```

I can complete `ls bui` to the filename `build`:
```
osh$ ls bui-vprintf: warning: ignoring excess arguments, starting with ‘quoted’
ld
```

and `diff --` with the many options to `diff`:
```
osh$ diff --compopt ['-o', 'nospace']
compopt ['-o', 'nospace']

--GTYPE-group-format=       --ignore-file-name-case     --report-identical-files
--LTYPE-line-format=        --ignore-matching-lines=    --show-c-function
--brief                     --ignore-space-change       --show-function-line=
[... lots more ...]
```
