### PR TITLE
Add annotations and enable typechecking for osh/word_compile.py and osh/builtin_bracket.py

### DIFF
--- a/osh/bool_parse.py
+++ b/osh/bool_parse.py
@@ -37,9 +37,10 @@ from core.util import p_die
 from frontend import lookup
 from osh import word_
 
-from typing import List, Optional, TYPE_CHECKING
+from typing import List, Optional, Union, TYPE_CHECKING
 if TYPE_CHECKING:
   from osh.word_parse import WordParser
+  from osh.builtin_bracket import _StringWordEmitter
 
 # import libc  # for regex_parse
 
@@ -48,7 +49,7 @@ class BoolParser(object):
   """Parses [[ at compile time and [ at runtime."""
 
   def __init__(self, w_parser):
-    # type: (WordParser) -> None
+    # type: (Union[WordParser, _StringWordEmitter]) -> None
     """
     Args:
       w_parser: WordParser

--- a/osh/expr_eval.py
+++ b/osh/expr_eval.py
@@ -10,6 +10,7 @@ expr_eval.py -- Currently used for boolean and arithmetic expressions.
 """
 
 import stat
+from typing import TYPE_CHECKING
 
 from _devbuild.gen.id_kind_asdl import Id
 from _devbuild.gen.id_tables import BOOL_ARG_TYPES
@@ -31,6 +32,9 @@ try:
   import libc  # for fnmatch
 except ImportError:
   from benchmarks import fake_libc as libc  # type: ignore
+
+if TYPE_CHECKING:
+    from _devbuild.gen.syntax_asdl import bool_expr_t
 
 
 def _StringToInteger(s, span_id=runtime.NO_SPID):
@@ -279,6 +283,7 @@ class _ExprEvaluator(object):
   """
 
   def __init__(self, mem, exec_opts, word_ev, errfmt):
+    # type: (Mem, ExecOpts, word_eval.WordEvaluator, ErrorFormatter) -> None
     self.mem = mem
     self.exec_opts = exec_opts
     self.word_ev = word_ev  # type = word_eval.WordEvaluator
@@ -665,6 +670,7 @@ class BoolEvaluator(_ExprEvaluator):
     return val.s
 
   def Eval(self, node):
+    # type: (bool_expr_t) -> bool
     #print('!!', node.tag)
 
     if node.tag == bool_expr_e.WordTest:

--- a/osh/word_compile.py
+++ b/osh/word_compile.py
@@ -6,8 +6,10 @@ This is called the "compile" stage because it happens after parsing, but it
 doesn't depend on any values at runtime.
 """
 
-from _devbuild.gen.id_kind_asdl import Id
-from _devbuild.gen.syntax_asdl import class_literal_term
+from typing import Any, Optional
+
+from _devbuild.gen.id_kind_asdl import Id, Id_t
+from _devbuild.gen.syntax_asdl import class_literal_term, class_literal_term_t, token
 from core import ui
 from osh import string_ops
 
@@ -29,6 +31,7 @@ _ONE_CHAR = {
 }
 
 def EvalCharLiteralForRegex(tok):
+  # type: (token) -> class_literal_term_t
   """For regex char classes.
 
   Similar logic as below.
@@ -62,6 +65,7 @@ def EvalCharLiteralForRegex(tok):
 # \d could be a syntax error -- it is better written as \\d
 
 def EvalCStringToken(id_, value):
+  # type: (Id_t, str) -> Optional[str]
   """
   This function is shared between echo -e and $''.
 

--- a/types/common.sh
+++ b/types/common.sh
@@ -6,7 +6,7 @@ typecheck() {
 }
 
 readonly MYPY_FLAGS='--strict --no-implicit-optional --no-strict-optional'
-
+readonly OSH_PARSE_MANIFEST='types/osh-parse-manifest.txt'
 
 # Hack because there's an asdl/pretty.py error that's hard to get rid of.
 assert-one-error() {

--- a/types/more-oil-manifest.txt
+++ b/types/more-oil-manifest.txt
@@ -1,0 +1,9 @@
+./osh/glob_.py
+./osh/string_ops.py
+./frontend/location.py
+./osh/history.py
+./core/comp_ui.py
+./frontend/lookup.py
+./frontend/py_reader.py
+./core/error.py
+./osh/word_compile.py

--- a/types/more-oil-manifest.txt
+++ b/types/more-oil-manifest.txt
@@ -7,3 +7,4 @@
 ./frontend/py_reader.py
 ./core/error.py
 ./osh/word_compile.py
+./osh/builtin_bracket.py

--- a/types/osh-parse.sh
+++ b/types/osh-parse.sh
@@ -19,7 +19,6 @@ demo() {
 }
 
 readonly PY_DEPS='_tmp/osh-parse-deps.txt'
-readonly OSH_PARSE_MANIFEST='types/osh-parse-manifest.txt'
 
 deps() {
   local pythonpath='.:vendor'

--- a/types/run.sh
+++ b/types/run.sh
@@ -77,7 +77,7 @@ typecheck-more-oil() {
   typecheck $MYPY_FLAGS \
     osh/glob_.py osh/string_ops.py frontend/location.py \
     osh/history.py core/comp_ui.py frontend/lookup.py \
-    frontend/py_reader.py core/error.py \
+    frontend/py_reader.py core/error.py osh/word_compile.py \
     > $log
 
   assert-one-error $log

--- a/types/run.sh
+++ b/types/run.sh
@@ -68,17 +68,13 @@ typed-arith-asdl() {
   echo
 }
 
-typecheck-more-oil() {
-  #typecheck $flags osh/word_compile.py
 
+typecheck-more-oil() {
+  local manifest=types/more-oil-manifest.txt
   local log=_tmp/typecheck-more-oil.txt
 
   set +o errexit
-  typecheck $MYPY_FLAGS \
-    osh/glob_.py osh/string_ops.py frontend/location.py \
-    osh/history.py core/comp_ui.py frontend/lookup.py \
-    frontend/py_reader.py core/error.py osh/word_compile.py \
-    > $log
+  cat $manifest | xargs -- $0 typecheck $MYPY_FLAGS > $log
 
   assert-one-error $log
 }

--- a/types/run.sh
+++ b/types/run.sh
@@ -69,12 +69,28 @@ typed-arith-asdl() {
 }
 
 
+readonly MORE_OIL_MANIFEST=types/more-oil-manifest.txt
+
+
+need-typechecking() {
+    # This command is useful to find files to annotate and add to
+    # $MORE_OIL_MANIFEST.
+    # It shows all the files that are not included in
+    # $MORE_OIL_MANIFEST or $OSH_PARSE_MANIFEST, and thus are not yet
+    # typechecked by typecheck-more-oil here or
+    # `types/osh_parse.sh travis`.
+    comm -2 -3 \
+         <(metrics/source-code.sh osh-files | grep '.py$' | sed 's@^@./@') \
+         <(cat $MORE_OIL_MANIFEST $OSH_PARSE_MANIFEST | sort) \
+        | xargs wc -l | sort -n
+}
+
+
 typecheck-more-oil() {
-  local manifest=types/more-oil-manifest.txt
   local log=_tmp/typecheck-more-oil.txt
 
   set +o errexit
-  cat $manifest | xargs -- $0 typecheck $MYPY_FLAGS > $log
+  cat $MORE_OIL_MANIFEST | xargs -- $0 typecheck $MYPY_FLAGS > $log
 
   assert-one-error $log
 }

--- a/types/run.sh
+++ b/types/run.sh
@@ -87,12 +87,12 @@ need-typechecking() {
 
 
 typecheck-more-oil() {
-  local log=_tmp/typecheck-more-oil.txt
-
-  set +o errexit
-  cat $MORE_OIL_MANIFEST | xargs -- $0 typecheck $MYPY_FLAGS > $log
-
-  assert-one-error $log
+  # The --follow-imports=silent option allows adding type annotations
+  # in smaller steps without worrying about triggering a bunch of
+  # errors from imports.  In the end, we may want to remove it, since
+  # everything will be annotated anyway.  (that would require
+  # re-adding assert-one-error and its associated cruft, though).
+  cat $MORE_OIL_MANIFEST | xargs -- $0 typecheck --follow-imports=silent $MYPY_FLAGS
 }
 
 

--- a/types/run.sh
+++ b/types/run.sh
@@ -76,7 +76,8 @@ typecheck-more-oil() {
   set +o errexit
   typecheck $MYPY_FLAGS \
     osh/glob_.py osh/string_ops.py frontend/location.py \
-    osh/history.py core/comp_ui.py \
+    osh/history.py core/comp_ui.py frontend/lookup.py \
+    frontend/py_reader.py core/error.py \
     > $log
 
   assert-one-error $log


### PR DESCRIPTION
Also:
* create a manifest for typecheck-more-oil files instead of specifying all the filenames inline.
* make typecheck-more-oil stop returning errors for dependencies of specified modules, using the `--follow-imports=silent` option to mypy.
