### PR TITLE
[word_eval] Fix the ${!prefix@} failure for the second time

### DIFF
--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -913,6 +913,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
           e_die("Array %r can't be referred to as a scalar (without @ or *)",
                 var_name, part=part)
 
+    suffix_processed = False
     if part.prefix_op:
       val = self._EmptyStrOrError(val)  # maybe error
 
@@ -927,7 +928,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
         # "${!prefix@}" is the only one that doesn't decay
         maybe_decay_array = not (quoted and suffix_op.op_id == Id.VOp3_At)
 
-        part.suffix_op = None  # don't process it later
+        suffix_processed = True
       else:
         # could be
         # - ${!ref-default}
@@ -938,7 +939,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
         # NOTE: The length operator followed by a suffix operator is a SYNTAX
         # error.
 
-    if part.suffix_op:
+    if part.suffix_op and not suffix_processed:
       op = part.suffix_op
       UP_op = op
       with tagswitch(op) as case:

--- a/spec/var-op-bash.test.sh
+++ b/spec/var-op-bash.test.sh
@@ -62,10 +62,21 @@ argv.py ${!Z*}
 argv.py ${!Z@}
 argv.py "${!Z*}"
 argv.py "${!Z@}"
+for i in 1 2; do argv.py ${!Z*}  ; done
+for i in 1 2; do argv.py ${!Z@}  ; done
+for i in 1 2; do argv.py "${!Z*}"; done
+for i in 1 2; do argv.py "${!Z@}"; done
 ## STDOUT:
 ['Z', 'ZIP', 'ZOO', 'ZOOM']
 ['Z', 'ZIP', 'ZOO', 'ZOOM']
 ['Z ZIP ZOO ZOOM']
 ['Z', 'ZIP', 'ZOO', 'ZOOM']
+['Z', 'ZIP', 'ZOO', 'ZOOM']
+['Z', 'ZIP', 'ZOO', 'ZOOM']
+['Z', 'ZIP', 'ZOO', 'ZOOM']
+['Z', 'ZIP', 'ZOO', 'ZOOM']
+['Z ZIP ZOO ZOOM']
+['Z ZIP ZOO ZOOM']
+['Z', 'ZIP', 'ZOO', 'ZOOM']
+['Z', 'ZIP', 'ZOO', 'ZOOM']
 ## END
-


### PR DESCRIPTION
See the fourth item in https://github.com/oilshell/oil/issues/653#issuecomment-599087679.

> See the following test case. Even though it succeeds for the first time, it fails for the second time.
> 
> **test3.sh**
> ```bash
> #!/usr/bin/env bash
> 
> abc_hello=1
> function hello1 { echo "${!abc_@}"; }
> hello1
> hello1
> ```
> 
> ```console
> $ osh test3.sh
> abc_hello
>   function hello1 { echo "${!abc_@}"; }
>                              ^~~~
> test3.sh:4: fatal: Bad indirect expansion: ''
> ```
