### PR TITLE
Add typechecking for 2 more files

### DIFF
--- a/types/more-oil-manifest.txt
+++ b/types/more-oil-manifest.txt
@@ -11,3 +11,4 @@
 ./osh/split.py
 ./oil_lang/expr_parse.py
 ./core/main_loop.py
+./oil_lang/regex_translate.py

--- a/types/more-oil-manifest.txt
+++ b/types/more-oil-manifest.txt
@@ -10,3 +10,4 @@
 ./osh/builtin_bracket.py
 ./osh/split.py
 ./oil_lang/expr_parse.py
+./core/main_loop.py


### PR DESCRIPTION
oil_lang/regex_translate.py needed substantial annotation changes, while core/main_loop.py was already passing mypy.