### PR TITLE
Nix shell

### DIFF
--- a/doctools/cmark.py
+++ b/doctools/cmark.py
@@ -26,7 +26,10 @@ from doctools import oil_doc
 #libname = find_library("cmark")
 #assert libname, "cmark not found"
 
-libname = '/usr/local/lib/libcmark.so'
+# There's some ongoing discussion about how to deal with the same in Nix.
+# I think normally you'd just patch/substitute this path during the Nix build.
+# See note in shell.nix
+libname = os.environ.get('_NIX_SHELL_LIBCMARK', '/usr/local/lib/libcmark.so')
 
 cmark = ctypes.CDLL(libname)
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,140 @@
+# Nix shell expression for the oil shell (formatted with nixfmt)
+#   Note: run `nixfmt shell.nix` in nix-shell to reformat in-place
+#
+# By default fetch the most-recent 19.09 version of the stable NixOS release.
+# This should be fine, but if it causes trouble it can be pinned to ensure
+# everyone is running exactly the same versions.
+{ nixpkgs ? fetchTarball "channel:nixos-19.09", dev ? "all", test ? "smoke"
+, cleanup ? true }:
+
+let
+  # Import the package set.
+  pkgs = import nixpkgs { };
+
+  # Added the following 3 declarations (and parameters/defaults above) to
+  # demonstrate how you could make the behavior a little configurable.
+  #
+  # By default, it will run:
+  # - "all" dev build (--argstr dev minimal or none to disable)
+  # - the "smoke" tests (--argstr test osh-all or none to disable)
+  # - and clean on exit (ex: --argstr cleanup none to disable)
+  build_oil = if dev == "none" then
+    "echo Skipping Oil build."
+  else ''
+    echo Building \'${dev}\' Oil.
+    "$PWD/build/dev.sh" ${dev}
+  '';
+  test_oil = if test == "none" then
+    "echo Skipping Oil tests."
+  else ''
+    echo Running Oil \'${test}\' tests.
+    "$PWD/test/spec.sh" ${test}
+  '';
+  cleanup_oil = if cleanup == "none" then ''
+    echo "Note: nix-shell will *NOT* clean up Oil dev build on exit!"
+    trap 'echo "NOT cleaning up Oil dev build."' EXIT
+  '' else ''
+    echo "Note: nix-shell will clean up the dev build on exit."
+    trap 'echo "Cleaning up Oil dev build."; "$PWD/build/dev.sh" clean' EXIT
+  '';
+in with pkgs;
+
+let
+  # Most of the items you listed in #513 are here now. I'm not sure what the
+  # remaining items here mean, so I'm not sure if they're covered.
+  #
+  # static analysis
+  #   mypy library for mycpp
+  # benchmarks
+  #   ocaml configure, etc. This is just source though.
+  # C deps
+  #   python headers for bootstrapping
+  # big one: Clang for ASAN and other sanitizers (even though GCC has some)
+  #   Clang for coverage too
+
+  # nixpkgs: busybox linux only; no smoosh
+  # could append something like: ++ lib.optionals stdenv.isLinux [ busybox ]
+  spec_tests = [ bash dash mksh zsh ];
+
+  static_analysis = [
+    mypy # This is the Python 3 version
+    (python2.withPackages (ps: with ps; [ flake8 pyannotate ]))
+    # python3Packages.black # wink wink :)
+  ];
+
+  binary = [ re2c ];
+  doctools = [ cmark ];
+  c_deps = [ readline ];
+
+  shell_deps = [
+    gawk
+    time
+    # additional command dependencies I found as I went
+    # guessing they go here...
+    # run with nix-shell --pure to make missing deps easier to find!
+    file
+    git
+    hostname
+    which
+  ];
+
+  nix_deps = [
+    nixfmt # `nixfmt shell.nix` to format in place
+  ];
+
+  # Create a shell with packages we need.
+in mkShell rec {
+
+  buildInputs = c_deps ++ binary ++ spec_tests ++ static_analysis ++ doctools
+    ++ shell_deps ++ nix_deps ++ doctools;
+
+  # Not sure if this is "right" (for nix, other platforms, etc.)
+  # doctools/cmark.py hardcoded /usr/local/lib/libcmark.so, and it looks
+  # like Nix has as much trouble with load_library as you have. For a
+  # "build" I think we'd use a patchPhase to replace the hard path
+  # in cmark.py with the correct one. Since we can't patch the source here
+  # I'm hacking an env in here and in cmark.py. Hopefully others will
+  # weigh in if there's a better way to handle this.
+  #
+  # Note: Nix automatically adds identifiers declared here to the environment!
+  _NIX_SHELL_LIBCMARK = if stdenv.isDarwin then
+    "${cmark}/lib/libcmark.dylib"
+  else
+    "${cmark}/lib/libcmark.so";
+
+  # Need nix to relax before it'll link against a local file.
+  NIX_ENFORCE_PURITY = 0;
+
+  # Andy--can you try with each of the options below enabled in turn?
+  # option A
+  LOCALE_ARCHIVE =
+    if stdenv.isLinux then "${glibcLocales}/lib/locale/locale-archive" else "";
+
+  # option B
+  # LOCALE_ARCHIVE = lib.optionalString (stdenv.hostPlatform.libc == "glibc") "${glibcLocales}/lib/locale/locale-archive";
+
+  # do setup work you want to do every time you enter the shell
+  # Here are a few ideas that made sense to me:
+  shellHook = ''
+    if [[ ! -a "$PWD/py-yajl/setup.py" ]]; then
+      git submodule update --init --recursive
+    fi
+
+    if [[ ! -a "$PWD/libc.so" ]]; then
+      ${build_oil}
+      ${test_oil}
+    else
+      echo "Dev build already exists. If you made changes, run:"
+      echo "    'build/dev.sh clean' and "
+      echo "    'build/dev.sh all' or 'build/dev.sh minimal'"
+    fi
+
+    # I added oil/bin to the path, but that may not be what you want
+    PATH="$PATH:$PWD/bin"
+
+    # Add current path to PYTHONPATH so python scripts can find modules
+    PYTHONPATH="$PYTHONPATH:$PWD"
+
+    ${cleanup_oil}
+  '';
+}


### PR DESCRIPTION
I've taken another swing at closing out the initial work by @adisbladis and @FRidh to create a Nix-based dev environment (this ongoing effort is mentioned in #509, #511 and #513 [which may also supersede #135 and #159]). Along with the associated changes mentioned below, this should be sufficient to build the "all" dev build (though I'm not certain it addresses all bullets from the issue; I've preserved the ones I'm not sure about in a comment in `shell.nix`).

# Associated Oil Changes
I had to make a few changes to Oil to get this working:
- Make the hardcoded libcmark path in doctools/cmark.py configurable. This is the only one included in this PR (because it's paired with statements in `shell.nix`), but you may want to rework it.
- As discussed on zulip, I disabled the libc tests so that I could make more progress:
    ```
    diff --git a/build/dev.sh b/build/dev.sh
    index bbf14355..310e459d 100755
    --- a/build/dev.sh
    +++ b/build/dev.sh
    @@ -180,7 +180,7 @@ py-ext() {
     
     pylibc() {
       py-ext libc build/setup.py
    -  native/libc_test.py "$@" > /dev/null
    +  # native/libc_test.py "$@" > /dev/null
     }
     
     fastlex() {
    ```
- I disabled a shell function overriding the re2c executable:
    ```
    diff --git a/build/codegen.sh b/build/codegen.sh
    index d06ba0ac..15128afb 100755
    --- a/build/codegen.sh
    +++ b/build/codegen.sh
    @@ -53,7 +53,7 @@ install-re2c() {
       make
     }
     
    -re2c() { _deps/re2c-1.0.3/re2c "$@"; }
    +#re2c() { _deps/re2c-1.0.3/re2c "$@"; }
     
     download-clang() {
       wget --directory _deps \
    ```

# README / DOC
I am not submitting edits to `README.md` because I'm not sure how you see nix-shell fitting into your existing build/quickstart/contributing docs and workflows. I'll list some usage notes/caveats (in part taken from @FRidh's PR) here in case you prefer to do this, but I can update whatever you'd like with a little direction.

- The Nix expression in `shell.nix` provides all build and test dependencies using the
[Nix package manager][].
- [Installing Nix][] is fairly simple.
    - For macOS users: the installer doesn't yet handle Catalina (10.15). I don't (personally) recommend trying to install Nix on Catalina to anyone who isn't already a regular Nix user.

        If they haven't updated to Catalina, they can install and use Nix now (as I am!), as long as they make sure they don't accept the Catalina update for now.

        I'm not sure what the best "positive" recommendation here is. Anyone in this group who *would* like to try Nix as soon as the installer is fixed will probably find out if they subscribe to https://github.com/NixOS/nix/issues/2925 and https://github.com/NixOS/nix/pull/3212, but these threads may still produce a lot of notification noise before it's fixed. 

        A better option might be creating a mirror Oil issue that describes the problem, suggest they subscribe to that issue, and then comment/resolve when you're comfortable giving a recommendation.
- To build the environment with nix-shell, they just need to clone the oil repo, cd into it, and run `nix-shell`. This will take a bit the first time they run it, but subsequent runs will be much faster. 
    - I added a "shell hook" that automatically does a few things to speed up onboarding. You'll probably want to tweak some of what it does (or the defaults?), so here's a list:
        - It updates the git submodules if the `py-yajl` directory is missing. Unless you cut this out of the hook, Nix users don't *have* to update submodules after clone.
        - It automatically runs `build/dev.sh all` (I figure this is most-helpful for finding slippage, and it doesn't take much longer on my system). It does this if libc.so is missing--there may be a better heuristic. This is configurable; you can specify the minimal target with `nix-shell --argstr dev minimal`, or disable the build with `--argstr dev none`.
        - It automatically runs `test/spec.sh smoke`. This is likewise configurable with something like `--argstr test interactive` or disabled with `--argstr test none`.
        - It traps EXIT to run `build/dev.sh clean`. This can be disabled with `--argstr cleanup none` (if libc.so exists on next entry, it'll skip build/test).
        - It appends `$PWD/bin` to their `$PATH`, so they can use Oil commands without a `bin/` prefix. You might want it on the front of the path; I'm not sure if your true/false/readlink/etc. executables should override anything else in `$PATH`.
- When they're done using the dev environment, they can use `exit` to return to the initial shell session.
- If they just run `nix-shell`, they'll have commands available from their external environment. This is sometimes beneficial, but it can also mask undeclared dependencies. If they run `nix-shell --pure`, it'll load a (mostly) clean environment that makes it easier to ferret out implicit dependencies.
- If they make changes that might affect dependencies (such as checking out a different branch), they'll need to exit and re-enter nix-shell to see those changes.

[Nix package manager]: https://nixos.org/nix/
[Installing Nix]: https://nixos.org/nix/download.html