### PR TITLE
Unhandled PS1 escapes

### DIFF
--- a/core/ui.py
+++ b/core/ui.py
@@ -260,7 +260,13 @@ class Prompt(object):
   def FirstPrompt(self):
     if self.lang == 'osh':
       val = self.mem.GetVar('PS1')
-      return self.EvalPrompt(val)
+      try:
+        return self.EvalPrompt(val)
+      except NotImplementedError as e:
+        print("Cannot use prompt='%s'; backslash code not implemented: \\%s"
+              % (val.s, e.args[0]))
+        return self.default_prompt
+      # TODO: handle other errors?
     else:
       # TODO: If the lang is Oil, we should use a better prompt language than
       # $PS1!!!


### PR DESCRIPTION
Prints an error message and reverts to the default prompt when `PS1` cannot be parsed.

Fixes #214.

One oddity is that the error message is printed twice; I think this must be because the `FirstPrompt` function is called twice for some reason.