### PR TITLE
[fix] extra import of pprint in devtools/make_help.py can cause error

### DIFF
--- a/devtools/make_help.py
+++ b/devtools/make_help.py
@@ -616,7 +616,6 @@ def main(argv):
 
       groups.append(topic_id)
 
-    import pprint
     with open(py_out, 'w') as f:
       f.write('GROUPS = %s\n' % pprint.pformat(groups))
 


### PR DESCRIPTION
The error is:
Traceback (most recent call last):
  File "devtools/make_help.py", line 706, in <module>
    main(sys.argv)
  File "devtools/make_help.py", line 577, in main
    d = pprint.pformat(topic_lookup)
UnboundLocalError: local variable 'pprint' referenced before assignment