### PR TITLE
buildtin: Add first version of bind

### DIFF
--- a/bin/oil.py
+++ b/bin/oil.py
@@ -445,6 +445,8 @@ def ShellMain(lang, argv0, argv, login_shell):
       builtin_e.ALIAS: builtin.Alias(aliases, errfmt),
       builtin_e.UNALIAS: builtin.UnAlias(aliases, errfmt),
 
+      builtin_e.BIND: builtin.Bind(line_input),
+
       builtin_e.HELP: builtin.Help(loader, errfmt),
 
       builtin_e.TYPE: builtin.Type(funcs, aliases, mem),

--- a/osh/builtin.py
+++ b/osh/builtin.py
@@ -122,6 +122,8 @@ _NORMAL_BUILTINS = {
     "alias": builtin_e.ALIAS,
     "unalias": builtin_e.UNALIAS,
 
+    "bind": builtin_e.BIND,
+
     # OSH only
     "repr": builtin_e.REPR,
 }
@@ -1210,6 +1212,25 @@ class UnAlias(object):
       except KeyError:
         self.errfmt.Print('No alias named %r', name, span_id=arg_vec.spids[i])
         status = 1
+    return status
+
+
+BIND_SPEC = _Register('bind')
+
+
+class Bind(object):
+  def __init__(self, readline_mod):
+    self.readline_mod = readline_mod
+
+  def __call__(self, arg_vec):
+    if len(arg_vec.strs) == 1:
+      raise args.UsageError('bind keyseq:function-name')
+
+    status = 0
+    for i in xrange(1, len(arg_vec.strs)):
+      readline_option = arg_vec.strs[i]
+      self.readline_mod.parse_and_bind(readline_option)
+
     return status
 
 

--- a/osh/runtime.asdl
+++ b/osh/runtime.asdl
@@ -82,6 +82,7 @@ module runtime
   | TEST | BRACKET | GETOPTS
   | COMMAND | TYPE | HELP | HISTORY
   | DECLARE | TYPESET | ALIAS | UNALIAS
+  | BIND
   | REPR
   | BUILTIN
 


### PR DESCRIPTION
* Add a simple, introductory version of the buildtin `bind` command that
  just passes configuration options to `readline`.

* Fixes #339.

Signed-off-by: mr.Shu <mr@shu.io>