### PR TITLE
[builtin/declare] Support -p

### DIFF
--- a/core/state.py
+++ b/core/state.py
@@ -1387,10 +1387,10 @@ class Mem(object):
 
     return value.Undef()
 
-  def GetCell(self, name):
+  def GetCell(self, name, lookup_mode = scope_e.Dynamic):
     # type: (str) -> cell
     """For the 'repr' builtin."""
-    cell, _ = self._ResolveNameOnly(name, scope_e.Dynamic)
+    cell, _ = self._ResolveNameOnly(name, lookup_mode)
     return cell
 
   def Unset(self, lval, lookup_mode):
@@ -1497,6 +1497,31 @@ class Mem(object):
           result[name] = str_val.s
     return result
 
+  def GetAllCells(self, lookup_mode = scope_e.Dynamic):
+    # type: () -> Dict[str, cell]
+    """Get all variables and their values, for 'set' builtin. """
+    result = {}  # type: Dict[str, str]
+
+    if lookup_mode == scope_e.Dynamic:
+      scopes = self.var_stack
+    elif lookup_mode == scope_e.LocalOnly:
+      scopes = self.var_stack[-1:]
+    elif lookup_mode == scope_e.GlobalOnly:
+      scopes = self.var_stack[0:1]
+    elif lookup_mode == scope_e.LocalOrGlobal:
+      scopes = self.var_stack[0:1]
+      if len(self.var_stack) > 1:
+        scopes.append(self.var_stack[-1])
+    else:
+      raise AssertionError()
+
+    for scope in scopes:
+      for name, cell in iteritems(scope):
+        result[name] = cell
+    return result
+
+  def IsGlobalScope(self):
+    return len(self.var_stack) == 1
 
 def SetLocalString(mem, name, s):
   # type: (Mem, str, str) -> None

--- a/core/state.py
+++ b/core/state.py
@@ -1388,7 +1388,7 @@ class Mem(object):
     return value.Undef()
 
   def GetCell(self, name, lookup_mode = scope_e.Dynamic):
-    # type: (str) -> cell
+    # type: (str, scope_t) -> cell
     """For the 'repr' builtin."""
     cell, _ = self._ResolveNameOnly(name, lookup_mode)
     return cell
@@ -1498,7 +1498,7 @@ class Mem(object):
     return result
 
   def GetAllCells(self, lookup_mode = scope_e.Dynamic):
-    # type: () -> Dict[str, cell]
+    # type: (scope_t) -> Dict[str, cell]
     """Get all variables and their values, for 'set' builtin. """
     result = {}  # type: Dict[str, str]
 
@@ -1521,6 +1521,7 @@ class Mem(object):
     return result
 
   def IsGlobalScope(self):
+    # type: () -> bool
     return len(self.var_stack) == 1
 
 def SetLocalString(mem, name, s):

--- a/core/state.py
+++ b/core/state.py
@@ -1387,7 +1387,7 @@ class Mem(object):
 
     return value.Undef()
 
-  def GetCell(self, name, lookup_mode = scope_e.Dynamic):
+  def GetCell(self, name, lookup_mode=scope_e.Dynamic):
     # type: (str, scope_t) -> cell
     """For the 'repr' builtin."""
     cell, _ = self._ResolveNameOnly(name, lookup_mode)
@@ -1497,7 +1497,7 @@ class Mem(object):
           result[name] = str_val.s
     return result
 
-  def GetAllCells(self, lookup_mode = scope_e.Dynamic):
+  def GetAllCells(self, lookup_mode=scope_e.Dynamic):
     # type: (scope_t) -> Dict[str, cell]
     """Get all variables and their values, for 'set' builtin. """
     result = {}  # type: Dict[str, str]

--- a/osh/builtin_assign.py
+++ b/osh/builtin_assign.py
@@ -26,7 +26,7 @@ if mylib.PYTHON:
   from frontend import arg_def
 
 
-def _PrintVariables(mem, cmd_val, arg, print_flags, readonly = False, exported = False):
+def _PrintVariables(mem, cmd_val, arg, print_flags, readonly=False, exported=False):
   # type: (Mem, value_t, Any, bool, bool, bool) -> int
   flag_g = getattr(arg, 'g', None)
   flag_n = getattr(arg, 'n', None)
@@ -173,7 +173,7 @@ class Export(object):
           "doesn't accept -f because it's dangerous.  (The code can usually be restructured with 'source')")
 
     if arg.p or len(cmd_val.pairs) == 0:
-      return _PrintVariables(self.mem, cmd_val, arg, True, exported = True)
+      return _PrintVariables(self.mem, cmd_val, arg, True, exported=True)
 
     positional = cmd_val.argv[arg_index:]
     if arg.n:
@@ -243,7 +243,7 @@ class Readonly(object):
     arg, arg_index = READONLY_SPEC.Parse(arg_r)
 
     if arg.p or len(cmd_val.pairs) == 0:
-      return _PrintVariables(self.mem, cmd_val, arg, True, readonly = True)
+      return _PrintVariables(self.mem, cmd_val, arg, True, readonly=True)
 
     for pair in cmd_val.pairs:
       if pair.rval is None:

--- a/osh/builtin_assign.py
+++ b/osh/builtin_assign.py
@@ -27,6 +27,7 @@ if mylib.PYTHON:
 
 
 def _PrintVariables(mem, cmd_val, arg, print_flags, readonly = False, exported = False):
+  # type: (Mem, value_t, Any, bool, bool, bool) -> int
   flag_g = getattr(arg, 'g', None)
   flag_n = getattr(arg, 'n', None)
   flag_r = getattr(arg, 'r', None)

--- a/osh/builtin_assign.py
+++ b/osh/builtin_assign.py
@@ -53,7 +53,7 @@ def _PrintVariables(mem, cmd_val, arg, print_flags, readonly=False, exported=Fal
     cells = {}
     for pair in cmd_val.pairs:
       name = pair.lval.name
-      if pair.rval and pair.rval.tag == value_e.Str:
+      if pair.rval and pair.rval.tag_() == value_e.Str:
         name += "=" + cast(value__Str, pair.rval).s
         names.append(name)
         cells[name] = None
@@ -67,7 +67,7 @@ def _PrintVariables(mem, cmd_val, arg, print_flags, readonly=False, exported=Fal
     if cell is None: continue
     val = cell.val
 
-    if val.tag == value_e.Undef: continue
+    if val.tag_() == value_e.Undef: continue
     if readonly and not cell.readonly: continue
     if exported and not cell.exported: continue
     if flag_n == '-' and not cell.nameref: continue
@@ -76,17 +76,17 @@ def _PrintVariables(mem, cmd_val, arg, print_flags, readonly=False, exported=Fal
     if flag_r == '+' and cell.readonly: continue
     if flag_x == '-' and not cell.exported: continue
     if flag_x == '+' and cell.exported: continue
-    if flag_a and val.tag != value_e.MaybeStrArray: continue
-    if flag_A and val.tag != value_e.AssocArray: continue
+    if flag_a and val.tag_() != value_e.MaybeStrArray: continue
+    if flag_A and val.tag_() != value_e.AssocArray: continue
 
     if print_flags:
       flags = '-'
       if cell.nameref: flags += 'n'
       if cell.readonly: flags += 'r'
       if cell.exported: flags += 'x'
-      if val.tag == value_e.MaybeStrArray:
+      if val.tag_() == value_e.MaybeStrArray:
         flags += 'a'
-      elif val.tag == value_e.AssocArray:
+      elif val.tag_() == value_e.AssocArray:
         flags += 'A'
       if flags == '-': flags += '-'
 
@@ -94,10 +94,10 @@ def _PrintVariables(mem, cmd_val, arg, print_flags, readonly=False, exported=Fal
     else:
       decl = name
 
-    if val.tag == value_e.Str:
+    if val.tag_() == value_e.Str:
       str_val = cast(value__Str, val)
       decl += "=" + string_ops.ShellQuote(str_val.s)
-    elif val.tag == value_e.MaybeStrArray:
+    elif val.tag_() == value_e.MaybeStrArray:
       array_val = cast(value__MaybeStrArray, val)
       if None in array_val.strs:
         # Note: Arrays with unset elements are printed in the form:
@@ -116,7 +116,7 @@ def _PrintVariables(mem, cmd_val, arg, print_flags, readonly=False, exported=Fal
           if body: body += ' '
           body += string_ops.ShellQuote(element or '')
         decl += "=(" + body + ")"
-    elif val.tag == value_e.AssocArray:
+    elif val.tag_() == value_e.AssocArray:
       assoc_val = cast(value__AssocArray, val)
       body = ''
       for key in sorted(assoc_val.d):

--- a/osh/string_ops.py
+++ b/osh/string_ops.py
@@ -438,7 +438,7 @@ def ShellQuote(s):
   It doesn't necessarily match bash byte-for-byte.  IIRC bash isn't consistent
   with it anyway.
 
-  Used for 'printf %q', ${x@Q}, and 'set'.
+  Used for 'printf %q', ${x@Q}, 'set', and `declare -p`.
   """
   # Could be made slightly nicer by e.g. returning unmodified when
   # there's nothing that needs to be quoted.  Bash's `printf %q`

--- a/spec/assign-extended.test.sh
+++ b/spec/assign-extended.test.sh
@@ -290,7 +290,7 @@ declare -A test_arr3
 declare -a test_arr4=('1' '2' '3')
 declare -a test_arr5=('1' '2' '3')
 declare -A test_arr6=(['a']='1' ['b']='2' ['c']='3')
-declare -a test_arr7=('' '' '' 'foo')
+declare -a test_arr7=(); test_arr7[3]='foo'
 ## END
 ## OK bash STDOUT:
 declare -a test_arr1=()

--- a/spec/assign-extended.test.sh
+++ b/spec/assign-extended.test.sh
@@ -459,6 +459,48 @@ declare -- test_var1="local"
 ## N-I mksh stdout-json: ""
 ## N-I mksh status: 1
 
+#### ble.sh: eval -- "$(declare -p var arr)"
+# This illustrates an example usage of "eval & declare" for exporting
+# multiple variables from $().
+eval -- "$(
+  printf '%s\n' a{1..10} | {
+    sum=0 i=0 arr=()
+    while read line; do
+      ((sum+=${#line},i++))
+      arr[$((i/3))]=$line
+    done
+    declare -p sum arr
+  })"
+echo sum=$sum
+for ((i=0;i<${#arr[@]};i++)); do
+  echo "arr[$i]=${arr[i]}"
+done
+## STDOUT:
+sum=21
+arr[0]=a2
+arr[1]=a5
+arr[2]=a8
+arr[3]=a10
+## END
+## N-I mksh stdout-json: ""
+## N-I mksh status: 1
+
+#### eval -- "$(declare -p arr)" (restore arrays w/ unset elements)
+arr=(1 2 3)
+eval -- "$(arr=(); arr[3]= arr[4]=foo; declare -p arr)"
+for i in {0..4}; do
+  echo "arr[$i]: ${arr[$i]+set ... [}${arr[$i]-unset}${arr[$i]+]}"
+done
+## STDOUT:
+arr[0]: unset
+arr[1]: unset
+arr[2]: unset
+arr[3]: set ... []
+arr[4]: set ... [foo]
+## END
+## N-I mksh stdout-json: ""
+## N-I mksh status: 1
+
 #### typeset -f 
 # mksh implement typeset but not declare
 typeset  -f myfunc func2


### PR DESCRIPTION
Support `declare` and `declare -p` (cf #647, but `declare -f`, `trap`, `trap -p` are not yet supported)

- Note: Bash quotes the values with double quotations, but this patch uses single quotations provided by `string_opt.ShellQuote`.
- Note: Bash ignores the flag `-g` when `-p` flag is specified, but this patch supports it.
- Note: Bash ignores the flags `-nrxaA` when `-p` flag and variable names are specified, but this patch supports them.
- Please see the changes in `spec/assign-extended.test.sh` for the detailed behavior
