### PR TITLE
Read in unbuffered mode for `read -n`

### DIFF
--- a/demo/read-n-demo.sh
+++ b/demo/read-n-demo.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+read-one () {
+	# try typing a letter without hitting newline
+	# the shell should respond immediately
+	read -n 1
+	echo $'\n'"$REPLY"
+}
+
+read-multiple () {
+	read -n 5
+	echo $'\n'"$REPLY"
+}
+
+all () {
+	echo "one char:"
+	read-one
+	echo "multiple chars:"
+	read-multiple
+}
+
+"$@"

--- a/demo/read-n-demo.sh
+++ b/demo/read-n-demo.sh
@@ -2,22 +2,24 @@
 set -euo pipefail
 
 read-one () {
-	# try typing a letter without hitting newline
-	# the shell should respond immediately
-	read -n 1
-	echo $'\n'"$REPLY"
+  # try typing a letter without hitting newline
+  # the shell should respond immediately
+  read -n 1
+  echo
+  echo "$REPLY"
 }
 
 read-multiple () {
-	read -n 5
-	echo $'\n'"$REPLY"
+  read -n 5
+  echo
+  echo "$REPLY"
 }
 
 all () {
-	echo "one char:"
-	read-one
-	echo "multiple chars:"
-	read-multiple
+  echo "one char:"
+  read-one
+  echo "multiple chars:"
+  read-multiple
 }
 
 "$@"

--- a/spec/builtins2.test.sh
+++ b/spec/builtins2.test.sh
@@ -210,3 +210,11 @@ builtin command echo hi
 ## stdout: hi
 ## N-I dash status: 127
 ## N-I dash stdout-json: ""
+
+#### read returns correct number of bytes without EOF
+# zsh goes into an infinite loop!
+timeout 1s $SH -c 'while true; do echo -n x; done | { read -n 3; echo $REPLY; }'
+## status: 124
+## stdout: xxx
+## N-I dash stdout:
+## BUG zsh stdout-json: ""

--- a/spec/builtins2.test.sh
+++ b/spec/builtins2.test.sh
@@ -212,8 +212,16 @@ builtin command echo hi
 ## N-I dash stdout-json: ""
 
 #### read returns correct number of bytes without EOF
-# zsh goes into an infinite loop!
-timeout 1s $SH -c 'while true; do echo -n x; done | { read -n 3; echo $REPLY; }'
+case $SH in
+  # the flag for zsh is different from bash and osh
+  *zsh) FLAG=k;;
+  # mksh returns as soon as _any_ bytes are read if you use -n
+  *mksh) FLAG=N;;
+  *) FLAG=n;;
+esac
+# redirect to /dev/null is because `mksh` prints 'broken pipe error' repeatedly
+# timeout is because `mksh` and `zsh` don't kill builtin loops on SIGPIPE
+timeout 1s $SH -c "while true; do printf x 2>/dev/null; done | { read -$FLAG 3; echo \$REPLY; }"
 ## status: 124
 ## stdout: xxx
 ## N-I dash stdout:


### PR DESCRIPTION
Puts TTY into 'noncanonical' mode for duration of read
Calls posix.read n times, since each time will only return 1 byte
Restore original mode even if an exception occurs

Addresses https://github.com/oilshell/oil/issues/274