### PR TITLE
fix flaky file completion order in builtin-completion

### DIFF
--- a/spec/builtin-completion.test.sh
+++ b/spec/builtin-completion.test.sh
@@ -113,7 +113,7 @@ PWD
 
 #### compgen with actions: function / variable / file 
 mkdir -p $TMP/compgen2
-touch $TMP/compgen2/PA_FILE_{1,2}
+touch $TMP/compgen2/{PA,Q}_FILE
 cd $TMP/compgen2  # depends on previous test above!
 PA_FUNC() { echo P; }
 Q_FUNC() { echo Q; }
@@ -121,8 +121,7 @@ compgen -A function -A variable -A file PA
 ## STDOUT:
 PA_FUNC
 PATH
-PA_FILE_1
-PA_FILE_2
+PA_FILE
 ## END
 
 #### compgen with actions: alias, setopt


### PR DESCRIPTION
I see consistent breaks here on nixos due to a different sort order of the file entries at the end. In response, I borrowed the PA/_Q pattern you used for functions. I didn't want to pipe the output through sort, because the existing test also covers the behavior of generating results in argument order.

[fail before nixos](https://github.com/oilshell/oil/files/4303758/compgen_before_nixos_fail.txt)
[pass after nixos](https://github.com/oilshell/oil/files/4303759/compgen_after_nixos_pass.txt)

I'm not exactly sure what's going on here, but I've fiddled with this a little and it looks like I see a different, stable, unsorted order on each problem. It smells like different random seeds. (I also statted the files on macos and see that they aren't sorted by inode, and all have the same timestamp. Here's a demo of the behavior itself:

```
$ uname -a
Linux ... 4.4.0-1062-aws #66-Ubuntu SMP Thu Jan 30 13:49:40 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
~ $ touch PA_FILE_{1,2,3,4,5,6,7,8,9}; compgen -A file PA
PA_FILE_3
PA_FILE_7
PA_FILE_5
PA_FILE_1
PA_FILE_9
PA_FILE_2
PA_FILE_6
PA_FILE_8
PA_FILE_4


$ uname -a
Darwin ... 18.7.0 Darwin Kernel Version 18.7.0: Tue Aug 20 16:57:14 PDT 2019; root:xnu-4903.271.2~2/RELEASE_X86_64 x86_64 i386 MacBookAir8,1 Darwin

$ touch PA_FILE_{1,2,3,4,5,6,7,8,9}; compgen -A file PA; rm PA_FILE_*
PA_FILE_7
PA_FILE_9
PA_FILE_8
PA_FILE_6
PA_FILE_1
PA_FILE_4
PA_FILE_3
PA_FILE_2
PA_FILE_5


$ uname -a
Linux ... 4.19.86 #1-NixOS SMP Sun Nov 24 07:21:09 UTC 2019 x86_64 GNU/Linux

$ touch PA_FILE_{1,2,3,4,5,6,7,8,9}; compgen -A file PA; rm PA_FILE_*
PA_FILE_8
PA_FILE_2
PA_FILE_9
PA_FILE_4
PA_FILE_3
PA_FILE_6
PA_FILE_5
PA_FILE_7
PA_FILE_1
```

Once again, before/after passes for linux and macos:
[pass before linux](https://travis-ci.org/abathur/oil/jobs/659878111#L3274)
[pass after linux](https://travis-ci.org/abathur/oil/jobs/659877173#L3274)
[pass before macos](https://travis-ci.org/abathur/oil/jobs/659878112#L3346)
[pass after macos](https://travis-ci.org/abathur/oil/jobs/659877174#L3346)