### PR TITLE
Remove dependency on bash in tarball

### DIFF
--- a/build/actions.sh
+++ b/build/actions.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 #
 # Build actions used in the Makefile.
 #
@@ -6,10 +6,9 @@
 #   ./actions.sh <function name>
 
 set -o nounset
-set -o pipefail
 set -o errexit
 
-source build/common.sh
+. build/common.sh
 
 write-release-date() {
   mkdir -p _build  # Makefile makes this, but scripts/release.sh needs it too

--- a/build/common.sh
+++ b/build/common.sh
@@ -1,7 +1,6 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -o nounset
-set -o pipefail
 set -o errexit
 
 # TODO: This changes depending on the version.  Maybe there should be a 'clang'
@@ -33,7 +32,7 @@ die() {
 }
 
 source-detected-config-or-die() {
-  if ! source _build/detected-config.sh; then
+  if ! . _build/detected-config.sh; then
     # Make this error stand out.
     echo
     echo "FATAL: can't find _build/detected-config.h.  Run './configure'"


### PR DESCRIPTION
**NOT READY FOR MERGE**

This removes `set -o pipefail` without supplying a replacement, I
don't see a way around this using POSIX sh (without writing a monster library, see https://stackoverflow.com/a/54931544)

This leaves the OIL_SYMLINKS and OPY_SYMLINKS arrays unchanged
even though they're incompatible because I'm not sure if they should be
turned into string variables (like INCLUDE_PATHS) or moved to a different
file, since they're not used in the tarball. @andychu which would you prefer?