### PR TITLE
Lookup files to be sourced in $PATH

### DIFF
--- a/osh/cmd_exec.py
+++ b/osh/cmd_exec.py
@@ -220,8 +220,11 @@ class Executor(object):
     except IndexError:
       raise args.UsageError('missing required argument')
 
+    (_, resolved) = builtin._ResolveFile(path, self.mem.GetVar('PATH').s.split(':'))
+    if resolved is None:
+       resolved = path
     try:
-      f = self.fd_state.Open(path)  # Shell can't use descriptors 3-9
+      f = self.fd_state.Open(resolved)  # Shell can't use descriptors 3-9
     except OSError as e:
       self.errfmt.Print('source %r failed: %s', path, posix.strerror(e.errno),
                         span_id=arg_vec.spids[1])

--- a/spec/builtin-eval-source.test.sh
+++ b/spec/builtin-eval-source.test.sh
@@ -135,3 +135,23 @@ FALSE
 FALSE
 ## END
 
+#### source works for files in current directory
+echo "echo current dir" > cmd
+. cmd
+rm cmd
+## STDOUT:
+current dir
+## N-I dash stdout-json: ""
+## N-I dash status: 2
+## N-I mksh stdout-json: ""
+## N-I mksh status: 1
+
+#### source gives precendence to PATH
+mkdir -p dir
+echo "echo path" > dir/cmd
+echo "echo current dir" > cmd
+PATH="dir:$PATH"
+. cmd
+rm -r dir cmd
+## STDOUT:
+path

--- a/spec/posix.test.sh
+++ b/spec/posix.test.sh
@@ -159,24 +159,3 @@ rm dir/cmd
 ## STDOUT:
 hi
 ## END
-
-#### source gives precendence to PATH
-mkdir -p dir
-echo "echo path" > dir/cmd
-echo "echo current dir" > cmd
-PATH="dir:$PATH"
-. cmd
-rm -r dir cmd
-## STDOUT:
-path
-
-#### source works for files in current directory
-echo "echo current dir" > cmd
-. cmd
-rm cmd
-## STDOUT:
-current dir
-## N-I dash stdout-json: ""
-## N-I dash status: 2
-## N-I mksh stdout-json: ""
-## N-I mksh status: 1

--- a/spec/posix.test.sh
+++ b/spec/posix.test.sh
@@ -142,3 +142,40 @@ three
 EOF2
 ## stdout-json: "one\ntwo\nthree\n"
 
+#### source works for files in subdirectory
+mkdir -p dir
+echo "echo path" > dir/cmd
+. dir/cmd
+rm dir/cmd
+## STDOUT:
+path
+
+#### source looks in PATH for files
+mkdir -p dir
+echo "echo hi" > dir/cmd
+PATH="dir:$PATH"
+. cmd
+rm dir/cmd
+## STDOUT:
+hi
+## END
+
+#### source gives precendence to PATH
+mkdir -p dir
+echo "echo path" > dir/cmd
+echo "echo current dir" > cmd
+PATH="dir:$PATH"
+. cmd
+rm dir/cmd
+## STDOUT:
+path
+
+#### source works for files in current directory
+echo "echo current dir" > cmd
+. cmd
+## STDOUT:
+current dir
+## N-I dash stdout-json: ""
+## N-I dash status: 2
+## N-I mksh stdout-json: ""
+## N-I mksh status: 1

--- a/spec/posix.test.sh
+++ b/spec/posix.test.sh
@@ -166,13 +166,14 @@ echo "echo path" > dir/cmd
 echo "echo current dir" > cmd
 PATH="dir:$PATH"
 . cmd
-rm dir/cmd
+rm -r dir cmd
 ## STDOUT:
 path
 
 #### source works for files in current directory
 echo "echo current dir" > cmd
 . cmd
+rm cmd
 ## STDOUT:
 current dir
 ## N-I dash stdout-json: ""


### PR DESCRIPTION
Gives precendence to $PATH before sourcing files in current directory
TIL: sourcing files in the current directory is a bash-ism, not part of POSIX,
see http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#dot

Addresses https://github.com/oilshell/oil/issues/389