### PR TITLE
Allow scalar form of BASH_LINENO and FUNCNAME

### DIFF
--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -60,7 +60,8 @@ if TYPE_CHECKING:
 
 
 # For compatibility, ${BASH_SOURCE} and ${BASH_SOURCE[@]} are both valid.
-_STRING_AND_ARRAY = 'BASH_SOURCE'
+# ${FUNCNAME} and ${BASH_LINENO} are also the same type of of special variables.
+_STRING_AND_ARRAY = ('BASH_SOURCE', 'FUNCNAME', 'BASH_LINENO')
 
 
 def EvalSingleQuoted(part):
@@ -907,7 +908,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
     else:  # no bracket op
       # When the array is "$@", var_name is None
       if var_name and val.tag_() in (value_e.MaybeStrArray, value_e.AssocArray):
-        if var_name == _STRING_AND_ARRAY:
+        if var_name in _STRING_AND_ARRAY:
           bash_array_compat = True
         else:
           e_die("Array %r can't be referred to as a scalar (without @ or *)",
@@ -1146,7 +1147,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
       # TODO: Special case for LINENO
       val = self.mem.GetVar(var_name)
       if val.tag_() in (value_e.MaybeStrArray, value_e.AssocArray):
-        if var_name == _STRING_AND_ARRAY:
+        if var_name in _STRING_AND_ARRAY:
           bash_array_compat = True
         else:
           e_die("Array %r can't be referred to as a scalar (without @ or *)",

--- a/spec/introspect.test.sh
+++ b/spec/introspect.test.sh
@@ -58,21 +58,38 @@ argv.py "${FUNCNAME[@]}"
 ## END
 
 
-#### ${BASH_SOURCE} usable as a string (e.g. for virtualenv)
+#### ${BASH_SOURCE}, etc. usable as a string (e.g. for virtualenv)
 
 # https://github.com/pypa/virtualenv/blob/master/virtualenv_embedded/activate.sh
+# https://github.com/akinomyoga/ble.sh/blob/6f6c2e5/ble.pp#L374
 
 argv.py "$BASH_SOURCE"  # SimpleVarSUb
 argv.py "${BASH_SOURCE}"  # BracedVarSub
+argv.py "$BASH_LINENO"  # SimpleVarSUb
+argv.py "${BASH_LINENO}"  # BracedVarSub
+argv.py "$FUNCNAME"  # SimpleVarSUb
+argv.py "${FUNCNAME}"  # BracedVarSub
 source spec/testdata/bash-source-string.sh
 
 ## STDOUT:
 ['']
 ['']
+['']
+['']
+['']
+['']
 ['spec/testdata/bash-source-string.sh']
 ['spec/testdata/bash-source-string.sh']
+['7']
+['7']
+['source']
+['source']
 ['spec/testdata/bash-source-string2.sh']
 ['spec/testdata/bash-source-string2.sh']
+['11']
+['11']
+['source']
+['source']
 ## END
 
 #### ${BASH_SOURCE[@]} with source and function name

--- a/spec/testdata/bash-source-string.sh
+++ b/spec/testdata/bash-source-string.sh
@@ -2,6 +2,10 @@
 
 argv.py $BASH_SOURCE  # SimpleVarSub
 argv.py ${BASH_SOURCE}
+argv.py $BASH_LINENO # SimpleVarSub
+argv.py ${BASH_LINENO}
+argv.py $FUNCNAME  # SimpleVarSub
+argv.py ${FUNCNAME}
 
 # Test with 2 entries
 source spec/testdata/bash-source-string2.sh

--- a/spec/testdata/bash-source-string2.sh
+++ b/spec/testdata/bash-source-string2.sh
@@ -2,3 +2,7 @@
 
 argv.py $BASH_SOURCE  # SimpleVarSub
 argv.py ${BASH_SOURCE}
+argv.py $BASH_LINENO  # SimpleVarSub
+argv.py ${BASH_LINENO}
+argv.py $FUNCNAME  # SimpleVarSub
+argv.py ${FUNCNAME}


### PR DESCRIPTION
Related to the second point in https://github.com/oilshell/oil/issues/653#issuecomment-599087679. I found that `BASH_SOURCE` is specially treated (de92fc57). `BASH_LINENO` and `FUNCNAME` are also members of the same family. They are original scalar variables and later extended to an array variable. They should allow both form of `$X` and `${X[0]}`.

Note: When I create a test, I noticed that there is a difference between Bash and Oil for `FUNCNAME` in source contexts, i.e., `FUNCNAME=` in Bash and `FUNCNAME=source` in Oil. The added test is created for the Oil behavior.