### PR TITLE
fix absolute executable path in errexit-oil spec

### DIFF
--- a/spec/errexit-oil.test.sh
+++ b/spec/errexit-oil.test.sh
@@ -218,7 +218,7 @@ fun || true  # this is OK
 shopt -s strict_errexit || true
 
 echo 'builtin ok' || true
-/bin/echo 'external ok' || true
+env echo 'external ok' || true
 
 fun || true  # this fails
 


### PR DESCRIPTION
This spec fails on nixos. After grepping around, I think it's also the last remaining spec that tries to *run* a hardcoded executable path. The logs attached below show verbose output for just this spec before and after the change:

[fail before nixos](https://github.com/oilshell/oil/files/4303585/errexit_nixos_local_fail.txt)
[pass after nixos](https://github.com/oilshell/oil/files/4303586/errexit_nixos_local_pass.txt)

For reference, here are clean before/afters of the same job for linux and macOS:
[pass before linux](https://travis-ci.org/abathur/oil/jobs/659853026#L3274)
[pass before macos](https://travis-ci.org/abathur/oil/jobs/659853027#L3346)
[pass after linux](https://travis-ci.org/abathur/oil/jobs/659859815#L3274)
[pass after macos](https://travis-ci.org/abathur/oil/jobs/659859816#L3346)