### PR TITLE
[test/spec] fix var-op-patsub "Substitute one unicode character" test

### DIFF
--- a/native/libc.c
+++ b/native/libc.c
@@ -321,6 +321,12 @@ func_regex_first_group_match(PyObject *self, PyObject *args) {
   regex_t pat;
   regmatch_t m[NMATCH];
 
+  const char *old_locale = setlocale(LC_CTYPE, NULL);
+  if (setlocale(LC_CTYPE, "") == NULL) {
+	  PyErr_SetString(PyExc_SystemError, "Invalid locale for LC_CTYPE");
+	  return NULL;
+  }
+
   // Could have been checked by regex_parse for [[ =~ ]], but not for glob
   // patterns like ${foo/x*/y}.
 
@@ -329,6 +335,8 @@ func_regex_first_group_match(PyObject *self, PyObject *args) {
                     "Invalid regex syntax (func_regex_first_group_match)");
     return NULL;
   }
+
+  setlocale(LC_CTYPE, old_locale);
 
   debug("first_group_match pat %s str %s pos %d", pattern, str, pos);
 

--- a/test/spec.sh
+++ b/test/spec.sh
@@ -524,7 +524,7 @@ var-op-len() {
 
 var-op-patsub() {
   # 1 unicode failure
-  sh-spec spec/var-op-patsub.test.sh --osh-failures-allowed 1 \
+  sh-spec spec/var-op-patsub.test.sh \
     $BASH $MKSH $ZSH $OSH_LIST "$@"
 }
 


### PR DESCRIPTION
Using the environment's locale instead of the default "C" locale
allows regcomp to understand UTF-8.

(finally got around to this tiny fix...)