### PR TITLE
Don't crash when parsing regexes on FreeBSD

### DIFF
--- a/native/libc.c
+++ b/native/libc.c
@@ -16,11 +16,7 @@
 
 #include <fnmatch.h>
 #include <glob.h>
-#ifdef __FreeBSD__
-#include <gnu/posix/regex.h>
-#else
 #include <regex.h>
-#endif
 
 #include <Python.h>
 


### PR DESCRIPTION
Before:
```
osh$ [[ 1 =~ [0-9] ]]
Segmentation fault (core dumped)
```

After:
```
osh$ [[ 1 =~ [0-9] ]]
osh$ echo $?
0
```

This happened because libc.c used the GNU regex library headers but
used the BSD library when dynamically linked. I'm not sure why it was
using different headers, maybe Python was originally statically linked?