### PR TITLE
Fixes libedit based tab completion.

### DIFF
--- a/core/completion.py
+++ b/core/completion.py
@@ -1074,7 +1074,10 @@ class ReadlineCallback(object):
 if __name__ == '__main__':
   # This does basic filename copmletion
   import readline
-  readline.parse_and_bind('tab: complete')
+  if 'libedit' in readline.__doc__:
+    readline.parse_and_bind("bind ^I rl_complete")
+  else:
+    readline.parse_and_bind("tab: complete")
   while True:
     x = raw_input('$ ')
     print(x)


### PR DESCRIPTION
According to this [article](https://pewpewthespells.com/blog/osx_readline.html) libedit based readline requires `readline.parse_and_bind("bind ^I rl_complete")` rather than `readline.parse_and_bind("tab: complete")`.  This is backed up by the note in the [python2.7 readline](https://docs.python.org/2.7/library/readline.html) docs.
AFAICT: otherwise completion is implemented the same except that using the readline's `set_completion_display_matches_hook` is going to be ignored on OSX.  OSH isn't using that hook, nor `Cmd` which seems to call it.

I can't test this until I get to my office tomorrow and try it on an OSX machine.