### PR TITLE
[spec/builtin-dirs] swap /lib for more-portable /dev

### DIFF
--- a/spec/builtin-dirs.test.sh
+++ b/spec/builtin-dirs.test.sh
@@ -72,7 +72,7 @@ cd /
 pushd /tmp >/dev/null
 echo --
 dirs -v
-pushd /lib >/dev/null
+pushd /dev >/dev/null
 echo --
 dirs -v
 ## status: 0
@@ -81,13 +81,13 @@ dirs -v
  0  /tmp
  1  /
 --
- 0  /lib
+ 0  /dev
  1  /tmp
  2  /
 ## END
 #
 #  zsh uses tabs
-## OK zsh stdout-json: "--\n0\t/tmp\n1\t/\n--\n0\t/lib\n1\t/tmp\n2\t/\n"
+## OK zsh stdout-json: "--\n0\t/tmp\n1\t/\n--\n0\t/dev\n1\t/tmp\n2\t/\n"
 
 #### dirs -p to print one entry per line
 set -o errexit
@@ -95,7 +95,7 @@ cd /
 pushd /tmp >/dev/null
 echo --
 dirs -p
-pushd /lib >/dev/null
+pushd /dev >/dev/null
 echo --
 dirs -p
 ## STDOUT:
@@ -103,7 +103,7 @@ dirs -p
 /tmp
 /
 --
-/lib
+/dev
 /tmp
 /
 ## END


### PR DESCRIPTION
Both cases try to use /lib, which neither macos nor nixos have. Instead of
making a longer, more abstract fix, I'm just swapping this for /dev. I checked
several docsets and didn't see a *nix without it, so it should at least be
"more" portable.

[fail before nixos](https://github.com/oilshell/oil/files/4303992/nixos_before_fail.txt)
[fail before macos](https://travis-ci.org/abathur/oil/jobs/659895964#L3349) (forgot to run case 6 here, but it fails the same way)

[pass after nixos](https://github.com/oilshell/oil/files/4303993/nixos_after_pass.txt)
[pass after macos](https://travis-ci.org/abathur/oil/jobs/659922765#L3346)

And, as before:
[pass before linux](https://travis-ci.org/abathur/oil/jobs/659895963#L3274) (forgot to run case 6 here, but it also passes)
[pass after linux](https://travis-ci.org/abathur/oil/jobs/659922764#L3274)
