### PR TITLE
[cleanup] Fix location of script in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Code Overview
 
 Try this to show a summary of what's in the repo and their line counts:
 
-    $ scripts/count.sh all
+    $ metrics/source-code.sh all
 
 (Other functions in this file may be useful as well.)
 


### PR DESCRIPTION
scripts/count.sh was moved to metrics/source-code.sh previously in
commit ce71e0c3d216a4963a41f04de31b18e0be76500f

(also this project is seriously cool. :)