### PR TITLE
Use python2 version of flake8

### DIFF
--- a/test/lint.sh
+++ b/test/lint.sh
@@ -90,8 +90,7 @@ bin-flake8() {
   if test -f "$ubuntu_flake8"; then
     $ubuntu_flake8 "$@"
   else
-    # Assume it's in $PATH, like on Travis.
-    flake8 "$@"
+    python2 -m flake8 "$@"
   fi
 }
 


### PR DESCRIPTION
I have `flake8` installed on my machine, but it's the python3 version, which throws a bunch of bogus errors for python2 code. This uses the python2 version regardless of the one in `$PATH`.