### PR TITLE
fix NoneType attribute error

### DIFF
--- a/tools/deps.py
+++ b/tools/deps.py
@@ -29,7 +29,7 @@ class Visitor(object):
     """
     #print 'CHILD', node.ASDL_TYPE
 
-    for name, _ in node.ASDL_TYPE.GetFields():
+    for name in node.__slots__:
       child = getattr(node, name)
       #log('Considering child %s', name)
 


### PR DESCRIPTION
I'm not sure this is the "right" fix, but after introspecting for a while I did find a fix that solves the AttributeError and does appear returns the right list of attributes here:
```
...
    self.VisitChildren(node)
  File "/Users/abathur/work/oil/tools/deps.py", line 32, in VisitChildren
    for name, _ in node.ASDL_TYPE.GetFields():
AttributeError: 'NoneType' object has no attribute 'GetFields'
```