### PR TITLE
Add property testing using hypothesis

### DIFF
--- a/core/property_tests.py
+++ b/core/property_tests.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python2
+
+import unittest
+
+from hypothesis import given
+from hypothesis.strategies import text
+
+from comp_ui import _PromptLen
+
+class PromptTest(unittest.TestCase):
+    @given(text())
+    def testNeverPanics(self, s):
+        self.assertIs(_PromptLen(s) >= 0, True)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vendor/typing.py
+++ b/vendor/typing.py
@@ -10,6 +10,9 @@
 # if TYPE_CHECKING:
 #   NullFunc = Callable[[int, int], int]
 
+TypingMeta = None
+TypeVar = None
+_ForwardRef = None
 List = None
 Tuple = None
 Optional = None


### PR DESCRIPTION
As discussed in https://github.com/oilshell/oil/issues/394. Adds a dependency on [`hypothesis`](https://hypothesis.readthedocs.io/en/latest/quickstart.html#running-tests) for tests.

Note that the tests will fail until https://github.com/oilshell/oil/pull/402 is merged.