### PR TITLE
expr_eval: Implement `[[ -o val ]]` option

### DIFF
--- a/osh/expr_eval.py
+++ b/osh/expr_eval.py
@@ -643,6 +643,11 @@ class BoolEvaluator(_ExprEvaluator):
             # TODO: Need location information of [
             e_die('Invalid file descriptor %r', s, word=node.child)
           return posix.isatty(fd)
+        # See whether `set -o` options have been set
+        if op_id == Id.BoolUnary_o:
+          if hasattr(self.exec_opts, s):
+            return getattr(self.exec_opts, s)
+          return False
 
         raise NotImplementedError(op_id)
 


### PR DESCRIPTION
* Implement the `-o` option for the test command (`[[ -o val ]]`).

* Fix  #338

Signed-off-by: mr.Shu <mr@shu.io>