### PR TITLE
Implement printf %()T %.s %*s %.*s

### DIFF
--- a/frontend/id_kind_def.py
+++ b/frontend/id_kind_def.py
@@ -485,7 +485,7 @@ def AddKinds(spec):
   spec.AddKind('Format', [
       'EscapedPercent',
       'Percent',  # starts another lexer mode
-      'Flag', 'Num', 'Dot', 'Type',
+      'Flag', 'Num', 'Dot', 'Type', 'Star', 'Time', 'Zero',
   ])
 
   # For parsing prompt strings like PS1.

--- a/frontend/lexer_def.py
+++ b/frontend/lexer_def.py
@@ -535,8 +535,8 @@ LEXER_DEF[lex_mode_e.PrintfPercent] = [
   R('[1-9][0-9]*', Id.Format_Num),
   C('.', Id.Format_Dot),
   # We support dsq.  The others we parse to display an error message.
-  R('[disqbcouxXeEfFgG]', Id.Format_Type),
-  R(r'[^\0]', Id.Unknown_Tok),  # any otehr char
+  R('[disqbcouxXeEfFgG]|\([^()]*\)T', Id.Format_Type),
+  R(r'[^\0]', Id.Unknown_Tok),  # any other char
 ]
 
 LEXER_DEF[lex_mode_e.VSub_1] = [

--- a/frontend/lexer_def.py
+++ b/frontend/lexer_def.py
@@ -532,7 +532,7 @@ LEXER_DEF[lex_mode_e.PrintfPercent] = [
   # Flags
   R('[-0 +#]', Id.Format_Flag),
 
-  R('[1-9][0-9]*', Id.Format_Num),
+  R('[1-9][0-9]*|\*', Id.Format_Num),
   C('.', Id.Format_Dot),
   # We support dsq.  The others we parse to display an error message.
   R('[disqbcouxXeEfFgG]|\([^()]*\)T', Id.Format_Type),

--- a/frontend/lexer_def.py
+++ b/frontend/lexer_def.py
@@ -530,12 +530,15 @@ LEXER_DEF[lex_mode_e.PrintfOuter] = _C_STRING_COMMON + [
 # Maybe: bash also supports %(strftime)T
 LEXER_DEF[lex_mode_e.PrintfPercent] = [
   # Flags
-  R('[-0 +#]', Id.Format_Flag),
+  R('[- +#]', Id.Format_Flag),
+  C('0', Id.Format_Zero),
 
-  R('[1-9][0-9]*|\*', Id.Format_Num),
+  R('[1-9][0-9]*', Id.Format_Num),
+  C('*', Id.Format_Star),
   C('.', Id.Format_Dot),
   # We support dsq.  The others we parse to display an error message.
-  R('[disqbcouxXeEfFgG]|\([^()]*\)T', Id.Format_Type),
+  R('[disqbcouxXeEfFgG]', Id.Format_Type),
+  R('\([^()]*\)T', Id.Format_Time),
   R(r'[^\0]', Id.Unknown_Tok),  # any other char
 ]
 

--- a/frontend/syntax.asdl
+++ b/frontend/syntax.asdl
@@ -349,7 +349,7 @@ module syntax
     Literal(Token token)
     -- flags are 0 hyphen space + #
     -- type is 's' for %s, etc.
-  | Percent(Token? flag, Token? width, Token? precision, Token type)
+  | Percent(Token* flags, Token? width, Token? precision, Token type)
 
   --
   -- OIL LANGUAGE

--- a/osh/builtin_printf.py
+++ b/osh/builtin_printf.py
@@ -87,9 +87,13 @@ class _FormatStringParser(object):
       self._Next(lex_mode_e.PrintfPercent)
 
     if self.token_type == Id.Format_Dot:
+      dot_spid = self.cur_token.span_id
       self._Next(lex_mode_e.PrintfPercent)  # past dot
-      part.precision = self.cur_token
-      self._Next(lex_mode_e.PrintfPercent)
+      if self.token_type == Id.Format_Num or self.cur_token.val == '0':
+        part.precision = self.cur_token
+        self._Next(lex_mode_e.PrintfPercent)
+      else:
+        part.precision = Token(Id.Format_Num, dot_spid, '0')
 
     if self.token_type == Id.Format_Type:
       part.type = self.cur_token

--- a/osh/builtin_printf.py
+++ b/osh/builtin_printf.py
@@ -48,7 +48,9 @@ class _FormatStringParser(object):
   """
   Grammar:
 
-    fmt           = Format_Percent Flag? Num? (Dot Num)? Type
+    width         = Num | Star
+    precision     = Dot (Num | Star | Zero)?
+    fmt           = Percent (Flag | Zero)* width? precision? (Type | Time)
     part          = Char_* | Format_EscapedPercent | fmt
     printf_format = part* Eof_Real   # we're using the main lexer
 

--- a/osh/builtin_printf.py
+++ b/osh/builtin_printf.py
@@ -115,7 +115,7 @@ class _FormatStringParser(object):
       p_die(msg, token=self.cur_token)
 
     # Do this check AFTER the floating point checks
-    if part.precision and part.type.val not in 'fs':
+    if part.precision and part.type.val[-1] not in 'fsT':
       p_die("precision can't be specified when here",
             token=part.precision)
 
@@ -329,6 +329,8 @@ class Printf(object):
               elif d == -2: # shell start time
                 d = shell_start_time
               s = time.strftime(typ[1:-2], time.localtime(d));
+              if precision is not None:
+                s = s[:precision]  # truncate
 
             else:
               raise AssertionError()

--- a/osh/builtin_printf.py
+++ b/osh/builtin_printf.py
@@ -8,7 +8,7 @@ from _devbuild.gen.id_kind_asdl import Id, Kind
 from _devbuild.gen.runtime_asdl import cmd_value__Argv, value_e, value__Str
 from _devbuild.gen.syntax_asdl import (
     printf_part, printf_part_t,
-    source, Token
+    source,
 )
 from _devbuild.gen.types_asdl import lex_mode_e, lex_mode_t
 
@@ -89,13 +89,11 @@ class _FormatStringParser(object):
       self._Next(lex_mode_e.PrintfPercent)
 
     if self.token_type == Id.Format_Dot:
-      dot_spid = self.cur_token.span_id
+      part.precision = self.cur_token
       self._Next(lex_mode_e.PrintfPercent)  # past dot
       if self.token_type in (Id.Format_Num, Id.Format_Star, Id.Format_Zero):
         part.precision = self.cur_token
         self._Next(lex_mode_e.PrintfPercent)
-      else:
-        part.precision = Token(Id.Format_Num, dot_spid, '0')
 
     if self.token_type in (Id.Format_Type, Id.Format_Time):
       part.type = self.cur_token
@@ -241,7 +239,10 @@ class Printf(object):
 
           precision = None
           if part.precision:
-            if part.precision.id in (Id.Format_Num, Id.Format_Zero):
+            if part.precision.id == Id.Format_Dot:
+              precision = '0'
+              precision_spid = part.precision.span_id
+            elif part.precision.id in (Id.Format_Num, Id.Format_Zero):
               precision = part.precision.val
               precision_spid = part.precision.span_id
             elif part.precision.id == Id.Format_Star:

--- a/spec/builtin-printf.test.sh
+++ b/spec/builtin-printf.test.sh
@@ -515,17 +515,22 @@ printf '[% d]\n' -42
 
 #### printf # flag
 # I didn't know these existed -- I only knew about - and 0 !
-printf '[%#o]\n' 42
-printf '[%#x]\n' 42
-printf '[%#X]\n' 42
+# Note: '#' flag for integers outputs a prefix ONLY WHEN the value is non-zero
+printf '[%#o][%#o]\n' 0 42
+printf '[%#x][%#x]\n' 0 42
+printf '[%#X][%#X]\n' 0 42
 echo ---
-printf '[%#f]\n' 3
+# Note: '#' flag for %f, %g always outputs the decimal point.
+printf '[%.0f][%#.0f]\n' 3 3
+# Note: In addition, '#' flag for %g does not omit zeroes in fraction
+printf '[%g][%#g]\n' 3 3
 ## STDOUT:
-[052]
-[0x2a]
-[0X2A]
+[0][052]
+[0][0x2a]
+[0][0X2A]
 ---
-[3.000000]
+[3][3.]
+[3][3.00000]
 ## END
 ## N-I osh STDOUT:
 ---

--- a/spec/builtin-printf.test.sh
+++ b/spec/builtin-printf.test.sh
@@ -584,3 +584,19 @@ status=0
 ## N-I dash/mksh/zsh/ash STDOUT:
 status=1
 ## END
+
+#### %10.5(strftime format)T
+# The result depends on timezone
+export TZ=Asia/Tokyo
+printf '[%10.5(%Y-%m-%d)T]\n' 1557978599
+export TZ=US/Eastern
+printf '[%10.5(%Y-%m-%d)T]\n' 1557978599
+echo status=$?
+## STDOUT:
+[     2019-]
+[     2019-]
+status=0
+## END
+## N-I dash/mksh/zsh/ash STDOUT:
+[[status=1
+## END

--- a/spec/builtin-printf.test.sh
+++ b/spec/builtin-printf.test.sh
@@ -219,6 +219,16 @@ printf '[%0.0s]\n' foo
 ## N-I mksh stdout-json: "[      ]\n["
 ## N-I mksh status: 1
 
+#### printf %6.s and %0.s
+printf '[%6.s]\n' foo
+printf '[%0.s]\n' foo
+## STDOUT:
+[      ]
+[]
+## END
+## N-I mksh stdout-json: "[      ]\n["
+## N-I mksh status: 1
+
 #### unsigned / octal / hex
 printf '[%u]\n' 42
 printf '[%o]\n' 42

--- a/spec/builtin-printf.test.sh
+++ b/spec/builtin-printf.test.sh
@@ -229,6 +229,20 @@ printf '[%0.s]\n' foo
 ## N-I mksh stdout-json: "[      ]\n["
 ## N-I mksh status: 1
 
+#### printf %*.*s (width/precision from args)
+printf '[%*s]\n' 9 hello
+printf '[%.*s]\n' 3 hello
+printf '[%*.3s]\n' 9 hello
+printf '[%9.*s]\n' 3 hello
+printf '[%*.*s]\n' 9 3 hello
+## STDOUT:
+[    hello]
+[hel]
+[      hel]
+[      hel]
+[      hel]
+## END
+
 #### unsigned / octal / hex
 printf '[%u]\n' 42
 printf '[%o]\n' 42

--- a/spec/builtin-printf.test.sh
+++ b/spec/builtin-printf.test.sh
@@ -541,15 +541,17 @@ status=1
 ## END
 
 #### %(strftime format)T
+# The result depends on timezone
+export TZ=Asia/Tokyo
+printf '%(%Y-%m-%d)T\n' 1557978599
+export TZ=US/Eastern
 printf '%(%Y-%m-%d)T\n' 1557978599
 echo status=$?
 ## STDOUT:
+2019-05-16
 2019-05-15
 status=0
 ## END
 ## N-I dash/mksh/zsh/ash STDOUT:
 status=1
-## END
-## N-I osh STDOUT:
-status=2
 ## END


### PR DESCRIPTION
Resolve #650

- 44d5af8e: Support `%()T`
- 8142a783: Support `%6.s` (fix parsing of precision)
- 99ead0e7: Support `%*.*s`
- c5d87362: Update test case for `#` flag

## Note on `%()T`

In the implementation of `%()T`, I needed to reflect the exported shell variable `TZ` in the real environment variable `TZ`. [This](https://github.com/oilshell/oil/blob/44d5af8e/osh/builtin_printf.py#L261-L268) is the corresponding section. I'm not sure whether I did this in the right way. (Maybe a new method like `self.mem.GetExportedVar(name)` should be added to `class Mem`). Could you check and edit if necessary?


## Note on `%6.s`

In the current master branch, the parsing of `%6.s` is broken to generate the following errors (`s` is treated as a precision), so I added a check for the precision and treat missing precision as `0` (as POSIX requirements).

```sh
osh$ printf '%6.s\n' a
  %6.s\n
      ^
(source.ArgvWord word_spid:2):1: Invalid printf format character
osh$ printf '%6.ss\n' a
Traceback (most recent call last):
  File "/home/murase/prog/ext-github/oilshell.oil/bin/oil.py", line 965, in <module>
    sys.exit(main(sys.argv))
  File "/home/murase/prog/ext-github/oilshell.oil/bin/oil.py", line 911, in main
    return AppBundleMain(argv)
  File "/home/murase/prog/ext-github/oilshell.oil/bin/oil.py", line 884, in AppBundleMain
    status = ShellMain('osh', argv0, main_argv, login_shell)
  File "/home/murase/prog/ext-github/oilshell.oil/bin/oil.py", line 686, in ShellMain
    prompt_plugin, errfmt)
  File "/home/murase/prog/ext-github/oilshell.oil/core/main_loop.py", line 95, in Interactive
    is_return, _ = ex.ExecuteAndCatch(node)
  File "/home/murase/prog/ext-github/oilshell.oil/osh/cmd_exec.py", line 1862, in ExecuteAndCatch
    status = self._Execute(node, fork_external=fork_external)
  File "/home/murase/prog/ext-github/oilshell.oil/osh/cmd_exec.py", line 1807, in _Execute
    status, check_errexit = self._Dispatch(node, fork_external)
  File "/home/murase/prog/ext-github/oilshell.oil/osh/cmd_exec.py", line 1061, in _Dispatch
    status = self._RunSimpleCommand(cmd_val, fork_external)
  File "/home/murase/prog/ext-github/oilshell.oil/osh/cmd_exec.py", line 802, in _RunSimpleCommand
    return self.RunSimpleCommand(cmd_val, fork_external)
  File "/home/murase/prog/ext-github/oilshell.oil/osh/cmd_exec.py", line 890, in RunSimpleCommand
    return self._RunBuiltin(builtin_id, cmd_val, fork_external)
  File "/home/murase/prog/ext-github/oilshell.oil/osh/cmd_exec.py", line 524, in _RunBuiltin
    status = self._RunBuiltinAndRaise(builtin_id, cmd_val, fork_external)
  File "/home/murase/prog/ext-github/oilshell.oil/osh/cmd_exec.py", line 467, in _RunBuiltinAndRaise
    status = builtin_func.Run(cmd_val)
  File "/home/murase/prog/ext-github/oilshell.oil/osh/builtin_printf.py", line 218, in Run
    precision = int(part.precision.val)
ValueError: invalid literal for int() with base 10: 's'
```

## Note on `printf # flag `

The tests for flag `#` in the current master branch doesn't fully describe the behavior, so I added and modified tests.
