### PR TITLE
fix: TravisCI linter by not importing unused sys

### DIFF
--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -3,7 +3,6 @@ word_eval.py - Evaluator for the word language.
 """
 
 import pwd
-import sys
 
 from _devbuild.gen.id_kind_asdl import Id, Kind
 from _devbuild.gen.syntax_asdl import (


### PR DESCRIPTION
* Do not import the `sys` module in `word_eval.py` as it is not used
  there.

* Fix TravisCI build as a result.

Signed-off-by: mr.Shu <mr@shu.io>