### PR TITLE
Fix hostname test for $PS1

### DIFF
--- a/spec/prompt.test.sh
+++ b/spec/prompt.test.sh
@@ -135,14 +135,11 @@ $
 
 #### hostname
 
-# NOTE: This test is not hermetic.  On my machine the short and long host name
-# are the same.
-
 PS1='\h '
 test "${PS1@P}" = "$(hostname -s) "  # short name
 echo status=$?
 PS1='\H '
-test "${PS1@P}" = "$(hostname -f) "  # fully qualified
+test "${PS1@P}" = "$(hostname) "  # fully qualified
 echo status=$?
 ## STDOUT:
 status=0


### PR DESCRIPTION
`\H` in bash is not equal to `hostname -f` as the latter one gets seems to get the FQDN from `getaddrinfo()` in the [Debian sources](https://salsa.debian.org/meskes/hostname/blob/master/hostname.c#L336) and not only `gethostname()`

So this is what I get on bash:

```bash
joris ~ $ cat /etc/hostname
xps15
joris ~ $ hostname -f
xps15.home
joris ~ $ PS1="\H ~ "
xps15 ~ PS1="\h ~ "
xps15 ~
```
I set `/etc/hostname` to xps15.local (and rebooted) and then there was a difference between `\h` and `\H`, as the first one was `xps15` and the second one was `xps15.local`. The [bash documentation on prompt](https://www.gnu.org/software/bash/manual/html_node/Controlling-the-Prompt.html#Controlling-the-Prompt) is quite explicit in this regard as there no mention of FQDN, so I didn't check how it is done there.

I took the liberty to remove the NOTE, feel free to add it again if I missed something.
