### PR TITLE
Take a stab at PROMPT_COMMAND

### DIFF
--- a/core/main_loop.py
+++ b/core/main_loop.py
@@ -18,8 +18,10 @@ from _devbuild.gen.syntax_asdl import (
     command_t, command,
     parse_result__EmptyLine, parse_result__Eof, parse_result__Node
 )
+from _devbuild.gen.runtime_asdl import value__Undef, arg_vector
 from core import ui
 from core import util
+from frontend import reader
 #from core.util import log
 
 from typing import Any, Optional, List, TYPE_CHECKING
@@ -43,6 +45,10 @@ def Interactive(opts, ex, c_parser, display, errfmt):
 
     while True:  # ONLY EXECUTES ONCE
       try:
+        prompt_command = ex.mem.GetVar('PROMPT_COMMAND')
+        if not isinstance(prompt_command, value__Undef):
+            arg_vec = arg_vector(['', prompt_command.s], [0, 0])
+            ex._Eval(arg_vec)
         # may raise HistoryError or ParseError
         result = c_parser.ParseInteractiveLine()
         if isinstance(result, parse_result__EmptyLine):

--- a/core/main_loop.py
+++ b/core/main_loop.py
@@ -40,10 +40,12 @@ def _ExecutePromptCommand(ex):
   command = prompt_var.s
 
   # save this so PROMPT_COMMAND can't set $?
-  old_status = ex.LastStatus()
+  ex.mem.PushStatusFrame()
   arg_vec = arg_vector(['PROMPT_COMMAND', command], [0, 0])
-  ex._Eval(arg_vec)
-  ex.mem.SetLastStatus(old_status)
+  try:
+    ex._Eval(arg_vec)
+  finally:
+    ex.mem.PopStatusFrame()
 
 
 def Interactive(opts, ex, c_parser, display, errfmt):

--- a/core/main_loop.py
+++ b/core/main_loop.py
@@ -33,16 +33,11 @@ if TYPE_CHECKING:
 
 def _ExecutePromptCommand(ex):
   # type: (Any) -> None
-  command = None
   prompt_var = ex.mem.GetVar('PROMPT_COMMAND')
-  if prompt_var.tag == value_e.Undef:
+  # Undefined, Array, or AssociativeArray
+  if prompt_var.tag != value_e.Str:
     return
-  elif prompt_var.tag == value_e.AssocArray:
-    command = prompt_var.d['0']
-  elif prompt_var.tag == value_e.StrArray:
-    command = prompt_var.strs[0]
-  elif prompt_var.tag == value_e.Str:
-    command = prompt_var.s
+  command = prompt_var.s
 
   # save this so PROMPT_COMMAND can't set $?
   old_status = ex.LastStatus()

--- a/core/main_loop.py
+++ b/core/main_loop.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
 
 
 def _ExecutePromptCommand(ex):
+  # type: (Any) -> None
   command = None
   prompt_var = ex.mem.GetVar('PROMPT_COMMAND')
   if prompt_var.tag == value_e.Undef:

--- a/spec/interactive.test.sh
+++ b/spec/interactive.test.sh
@@ -55,3 +55,13 @@ RCFILE
 ## N-I dash status: 2
 ## N-I mksh status: 1
 
+#### interactive shell runs PROMPT_COMMAND after each command
+TEST_CASE='PROMPT_COMMAND="echo hi"'
+case $SH in
+	*bash) echo "$TEST_CASE" | $SH --noprofile --norc -i;;
+	*osh) $SH --rcfile /dev/null -i -c "$TEST_CASE";;
+	*) $SH -i -c "$TEST_CASE";;
+esac
+## STDOUT:
+hi
+## N-I dash/mksh stdout-json: ""

--- a/spec/interactive.test.sh
+++ b/spec/interactive.test.sh
@@ -20,7 +20,11 @@ one
 #### fatal errors continue
 
 # NOTE: tried here doc, but sys.stdin.isatty() fails.  Could we fake it?
-$SH -i -c '
+case "$SH" in
+	*bash) FLAGS='--noprofile --norc';;
+	*osh) FLAGS='--rcfile /dev/null';;
+esac
+$SH $FLAGS -i -c '
 echo $(( 1 / 0 ))
 echo one
 exit 42

--- a/test/sh_spec.py
+++ b/test/sh_spec.py
@@ -957,7 +957,6 @@ def main(argv):
     # Copied from my own environment.  For now, we want to test bash and other
     # shells in utf-8 mode.
     'LANG': 'en_US.UTF-8',
-    'HOME': os.path.expanduser('~')
   }
   stats = RunCases(cases, case_predicate, shell_pairs, env, out)
   out.EndCases(stats)

--- a/test/sh_spec.py
+++ b/test/sh_spec.py
@@ -957,6 +957,7 @@ def main(argv):
     # Copied from my own environment.  For now, we want to test bash and other
     # shells in utf-8 mode.
     'LANG': 'en_US.UTF-8',
+    'HOME': os.path.expanduser('~')
   }
   stats = RunCases(cases, case_predicate, shell_pairs, env, out)
   out.EndCases(stats)


### PR DESCRIPTION
Location information is wrong - PROMPT_COMMAND=';' gives a traceback
pointing to ~/.local/oil/oshrc instead of [ interactive ] or
[ PROMPT_COMMAND ]

Other than that, this seems to be working pretty well with my patched version of bash-git-prompt.

Addresses https://github.com/oilshell/oil/issues/400