### PR TITLE
[types] add scripts/function to help maintain correct imports when adding type annotation

### DIFF
--- a/devtools/findclassdefs.py
+++ b/devtools/findclassdefs.py
@@ -1,0 +1,35 @@
+"""
+Given a list of module filenames as arguments, and a list of class
+names in STDIN (one per line), write out fully qualified names for
+each of the classes, if they are defined in one of the given modules.
+
+Used with typeimports.py to auto-add imports when adding type
+annotations.
+"""
+from collections import defaultdict
+import re
+import sys
+import ast
+
+def build_name_module_mapping(filenames):
+	name_to_module = defaultdict(list)
+	for filename in filenames:
+		src = open(filename, 'r').read()
+		mod_path = filename.replace('.py', '').replace('/', '.')
+		module = ast.parse(src, filename)
+		for node in ast.walk(module):
+			if isinstance(node, ast.ClassDef):
+				name_to_module[node.name].append(mod_path)
+	return name_to_module
+
+def main():
+	name_to_module = build_name_module_mapping(sys.argv[1:])
+
+	for class_name in sys.stdin:
+		class_name = class_name.strip()
+		mod_paths = name_to_module[class_name]
+		if len(mod_paths) == 1:
+			print mod_paths[0] + '.' + class_name
+
+if __name__ == '__main__':
+	main()

--- a/devtools/typeimports.py
+++ b/devtools/typeimports.py
@@ -1,0 +1,103 @@
+"""
+A very brittle, ad-hoc script to add imports to python modules,
+only if they are contained within an "if TYPE_CHECKING" block.  It is
+likely to break if given the slightest deviation from expected input.
+The modified code is printed to STDOUT.
+
+This is a helper to make adding mypy type annotations more pleasant
+(with the end goal of translating python to cpp using mycpp).
+
+  Usage: typeimports.py PYTHON_FILENAME [IMPORT_NAME...]
+
+  where IMPORT_NAME is something like _devbuild.gen.syntax_asdl.command_t
+  to be turned into "from _devbuild.gen.syntax_asdl import (command_t, ..."
+
+Assumptions:
+
+* There is a top level 'if TYPE_CHECKING:' statement (if not, this script is a no-op).
+  Only imports in this conditional clause are considered.
+
+* There already exist import statements for the relevant modules.  New
+  import statements are not added. (This might be worth fixing)
+
+* These imports are of the form "from XXX import (YYY, ZZZ...)",
+  though they can be multi-line.
+
+* The IMPORT_NAMES are all valid and well-formed.
+
+Limitations:
+
+* Since this script only adds annotations to the 'if TYPE_CHECKING:'
+  block, it will not add imports in the right place if you are adding
+  `cast(...)` statements.  You'll probably have to go through
+  afterward and move some imports to the top level of the module.
+"""
+
+from collections import defaultdict
+import sys
+import ast
+import textwrap
+
+
+def register_parents(node, parent_map):
+	for child in ast.iter_child_nodes(node):
+		parent_map[child] = node
+		register_parents(child, parent_map)
+
+
+def replace_slice(orig, start, end, replacement):
+	return orig[:start] + replacement + orig[end:]
+
+
+def add_import(src, module, import_mod, import_names):
+	lines = src.splitlines()
+
+	parent_map = {}
+	register_parents(module, parent_map)
+
+	for node in ast.walk(module):
+		if isinstance(node, ast.ImportFrom):
+			parent = parent_map[node]
+
+			if isinstance(parent, ast.If) and isinstance(parent.test, ast.Name) and parent.test.id == 'TYPE_CHECKING':
+				if node.module != import_mod:
+					continue
+				start = node.lineno - 1
+				starting_line = lines[start]
+				if '(' in starting_line:
+					end = start
+					while ')' not in lines[end]:
+						end += 1
+				else:
+					end = start
+
+				new_names = [n.name for n in node.names] + import_names
+				new_imports = ', '.join(sorted(new_names))
+				new_lines = ['  from {} import ('.format(import_mod)] + \
+					textwrap.wrap(new_imports, 80, initial_indent='    ', subsequent_indent='    ') +\
+					['  )']
+				lines = replace_slice(lines, start, end+1, new_lines)
+	return '\n'.join(lines)
+
+
+def main():
+	filename = sys.argv[1]
+	imports_to_add = sys.argv[2:]
+	src = open(filename, 'r').read()
+
+	to_add = defaultdict(list)
+	for impname in imports_to_add:
+		mod, _, name = impname.rpartition('.')
+		to_add[mod].append(name)
+
+	for import_mod, import_names in to_add.items():
+		# Repeatedly parsing and adding imports for one module at a
+		# time is wasteful, but avoids the necessity of dealing with
+		# line numbers shifting.
+		module = ast.parse(src, filename)
+		src = add_import(src, module, import_mod, import_names)
+	compile(src, '', 'exec')
+	print src,
+
+if __name__ == '__main__':
+	main()

--- a/types/run.sh
+++ b/types/run.sh
@@ -101,12 +101,14 @@ add-imports() {
   # TYPE_CHECKING:' block of a single module, if the relevant
   # classes are found in one of COMMON_TYPE_MODULES
 
-  # Also, this prints out the typechecking output, to avoid having
-  # to run two redundant (and slow) typechecking commands.
+  # Also, this saves the typechecking output to the file named by
+  # $typecheck_out, to make it possible to avoid having to run two
+  # redundant (and slow) typechecking commands.  You can just cat that
+  # file after running this function.
   local module=$1
   export PYTHONPATH=.
-  module_tmp=_tmp/add-imports-module.tmp
-  typecheck_out=_tmp/add-imports-typecheck-output
+  readonly module_tmp=_tmp/add-imports-module.tmp
+  readonly typecheck_out=_tmp/add-imports-typecheck-output
   set +o pipefail
   # unbuffer is just to preserve colorization (it tricks the command
   # into thinking it's writing to a pty instead of a pipe)
@@ -120,8 +122,8 @@ add-imports() {
   then
     cp $module "_tmp/add-imports.$(basename $module).bak"
     mv "$module_tmp" "$module"
+	echo "Updated $module"
   fi
-  cat "$typecheck_out"
 }
 
 typecheck-more-oil() {

--- a/types/run.sh
+++ b/types/run.sh
@@ -105,9 +105,8 @@ add-imports() {
   # to run two redundant (and slow) typechecking commands.
   local module=$1
   export PYTHONPATH=.
-  module_tmp=$(mktemp)
-  typecheck_out=$(mktemp)
-  trap 'rm -f -- "$module_tmp" "$typecheck_out"' INT TERM HUP EXIT
+  module_tmp=_tmp/add-imports-module.tmp
+  typecheck_out=_tmp/add-imports-typecheck-output
   set +o pipefail
   # unbuffer is just to preserve colorization (it tricks the command
   # into thinking it's writing to a pty instead of a pipe)
@@ -119,7 +118,7 @@ add-imports() {
 
   if ! diff -q "$module_tmp" "$module" > /dev/null
   then
-    cp $module "$(mktemp -p /tmp oil-add-imports.XXXXXXXXX)"
+    cp $module "_tmp/add-imports.$(basename $module).bak"
     mv "$module_tmp" "$module"
   fi
   cat "$typecheck_out"


### PR DESCRIPTION
These are very hacky and intended to be temporary, just until the type annotation is completed.

@andychu I'm working on adding type annotations to osh/word_eval.py, and I decided that I've been spending too much time manually updating imports, so I wrote these helpers.  I don't know if anyone else will want to use them, but I thought it was better to commit them than not.