### PR TITLE
[WIP] more portable root user expansion

### DIFF
--- a/spec/brace-expansion.test.sh
+++ b/spec/brace-expansion.test.sh
@@ -169,10 +169,29 @@ echo {foo~,~}/bar
 #### Two kinds of tilde expansion
 # NOTE: osh matches mksh.  Is that OK?
 # ~/foo and ~bar
+# necessary to establish ~ == ~current_user?
+# (could be a separate test now?)
+[[ ~ == $(eval printf \'%s\\\n\' \~$LOGNAME) ]]
+_must_exist(){ test -d "$1" && test -d "$2"; }
+_check_paths(){
+  echo $1
+  if test -d "$2"; then
+    # hope root's homedir ends in root
+    echo $2 | grep -E -o "/root$"
+  else
+    echo $2
+  fi
+}
+_must_exist ~{,root}
 HOME=/home/bob
-echo ~{/src,root}
-## stdout: /home/bob/src /root
-## OK osh/mksh stdout: ~/src ~root
+_check_paths ~{,root}
+## STDOUT:
+/home/bob
+/root
+## OK osh/mksh STDOUT:
+~
+~root
+## END
 
 #### Tilde expansion come before var expansion
 HOME=/home/bob


### PR DESCRIPTION
Opening for discussion. Needs changes before merge. I suspect we can delete parts or break them out into other tests, and you may have ideas on another approach. 

Thoughts/notes:

1. `[[ ~ == $(eval printf \'%s\\\n\' \~$LOGNAME) ]]` is actually just part of an earlier attempt at fixing the test, but I kept the line for discussion since I haven't seen this narrow slice of behavior covered in another test. If you think it's worthwhile, I could imagine folding it into how _must_exist checks the first expansion, or creating a new test in tilde.test.sh?
2. Because using grep to test/filter the root user's path `/root` weakens the stdout assertion a little, I tried to compensate by also testing that the directories exist. If you think testing the end of the root user's path is enough, I can cut `_must_exist` and some related changes:
    - I pared `{/src,root}` back to `{,root}` since ~/src is less-likely to exist than ~/
    - delayed overriding HOME to test that the user home exists before testing output