### PR TITLE
[doc] clarify docstring of frontend/syntax_abbrev.py

### DIFF
--- a/frontend/syntax_abbrev.py
+++ b/frontend/syntax_abbrev.py
@@ -1,5 +1,7 @@
 """
-ssyntax_abbrev.py - Abbreviations for pretty-printing syntax.asdl.
+syntax_abbrev.py - Abbreviations for pretty-printing syntax.asdl.
+
+This module is not used directly, but is combined with generated code.
 """
 
 from _devbuild.gen.id_kind_asdl import Id


### PR DESCRIPTION
This was a bit confusing to me at first.