### PR TITLE
[types] Convert type checking to use config file for mypy, remove assert-one-error hack

### DIFF
--- a/types/common.sh
+++ b/types/common.sh
@@ -5,4 +5,6 @@ typecheck() {
   MYPYPATH=.:native PYTHONPATH=. mypy --py2 "$@"
 }
 
-readonly MYPY_FLAGS='--config-file=types/mypy.ini'
+
+readonly MYPY_INI='types/mypy.ini'
+readonly MYPY_FLAGS="--config-file=$MYPY_INI"

--- a/types/common.sh
+++ b/types/common.sh
@@ -6,25 +6,3 @@ typecheck() {
 }
 
 readonly MYPY_FLAGS='--config-file=types/mypy.ini'
-
-
-# Hack because there's an asdl/pretty.py error that's hard to get rid of.
-assert-one-error() {
-  local log_path=$1
-  echo
-  cat $log_path
-  echo
-
-  # Hack to get rid of summary line that appears in some MyPy versions.
-  local num_errors=$(grep -F -v 'Found 1 error in 1 file' $log_path | wc -l)
-
-  # 1 type error allowed for asdl/pretty.py, because our --no-strict-optional
-  # conflicts with demo/typed and so forth.
-  if [[ $num_errors -eq 1 ]]; then
-    echo OK
-    return 0
-  else
-    echo "Expected 1 error, but got $num_errors"
-    return 1
-  fi
-}

--- a/types/common.sh
+++ b/types/common.sh
@@ -5,7 +5,7 @@ typecheck() {
   MYPYPATH=.:native PYTHONPATH=. mypy --py2 "$@"
 }
 
-readonly MYPY_FLAGS='--strict --no-implicit-optional --no-strict-optional'
+readonly MYPY_FLAGS='--config-file=types/mypy.ini'
 
 
 # Hack because there's an asdl/pretty.py error that's hard to get rid of.

--- a/types/mypy.ini
+++ b/types/mypy.ini
@@ -18,6 +18,6 @@ no_implicit_reexport = True
 
 strict_optional = True
 
-[mypy-core.alloc,core.main_loop,core.pyutil,core.ui,_devbuild.gen/syntax_asdl,frontend.match,frontend.parse_lib,frontend.tdop,oil_lang.expr_parse,oil_lang.expr_to_ast,osh.bool_parse,osh.braces,osh.cmd_parse,osh.word_,osh.word_parse,pgen2.parse,pylib.os_path]
+[mypy-core.alloc,core.main_loop,core.pyutil,core.ui,_devbuild.gen/syntax_asdl,frontend.match,frontend.parse_lib,frontend.tdop,oil_lang.expr_parse,oil_lang.expr_to_ast,osh.bool_parse,osh.braces,osh.cmd_parse,osh.glob_,osh.word_,osh.word_parse,pgen2.parse,pylib.os_path]
 
 strict_optional = False

--- a/types/mypy.ini
+++ b/types/mypy.ini
@@ -16,63 +16,13 @@ warn_unused_ignores = True
 warn_return_any = True
 no_implicit_reexport = True
 
+strict_optional = False
 
+[mypy-asdl.pretty]
 strict_optional = True
 
-# --START-LAX-CONFIG--
-# Everything below this gets stripped out in order to generate a stricter version of this config.
-# see types/osh-parse.sh, typecheck-all function
-
-[mypy-core.alloc]
+[mypy-_devbuild.gen.*]
+strict_optional = True
+[mypy-_devbuild.gen.syntax_asdl]
 strict_optional = False
 
-[mypy-core.main_loop]
-strict_optional = False
-
-[mypy-core.pyutil]
-strict_optional = False
-
-[mypy-core.ui]
-strict_optional = False
-
-[mypy-_devbuild.gen/syntax_asdl]
-strict_optional = False
-
-[mypy-frontend.match]
-strict_optional = False
-
-[mypy-frontend.parse_lib]
-strict_optional = False
-
-[mypy-frontend.tdop]
-strict_optional = False
-
-[mypy-oil_lang.expr_parse]
-strict_optional = False
-
-[mypy-oil_lang.expr_to_ast]
-strict_optional = False
-
-[mypy-osh.bool_parse]
-strict_optional = False
-
-[mypy-osh.braces]
-strict_optional = False
-
-[mypy-osh.cmd_parse]
-strict_optional = False
-
-[mypy-osh.glob_]
-strict_optional = False
-
-[mypy-osh.word_]
-strict_optional = False
-
-[mypy-osh.word_parse]
-strict_optional = False
-
-[mypy-pgen2.parse]
-strict_optional = False
-
-[mypy-pylib.os_path]
-strict_optional = False

--- a/types/mypy.ini
+++ b/types/mypy.ini
@@ -16,8 +16,59 @@ warn_unused_ignores = True
 warn_return_any = True
 no_implicit_reexport = True
 
+
 strict_optional = True
 
-[mypy-core.alloc,core.main_loop,core.pyutil,core.ui,_devbuild.gen/syntax_asdl,frontend.match,frontend.parse_lib,frontend.tdop,oil_lang.expr_parse,oil_lang.expr_to_ast,osh.bool_parse,osh.braces,osh.cmd_parse,osh.glob_,osh.word_,osh.word_parse,pgen2.parse,pylib.os_path]
+[mypy-core.alloc]
+strict_optional = False
 
+[mypy-core.main_loop]
+strict_optional = False
+
+[mypy-core.pyutil]
+strict_optional = False
+
+[mypy-core.ui]
+strict_optional = False
+
+[mypy-_devbuild.gen/syntax_asdl]
+strict_optional = False
+
+[mypy-frontend.match]
+strict_optional = False
+
+[mypy-frontend.parse_lib]
+strict_optional = False
+
+[mypy-frontend.tdop]
+strict_optional = False
+
+[mypy-oil_lang.expr_parse]
+strict_optional = False
+
+[mypy-oil_lang.expr_to_ast]
+strict_optional = False
+
+[mypy-osh.bool_parse]
+strict_optional = False
+
+[mypy-osh.braces]
+strict_optional = False
+
+[mypy-osh.cmd_parse]
+strict_optional = False
+
+[mypy-osh.glob_]
+strict_optional = False
+
+[mypy-osh.word_]
+strict_optional = False
+
+[mypy-osh.word_parse]
+strict_optional = False
+
+[mypy-pgen2.parse]
+strict_optional = False
+
+[mypy-pylib.os_path]
 strict_optional = False

--- a/types/mypy.ini
+++ b/types/mypy.ini
@@ -19,6 +19,10 @@ no_implicit_reexport = True
 
 strict_optional = True
 
+# --START-LAX-CONFIG--
+# Everything below this gets stripped out in order to generate a stricter version of this config.
+# see types/osh-parse.sh, typecheck-all function
+
 [mypy-core.alloc]
 strict_optional = False
 

--- a/types/mypy.ini
+++ b/types/mypy.ini
@@ -1,0 +1,23 @@
+[mypy]
+
+# strict mode enables all these if passed on the command line, but in
+# config files you have to specify them all individually.
+warn_unused_configs = True
+disallow_subclassing_any = True
+disallow_any_generics = True
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True
+
+strict_optional = True
+
+[mypy-core.alloc,core.main_loop,core.pyutil,core.ui,_devbuild.gen/syntax_asdl,frontend.match,frontend.parse_lib,frontend.tdop,oil_lang.expr_parse,oil_lang.expr_to_ast,osh.bool_parse,osh.braces,osh.cmd_parse,osh.word_,osh.word_parse,pgen2.parse,pylib.os_path]
+
+strict_optional = False

--- a/types/osh-parse.sh
+++ b/types/osh-parse.sh
@@ -58,11 +58,7 @@ typecheck-all() {
     flags=$MYPY_FLAGS
   fi
 
-  set +o errexit
-  cat $manifest | xargs -- $0 typecheck $flags >_tmp/err.txt
-  #echo "status: $?"
-
-  assert-one-error _tmp/err.txt
+  cat $manifest | xargs -- $0 typecheck $flags
 }
 
 # The manifest needs to be checked in because we don't have

--- a/types/osh-parse.sh
+++ b/types/osh-parse.sh
@@ -44,12 +44,6 @@ egrep-deps() {
   cat $PY_DEPS | xargs -- egrep "$@"
 }
 
-readonly MYPY_INI_STRICT='_tmp/mypy-strict.ini'
-
-gen_strict_mypy_config() {
-  <"$MYPY_INI" sed '/--START-LAX-CONFIG--/,$d' > "$MYPY_INI_STRICT"
-}
-
 typecheck-all() {
   local manifest=$1
   local strict_none=${2:-}
@@ -59,8 +53,7 @@ typecheck-all() {
   #local flags=''
   local flags
   if test -n "$strict_none"; then
-    gen_strict_mypy_config
-    flags="--config-file=$MYPY_INI_STRICT"
+    flags="$MYPY_FLAGS --strict-optional"
   else
     flags=$MYPY_FLAGS
   fi

--- a/types/osh-parse.sh
+++ b/types/osh-parse.sh
@@ -44,6 +44,12 @@ egrep-deps() {
   cat $PY_DEPS | xargs -- egrep "$@"
 }
 
+readonly MYPY_INI_STRICT='_tmp/mypy-strict.ini'
+
+gen_strict_mypy_config() {
+  <"$MYPY_INI" sed '/--START-LAX-CONFIG--/,$d' > "$MYPY_INI_STRICT"
+}
+
 typecheck-all() {
   local manifest=$1
   local strict_none=${2:-}
@@ -53,7 +59,8 @@ typecheck-all() {
   #local flags=''
   local flags
   if test -n "$strict_none"; then
-    flags='--strict'
+    gen_strict_mypy_config
+    flags="--config-file=$MYPY_INI_STRICT"
   else
     flags=$MYPY_FLAGS
   fi

--- a/types/run.sh
+++ b/types/run.sh
@@ -46,7 +46,7 @@ check-arith() {
   # NOTE: There are still some Any types here!  We don't want them for
   # translation.
 
-  MYPYPATH=. PYTHONPATH=. typecheck $MYPY_FLAGS \
+  typecheck $MYPY_FLAGS \
     asdl/typed_arith_parse.py asdl/typed_arith_parse_test.py asdl/tdop.py
 }
 

--- a/types/run.sh
+++ b/types/run.sh
@@ -36,7 +36,7 @@ pyann-patched() {
 
 iter-demo-asdl() {
   asdl/run.sh gen-typed-demo-asdl
-  typecheck --strict \
+  typecheck $MYPY_FLAGS \
     _devbuild/gen/typed_demo_asdl.py asdl/typed_demo.py
 
   PYTHONPATH=. asdl/typed_demo.py "$@"
@@ -46,8 +46,7 @@ check-arith() {
   # NOTE: There are still some Any types here!  We don't want them for
   # translation.
 
-  local strict='--strict'
-  MYPYPATH=. PYTHONPATH=. typecheck $strict \
+  MYPYPATH=. PYTHONPATH=. typecheck $MYPY_FLAGS \
     asdl/typed_arith_parse.py asdl/typed_arith_parse_test.py asdl/tdop.py
 }
 

--- a/types/run.sh
+++ b/types/run.sh
@@ -69,12 +69,7 @@ iter-arith-asdl() {
 typecheck-more-oil() {
   #typecheck $flags osh/word_compile.py
 
-  local log=_tmp/typecheck-more-oil.txt
-
-  set +o errexit
-  typecheck $MYPY_FLAGS osh/glob_.py osh/string_ops.py > $log
-
-  assert-one-error $log
+  typecheck $MYPY_FLAGS osh/glob_.py osh/string_ops.py
 }
 
 


### PR DESCRIPTION
@andychu I think I got all the instances where we run mypy, except for in mycpp/examples.py -- but I couldn't find an entry point that I could make work.  I think converting it just like the others should work ok, perhaps with some additions to mypy.ini's per-module config sections.

Please feel free to just kick this back to me if I broke or missed anything.  Working through issues is a good way to learn :)