### PR TITLE
[spec/brace-expansion] improve ~root test portability

### DIFF
--- a/spec/brace-expansion.test.sh
+++ b/spec/brace-expansion.test.sh
@@ -170,8 +170,18 @@ echo {foo~,~}/bar
 # NOTE: osh matches mksh.  Is that OK?
 # ~/foo and ~bar
 HOME=/home/bob
-echo ~{/src,root}
-## stdout: /home/bob/src /root
+expected_root_home=$(awk -F: -v v="root" '{if ($1==v) print $6}' /etc/passwd)
+test_expansion(){
+  if [[ "$1" == "~/src" && "$2" == "~root" ]]; then
+    echo "$1 $2"
+  elif [[ "$1" == "/home/bob/src" && "$2" == "$expected_root_home" ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+test_expansion ~{/src,root}
+## status: 0
 ## OK osh/mksh stdout: ~/src ~root
 
 #### Tilde expansion come before var expansion


### PR DESCRIPTION
To dodge assertion failures caused by the root user having a home directory other than `/root` on some platforms (including macos and nixos), this tests the fully-expanded paths from bash and zsh against the root user's home directory by extracting it from /etc/passwd. This revisits #634.

[fail before nixos](https://github.com/oilshell/oil/files/4304497/nixos_before_fail.txt)
[fail before macos](https://travis-ci.org/abathur/oil/jobs/659933665#L3349)

[pass after nixos](https://github.com/oilshell/oil/files/4304496/nixos_after_pass.txt)
[pass after macos](https://travis-ci.org/abathur/oil/jobs/659973493#L3346)

And of course:
[pass before linux](https://travis-ci.org/abathur/oil/jobs/659933664#L3274)
[pass after linux](https://travis-ci.org/abathur/oil/jobs/659973492#L3274)

