### PR TITLE
build/compile.sh: fix bug in $READLINE_DIR flags

### DIFF
--- a/build/compile.sh
+++ b/build/compile.sh
@@ -195,7 +195,7 @@ build() {
     c_module_src_list=$(cat $abs_c_module_srcs)
 
     if [[ -n "$READLINE_DIR" ]]; then
-      readline_flags+="-L $READLINE_DIR/lib -I $READLINE_DIR/include"
+      readline_flags+="-L $READLINE_DIR/lib -I $READLINE_DIR/include "
     fi
 
     # NOTE: pyconfig.h has HAVE_LIBREADLINE but doesn't appear to use it?


### PR DESCRIPTION
Hi! I was trying to compile on Mac OS X with readline and ran into some small trouble with
build/compile.sh. Making this change solved it. I haven't tested this on linux as the change is rather trivial, but I can if that would be helpful.

Summary:

If $READLINE_DIR is specified, $readline_flags becomes something like:

`"-L /usr/local/opt/readline/lib -I /usr/local/opt/readline/include-l readline -D HAVE_READLINE"`

And the lack of space between the include and the `-l` trips up clang on mac.

Changes:

This commit adds an extra space to separate the `-I` and `-l` flags to `cc`.

Test plan:

Was able to build osh on Mac OS X with
`./configure --prefix ~ --with-readline --readline /usr/local/opt/readline`
where I was not previously.