### PR TITLE
Fix handling of unicode in affix removal (${s#?} and ${s%?})

### DIFF
--- a/native/libc.c
+++ b/native/libc.c
@@ -71,7 +71,15 @@ func_fnmatch(PyObject *self, PyObject *args) {
   int flags = 0;
 #endif
 
+  const char *old_locale = setlocale(LC_CTYPE, NULL);
+  if (setlocale(LC_CTYPE, "") == NULL) {
+	  PyErr_SetString(PyExc_SystemError, "Invalid locale for LC_CTYPE");
+	  return NULL;
+  }
+
   int ret = fnmatch(pattern, str, flags);
+
+  setlocale(LC_CTYPE, old_locale);
 
   switch (ret) {
   case 0:

--- a/osh/string_ops.py
+++ b/osh/string_ops.py
@@ -109,10 +109,10 @@ def _PreviousUtf8Char(s, i):
     byte_as_int = ord(s[i])
     if (byte_as_int >> 6) != 0b10:
       offset = following_i - i
-      char_length = _Utf8CharLen(byte_as_int)
-      if offset > 4 or offset != char_length:
+      if offset != _Utf8CharLen(byte_as_int):
         # Leaving a generic error for now, but if we want to, it's not
-        # hard to calculate the position where things go wrong.
+        # hard to calculate the position where things go wrong.  Note
+        # that offset might be more than 4, for an invalid utf-8 string.
         raise util.InvalidUtf8(INVALID_START)
       return i
 

--- a/osh/string_ops.py
+++ b/osh/string_ops.py
@@ -76,7 +76,11 @@ def _Utf8CharLen(starting_byte):
 
 def _NextUtf8Char(s, i):
   """
-  Given a string and a byte offset, returns the byte position of the next char.
+  Given a string and a byte offset, returns the byte position after
+  the character at this position.  Usually this is the position of the
+  next character, but for the last character in the string, it's the
+  position just past the end of the string.
+
   Validates UTF-8.
   """
   byte_as_int = ord(s[i])  # Should never raise IndexError

--- a/osh/string_ops_test.py
+++ b/osh/string_ops_test.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 
 import unittest
 
+from core import util
 from osh import string_ops  # module under test
 
 
@@ -25,6 +26,55 @@ class LibStrTest(unittest.TestCase):
       print('')
       print('Utf8Encode case %r %r' % (expected, code_point))
       self.assertEqual(expected, string_ops.Utf8Encode(code_point))
+
+  def test_NextUtf8Char(self):
+    CASES = [
+        ([1, 3, 6, 10], '\x24\xC2\xA2\xE0\xA4\xB9\xF0\x90\x8D\x88'),
+        ([1, 3, 'Invalid UTF-8 continuation byte'], '\x24\xC2\xA2\xE0\xE0\xA4'),
+        ([1, 3, 6, 'Invalid start of UTF-8 character'], '\x24\xC2\xA2\xE0\xA4\xA4\xB9'),
+        ([1, 3, 'Invalid start of UTF-8 character'], '\x24\xC2\xA2\xFF'),
+        ([1, 'Incomplete UTF-8 character'], '\x24\xF0\x90\x8D'),
+    ]
+    for expected_indexes, input_str in CASES:
+      print()
+      print('_NextUtf8Char case %r %r' % (expected_indexes, input_str))
+      i = 0
+      actual_indexes = []
+      while True:
+        try:
+          i = string_ops._NextUtf8Char(input_str, i)
+          actual_indexes.append(i)
+          if i >= len(input_str):
+            break
+        except util.InvalidUtf8 as e:
+          actual_indexes.append(e.msg)
+          break
+      self.assertEqual(expected_indexes, actual_indexes)
+
+  def test_PreviousUtf8Char(self):
+    # The error messages could probably be improved for more consistency
+    # with NextUtf8Char, at the expense of more complexity.
+    CASES = [
+        ([6, 3, 1, 0], '\x24\xC2\xA2\xE0\xA4\xB9\xF0\x90\x8D\x88'),
+        ([6, 3, 1, 'Invalid start of UTF-8 character'], '\xA2\xC2\xA2\xE0\xA4\xB9\xF0\x90\x8D\x88'),
+        ([10, 'Invalid start of UTF-8 character'], '\xF0\x90\x8D\x88\x90\x8D\x88\x90\x8D\x88\x24'),
+        ([3, 'Invalid start of UTF-8 character'], '\xF0\x90\x8D\x24'),
+    ]
+    for expected_indexes, input_str in CASES:
+      print()
+      print('_PreviousUtf8Char case %r %r' % (expected_indexes, input_str))
+      i = len(input_str)
+      actual_indexes = []
+      while True:
+        try:
+          i = string_ops._PreviousUtf8Char(input_str, i)
+          actual_indexes.append(i)
+          if i == 0:
+            break
+        except util.InvalidUtf8 as e:
+          actual_indexes.append(e.msg)
+          break
+      self.assertEqual(expected_indexes, actual_indexes)
 
   def testUnarySuffixOpDemo(self):
     print(string_ops)

--- a/spec/var-op-strip.test.sh
+++ b/spec/var-op-strip.test.sh
@@ -267,3 +267,39 @@ argv.py "${x%%}"
 ['abc']
 ['abc']
 ## END
+
+#### strip all unicode
+x=μabcμ
+echo "${x#?abc?}"
+echo "${x##?abc?}"
+echo "${x%?abc?}"
+echo "${x%%?abc?}"
+## STDOUT:
+
+
+
+
+## BUG dash/mksh STDOUT:
+μabcμ
+μabcμ
+μabcμ
+μabcμ
+## END
+
+#### strip none unicode
+x=μabcμ
+argv.py "${x#}"
+argv.py "${x##}"
+argv.py "${x%}"
+argv.py "${x%%}"
+## STDOUT:
+['\xce\xbcabc\xce\xbc']
+['\xce\xbcabc\xce\xbc']
+['\xce\xbcabc\xce\xbc']
+['\xce\xbcabc\xce\xbc']
+## BUG ash STDOUT:
+['\xce\xbcabc\xce\xbc']
+['\xbcabc\xce\xbc']
+['\xce\xbcabc\xce\xbc']
+['\xce']
+## END

--- a/spec/var-op-strip.test.sh
+++ b/spec/var-op-strip.test.sh
@@ -63,9 +63,17 @@ echo ${v%[[:alpha:]]}
 # NOTE: LANG is set to utf-8.
 v='μ-'
 echo ${v#?}  # ? is a glob that stands for one character
-## stdout: -
-## BUG dash/mksh/ash stdout-repr: '\xbc-\n'
-## BUG zsh stdout-repr: '\n'
+echo ${v##?}
+v='-μ'
+echo ${v%?}  # ? is a glob that stands for one character
+echo ${v%%?}
+## STDOUT:
+-
+-
+-
+-
+## BUG dash/mksh/ash stdout-repr: '\xbc-\n\xbc-\n-\xce\n-\xce\n'
+## BUG zsh stdout-repr: '\n\n\n\n'
 
 #### Bug fix: Test that you can remove everything with glob
 s='--x--'

--- a/test/spec.sh
+++ b/test/spec.sh
@@ -534,7 +534,7 @@ var-op-other() {
 }
 
 var-op-strip() {
-  sh-spec spec/var-op-strip.test.sh --osh-failures-allowed 1 \
+  sh-spec spec/var-op-strip.test.sh \
     ${REF_SHELLS[@]} $ZSH $BUSYBOX_ASH $OSH_LIST "$@"
 }
 


### PR DESCRIPTION
Fixes: #173 

Hi @andychu, this one turned out to be a bit tricker than I thought.  I needed to change func_fnmatch in libc.c to set the locale to "" (making it refer to the environment variables) -- otherwise it assumed LANG=C, which meant that fnmatch did not properly handle multibyte characters.  I'm not sure if this was the best way to deal with this.

Also, it turns out that iterating backwards over a UTF-8 string is not substantially harder than going forwards, so I did that, rather than iterating forwards and building up a list of indexes as was suggested by your comment above DoUnarySuffixOp.

I hope this is alright.  I spent more time checking edge cases so as not to embarrass myself again :)