### PR TITLE
Crude first version of printf builtin

### DIFF
--- a/core/cmd_exec.py
+++ b/core/cmd_exec.py
@@ -268,6 +268,9 @@ class Executor(object):
     elif builtin_id == builtin_e.ECHO:
       status = builtin.Echo(argv)
 
+    elif builtin_id == builtin_e.PRINTF:
+      status = builtin.Printf(argv, self.mem)
+
     elif builtin_id == builtin_e.SHIFT:
       status = builtin.Shift(argv, self.mem)
 

--- a/core/runtime.asdl
+++ b/core/runtime.asdl
@@ -69,7 +69,7 @@ module runtime
   char_kind = DE_White | DE_Gray | Black | Backslash
 
   builtin = 
-    NONE | READ | ECHO | SHIFT
+    NONE | READ | ECHO | PRINTF | SHIFT
   | CD | PUSHD | POPD | DIRS
   | EXPORT | UNSET | SET | SHOPT
   | TRAP | UMASK

--- a/spec/builtin-printf.test.sh
+++ b/spec/builtin-printf.test.sh
@@ -17,7 +17,7 @@
 #### printf -v %s
 var=foo
 printf -v $var %s 'hello there'
-argv "$foo" 
+argv.py "$foo"
 ## STDOUT:
 ['hello there']
 ## END
@@ -25,7 +25,7 @@ argv "$foo"
 #### printf -v %q
 var=foo
 printf -v $var %q '"quoted" with spaces and \'
-argv "$foo" 
+argv.py "$foo"
 ## STDOUT:
 ['\\"quoted\\"\\ with\\ spaces\\ and\\ \\\\']
 ## END
@@ -33,7 +33,7 @@ argv "$foo"
 #### declare instead of %s
 var=foo
 declare $var='hello there'
-argv "$foo" 
+argv.py "$foo"
 ## STDOUT:
 ['hello there']
 ## END
@@ -43,9 +43,9 @@ var=foo
 val='"quoted" with spaces and \'
 # I think this is bash 4.4 only.
 declare $var="${val@Q}"
-argv "$foo" 
+echo "$foo"
 ## STDOUT:
-['hello there']
+'"quoted" with spaces and \'
 ## END
 
 #### printf -v dynamic scope

--- a/test/spec.sh
+++ b/test/spec.sh
@@ -317,7 +317,7 @@ builtin-io() {
 }
 
 builtin-printf() {
-  sh-spec spec/builtin-printf.test.sh --osh-failures-allowed 5 \
+  sh-spec spec/builtin-printf.test.sh --osh-failures-allowed 4 \
     $BASH $OSH_LIST "$@"
 }
 

--- a/test/spec.sh
+++ b/test/spec.sh
@@ -317,7 +317,8 @@ builtin-io() {
 }
 
 builtin-printf() {
-  sh-spec spec/builtin-printf.test.sh $BASH $OSH_LIST "$@"
+  sh-spec spec/builtin-printf.test.sh --osh-failures-allowed 5 \
+    $BASH $OSH_LIST "$@"
 }
 
 builtins2() {


### PR DESCRIPTION
Passes one spec test!

And good enough to run bash_completion, and now without the message

    -vprintf: warning: ignoring excess arguments, starting with ‘quoted’

we were seeing, which is from /usr/bin/printf not understanding `-v`.

This shadows /usr/bin/printf, which has more functionality but also
differs from the shell builtin.  So some scripts that worked may now
fail, in which case the fix is to add the missing functionality here.

Fixes an item in #208.
