### PR TITLE
print newline after process is interrupted

### DIFF
--- a/core/process.py
+++ b/core/process.py
@@ -864,7 +864,8 @@ class Waiter(object):
 
     # TODO: change status in more cases.
     if posix.WIFSIGNALED(status):
-      pass
+      if posix.WTERMSIG(status) == signal.SIGINT:
+        print()
     elif posix.WIFEXITED(status):
       status = posix.WEXITSTATUS(status)
       #log('exit status: %s', status)


### PR DESCRIPTION
closes https://github.com/oilshell/oil/issues/258

this turned out to be simpler than I expected, since posix has a way to get how a process exited from its status.