### PR TITLE
[core/process] Fix/Implement redirections <>, 5>&-, 6>&5-, {fd}>file, etc.

### DIFF
--- a/bin/oil.py
+++ b/bin/oil.py
@@ -351,7 +351,7 @@ def ShellMain(lang, argv0, argv, login_shell):
   procs = {}
 
   job_state = process.JobState()
-  fd_state = process.FdState(errfmt, job_state)
+  fd_state = process.FdState(errfmt, job_state, mem)
 
   opt_hook = ShellOptHook(line_input)
   parse_opts, exec_opts, mutable_opts = state.MakeOpts(mem, opt_hook)

--- a/core/process.py
+++ b/core/process.py
@@ -315,6 +315,9 @@ class FdState(object):
             ok = False
           posix.close(target_fd)  # We already made a copy of it.
 
+        if ok:
+          self._PushClose(r.fd)
+
         # Now handle the extra redirects for aliases &> and &>>.
         #
         # We can rewrite
@@ -333,10 +336,6 @@ class FdState(object):
           elif r.op_id == Id.Redir_AndDGreat:
             if not self._PushDup(r.fd, 2):
               ok = False
-
-        # I don't think we need to close(0) because it will be restored from its
-        # saved position (10), which closes it.
-        #self._PushClose(r.fd)
 
       elif case(redirect_e.FileDesc):  # e.g. echo hi 1>&2
         r = cast(redirect__FileDesc, UP_r)

--- a/core/process.py
+++ b/core/process.py
@@ -127,7 +127,7 @@ class FdState(object):
 
   For example, you can do 'myfunc > out.txt' without forking.
   """
-  def __init__(self, errfmt, job_state, mem = None):
+  def __init__(self, errfmt, job_state, mem=None):
     # type: (ErrorFormatter, JobState, Mem) -> None
     """
     Args:

--- a/core/process.py
+++ b/core/process.py
@@ -231,7 +231,7 @@ class FdState(object):
 
     return need_restore
 
-  def _PushDup(self, fd1, fd2, fd2name = None):
+  def _PushDup(self, fd1, fd2, fd2name=None):
     # type: (int, int, string) -> bool
     """Save fd2, and dup fd1 onto fd2.
 
@@ -283,7 +283,7 @@ class FdState(object):
     self._PushSave(fd)
     return True
 
-  def _PushMoveFd(self, fd1, fd2, fd2name = None):
+  def _PushMoveFd(self, fd1, fd2, fd2name=None):
     # type: (int, int) -> bool
 
     if fd2name:
@@ -1052,7 +1052,7 @@ class Pipeline(Job):
       self.pids.append(pid)
       self.pipe_status.append(-1)  # uninitialized
 
-      # NOTE: This is done in the SHELL PROCESS after every fork() call.rr
+      # NOTE: This is done in the SHELL PROCESS after every fork() call.
       # It can't be done at the end; otherwise processes will have descriptors
       # from non-adjacent pipes.
       proc.MaybeClosePipe()

--- a/core/process.py
+++ b/core/process.py
@@ -192,7 +192,7 @@ class FdState(object):
     if self.mem is None: return None
 
     val = self.mem.GetVar(fd_name)
-    if val.tag == value_e.Str:
+    if val.tag_() == value_e.Str:
       try:
         return int(cast(value__Str, val).s)
       except ValueError:

--- a/core/process.py
+++ b/core/process.py
@@ -220,6 +220,7 @@ class FdState(object):
     Returns:
       success Bool
     """
+    if fd1 == fd2: return True
 
     need_restore = self._PushSave(fd2)
 
@@ -311,8 +312,10 @@ class FdState(object):
           return False
 
         # Apply redirect
-        if not self._PushDup(target_fd, r.fd):
-          ok = False
+        if target_fd != r.fd:
+          if not self._PushDup(target_fd, r.fd):
+            ok = False
+          posix.close(target_fd)  # We already made a copy of it.
 
         # Now handle the extra redirects for aliases &> and &>>.
         #
@@ -333,7 +336,6 @@ class FdState(object):
             if not self._PushDup(r.fd, 2):
               ok = False
 
-        posix.close(target_fd)  # We already made a copy of it.
         # I don't think we need to close(0) because it will be restored from its
         # saved position (10), which closes it.
         #self._PushClose(r.fd)

--- a/core/process.py
+++ b/core/process.py
@@ -184,9 +184,11 @@ class FdState(object):
     return f
 
   def _WriteFdToMem(self, fd_name, fd):
+    # type: (string, int) -> None
     if self.mem:
       self.mem.SetVar(lvalue.Named(fd_name), value.Str(str(fd)), scope_e.Dynamic)
   def _ReadFdFromMem(self, fd_name):
+    # type: (string) -> int?
     if self.mem is None: return None
 
     val = self.mem.GetVar(fd_name)

--- a/core/process_test.py
+++ b/core/process_test.py
@@ -17,6 +17,7 @@ from core import util
 from core.util import log
 from core import state
 from osh import builtin_misc
+from asdl import runtime
 
 Process = process.Process
 ExternalThunk = process.ExternalThunk
@@ -77,7 +78,7 @@ class ProcessTest(unittest.TestCase):
 
     # Should get the first line twice, because Pop() closes it!
 
-    r = redirect.Path(Id.Redir_Less, 0, PATH)
+    r = redirect.Path(Id.Redir_Less, 0, PATH, runtime.NO_SPID)
     fd_state.Push([r], waiter)
     line1 = builtin_misc.ReadLineFromStdin(None)
     fd_state.Pop()

--- a/core/process_test.py
+++ b/core/process_test.py
@@ -78,7 +78,7 @@ class ProcessTest(unittest.TestCase):
 
     # Should get the first line twice, because Pop() closes it!
 
-    r = redirect.Path(Id.Redir_Less, 0, PATH, runtime.NO_SPID)
+    r = redirect.Path(Id.Redir_Less, 0, None, PATH, runtime.NO_SPID)
     fd_state.Push([r], waiter)
     line1 = builtin_misc.ReadLineFromStdin(None)
     fd_state.Pop()

--- a/core/process_test.py
+++ b/core/process_test.py
@@ -78,7 +78,7 @@ class ProcessTest(unittest.TestCase):
 
     # Should get the first line twice, because Pop() closes it!
 
-    r = redirect.Path(Id.Redir_Less, 0, None, PATH, runtime.NO_SPID)
+    r = redirect.Path(Id.Redir_Less, '0', PATH, runtime.NO_SPID)
     fd_state.Push([r], waiter)
     line1 = builtin_misc.ReadLineFromStdin(None)
     fd_state.Pop()

--- a/frontend/consts.py
+++ b/frontend/consts.py
@@ -59,7 +59,7 @@ REDIR_DEFAULT_FD = {
     Id.Redir_Great: 1,
     Id.Redir_DGreat: 1,
     Id.Redir_Clobber: 1,
-    Id.Redir_LessGreat: 1,  # TODO: What does echo <>foo do?
+    Id.Redir_LessGreat: 0,  # 'exec <> foo' opens a file with read/write
     # bash &> and &>>
     Id.Redir_AndGreat: 1,
     Id.Redir_AndDGreat: 1,

--- a/frontend/lexer_def.py
+++ b/frontend/lexer_def.py
@@ -259,6 +259,7 @@ def IsKeyword(name):
   # type: (str) -> bool
   return name in OSH_KEYWORD_NAMES
 
+FD_VAR_NAME = r'\{' + VAR_NAME_RE + r'\}'
 
 # These two can must be recognized in the Outer state, but can't nested within
 # [[.
@@ -303,16 +304,16 @@ LEXER_DEF[lex_mode_e.ShCommand] = [
   R(r'[0-9]*<>', Id.Redir_LessGreat),
   R(r'[0-9]*>\|', Id.Redir_Clobber),
 
-  R(r'\{[_a-zA-Z][_a-zA-Z0-9]*\}<', Id.Redir_Less),
-  R(r'\{[_a-zA-Z][_a-zA-Z0-9]*\}>', Id.Redir_Great),
-  R(r'\{[_a-zA-Z][_a-zA-Z0-9]*\}<<', Id.Redir_DLess),
-  R(r'\{[_a-zA-Z][_a-zA-Z0-9]*\}<<<', Id.Redir_TLess),
-  R(r'\{[_a-zA-Z][_a-zA-Z0-9]*\}>>', Id.Redir_DGreat),
-  R(r'\{[_a-zA-Z][_a-zA-Z0-9]*\}<<-', Id.Redir_DLessDash),
-  R(r'\{[_a-zA-Z][_a-zA-Z0-9]*\}>&', Id.Redir_GreatAnd),
-  R(r'\{[_a-zA-Z][_a-zA-Z0-9]*\}<&', Id.Redir_LessAnd),
-  R(r'\{[_a-zA-Z][_a-zA-Z0-9]*\}<>', Id.Redir_LessGreat),
-  R(r'\{[_a-zA-Z][_a-zA-Z0-9]*\}>\|', Id.Redir_Clobber),
+  R(FD_VAR_NAME + r'<', Id.Redir_Less),
+  R(FD_VAR_NAME + r'>', Id.Redir_Great),
+  R(FD_VAR_NAME + r'<<', Id.Redir_DLess),
+  R(FD_VAR_NAME + r'<<<', Id.Redir_TLess),
+  R(FD_VAR_NAME + r'>>', Id.Redir_DGreat),
+  R(FD_VAR_NAME + r'<<-', Id.Redir_DLessDash),
+  R(FD_VAR_NAME + r'>&', Id.Redir_GreatAnd),
+  R(FD_VAR_NAME + r'<&', Id.Redir_LessAnd),
+  R(FD_VAR_NAME + r'<>', Id.Redir_LessGreat),
+  R(FD_VAR_NAME + r'>\|', Id.Redir_Clobber),
 
   # No leading descriptor (2 is implied)
   C(r'&>', Id.Redir_AndGreat),

--- a/frontend/lexer_def.py
+++ b/frontend/lexer_def.py
@@ -303,6 +303,17 @@ LEXER_DEF[lex_mode_e.ShCommand] = [
   R(r'[0-9]*<>', Id.Redir_LessGreat),
   R(r'[0-9]*>\|', Id.Redir_Clobber),
 
+  R(r'\{[_a-zA-Z][_a-zA-Z0-9]*\}<', Id.Redir_Less),
+  R(r'\{[_a-zA-Z][_a-zA-Z0-9]*\}>', Id.Redir_Great),
+  R(r'\{[_a-zA-Z][_a-zA-Z0-9]*\}<<', Id.Redir_DLess),
+  R(r'\{[_a-zA-Z][_a-zA-Z0-9]*\}<<<', Id.Redir_TLess),
+  R(r'\{[_a-zA-Z][_a-zA-Z0-9]*\}>>', Id.Redir_DGreat),
+  R(r'\{[_a-zA-Z][_a-zA-Z0-9]*\}<<-', Id.Redir_DLessDash),
+  R(r'\{[_a-zA-Z][_a-zA-Z0-9]*\}>&', Id.Redir_GreatAnd),
+  R(r'\{[_a-zA-Z][_a-zA-Z0-9]*\}<&', Id.Redir_LessAnd),
+  R(r'\{[_a-zA-Z][_a-zA-Z0-9]*\}<>', Id.Redir_LessGreat),
+  R(r'\{[_a-zA-Z][_a-zA-Z0-9]*\}>\|', Id.Redir_Clobber),
+
   # No leading descriptor (2 is implied)
   C(r'&>', Id.Redir_AndGreat),
   C(r'&>>', Id.Redir_AndDGreat),

--- a/frontend/syntax.asdl
+++ b/frontend/syntax.asdl
@@ -239,8 +239,8 @@ module syntax
   | LogicalOr(bool_expr left, bool_expr right)
 
   redir = 
-    Redir(Token op, int fd, word arg_word)
-  | HereDoc(Token op, int fd,
+    Redir(Token op, int fd, string? fd_name, word arg_word)
+  | HereDoc(Token op, int fd, string? fd_name,
             word here_begin,  -- e.g. EOF or 'EOF'
             int here_end_span_id,  -- this span is an entire line
             word_part* stdin_parts -- one for each line

--- a/frontend/syntax.asdl
+++ b/frontend/syntax.asdl
@@ -239,8 +239,8 @@ module syntax
   | LogicalOr(bool_expr left, bool_expr right)
 
   redir = 
-    Redir(Token op, int fd, string? fd_name, word arg_word)
-  | HereDoc(Token op, int fd, string? fd_name,
+    Redir(Token op, string fdspec, word arg_word)
+  | HereDoc(Token op, string fdspec,
             word here_begin,  -- e.g. EOF or 'EOF'
             int here_end_span_id,  -- this span is an entire line
             word_part* stdin_parts -- one for each line

--- a/osh/cmd_exec.py
+++ b/osh/cmd_exec.py
@@ -639,7 +639,10 @@ class Executor(object):
 
         # note: needed for redirect like 'echo foo > x$LINENO'
         self.mem.SetCurrentSpanId(n.op.span_id)
-        fd = consts.RedirDefaultFd(n.op.id) if n.fd == runtime.NO_SPID else n.fd
+        fd = n.fd
+        fd_name = n.fd_name
+        if fd == runtime.NO_SPID and not fd_name:
+          fd = consts.RedirDefaultFd(n.op.id)
 
         redir_type = consts.RedirArgType(n.op.id)  # could be static in the LST?
 
@@ -654,7 +657,7 @@ class Executor(object):
             raise error.RedirectEval(
                 "Redirect filename can't be empty", word=n.arg_word)
 
-          return redirect.Path(n.op.id, fd, filename, n.op.span_id)
+          return redirect.Path(n.op.id, fd, fd_name, filename, n.op.span_id)
 
         elif redir_type == redir_arg_type_e.Desc:  # e.g. 1>&2, 1>&-, 1>&2-
           val = self.word_ev.EvalWordToString(n.arg_word)
@@ -666,13 +669,13 @@ class Executor(object):
 
           try:
             if t == '-':
-              return redirect.CloseFd(n.op.id, fd, n.op.span_id)
+              return redirect.CloseFd(n.op.id, fd, fd_name, n.op.span_id)
             elif t[-1] == '-':
               target_fd = int(t[:-1])
-              return redirect.MoveFd(n.op.id, fd, target_fd, n.op.span_id)
+              return redirect.MoveFd(n.op.id, fd, fd_name, target_fd, n.op.span_id)
             else:
               target_fd = int(t)
-              return redirect.FileDesc(n.op.id, fd, target_fd, n.op.span_id)
+              return redirect.FileDesc(n.op.id, fd, fd_name, target_fd, n.op.span_id)
           except ValueError:
             raise error.RedirectEval(
                 "Redirect descriptor should look like an integer, '-', or an integer + '-', got %s", val,
@@ -683,18 +686,21 @@ class Executor(object):
           val = self.word_ev.EvalWordToString(n.arg_word)
           assert val.tag == value_e.Str, val
           # NOTE: bash and mksh both add \n
-          return redirect.HereDoc(fd, val.s + '\n', n.op.span_id)
+          return redirect.HereDoc(fd, fd_name, val.s + '\n', n.op.span_id)
         else:
           raise AssertionError('Unknown redirect op')
 
       elif case(redir_e.HereDoc):
         n = cast(redir__HereDoc, UP_n)
-        fd = consts.RedirDefaultFd(n.op.id) if n.fd == runtime.NO_SPID else n.fd
+        fd = n.fd
+        fd_name = n.fd_name
+        if fd == runtime.NO_SPID and fd_name is None:
+          fd = consts.RedirDefaultFd(n.op.id)
         # HACK: Wrap it in a word to evaluate.
         w = compound_word(n.stdin_parts)
         val = self.word_ev.EvalWordToString(w)
         assert val.tag == value_e.Str, val
-        return redirect.HereDoc(fd, val.s, n.op.span_id)
+        return redirect.HereDoc(fd, fd_name, val.s, n.op.span_id)
 
       else:
         raise AssertionError('Unknown redirect type')

--- a/osh/cmd_exec.py
+++ b/osh/cmd_exec.py
@@ -641,7 +641,7 @@ class Executor(object):
         self.mem.SetCurrentSpanId(n.op.span_id)
         fd = n.fd
         fd_name = n.fd_name
-        if fd == runtime.NO_SPID and not fd_name:
+        if fd == process.NO_FD and not fd_name:
           fd = consts.RedirDefaultFd(n.op.id)
 
         redir_type = consts.RedirArgType(n.op.id)  # could be static in the LST?
@@ -694,7 +694,7 @@ class Executor(object):
         n = cast(redir__HereDoc, UP_n)
         fd = n.fd
         fd_name = n.fd_name
-        if fd == runtime.NO_SPID and fd_name is None:
+        if fd == process.NO_FD and fd_name is None:
           fd = consts.RedirDefaultFd(n.op.id)
         # HACK: Wrap it in a word to evaluate.
         w = compound_word(n.stdin_parts)

--- a/osh/cmd_exec.py
+++ b/osh/cmd_exec.py
@@ -684,7 +684,7 @@ class Executor(object):
 
         elif redir_type == redir_arg_type_e.Here:  # here word
           val = self.word_ev.EvalWordToString(n.arg_word)
-          assert val.tag == value_e.Str, val
+          assert val.tag_() == value_e.Str, val
           # NOTE: bash and mksh both add \n
           return redirect.HereDoc(fd, fd_name, val.s + '\n', n.op.span_id)
         else:
@@ -699,7 +699,7 @@ class Executor(object):
         # HACK: Wrap it in a word to evaluate.
         w = compound_word(n.stdin_parts)
         val = self.word_ev.EvalWordToString(w)
-        assert val.tag == value_e.Str, val
+        assert val.tag_() == value_e.Str, val
         return redirect.HereDoc(fd, fd_name, val.s, n.op.span_id)
 
       else:
@@ -827,7 +827,7 @@ class Executor(object):
     Args:
       fork_external: for subshell ( ls / ) or ( command ls / )
     """
-    assert cmd_val.tag == cmd_value_e.Argv
+    assert cmd_val.tag_() == cmd_value_e.Argv
 
     argv = cmd_val.argv
     span_id = cmd_val.arg_spids[0] if cmd_val.arg_spids else runtime.NO_SPID
@@ -890,7 +890,7 @@ class Executor(object):
       UP_val = self.mem.GetVar(arg0)
 
       if mylib.PYTHON:  # Not reusing CPython objects
-        if UP_val.tag == value_e.Obj:
+        if UP_val.tag_() == value_e.Obj:
           val = cast(value__Obj, UP_val)
           if isinstance(val.obj, objects.Proc):
             status = self._RunOilProc(val.obj, argv[1:])
@@ -1391,7 +1391,7 @@ class Executor(object):
 
         if node.arg_word:  # Evaluate the argument
           val = self.word_ev.EvalWordToString(node.arg_word)
-          assert val.tag == value_e.Str
+          assert val.tag_() == value_e.Str
           try:
             arg = int(val.s)  # They all take integers
           except ValueError:
@@ -1640,7 +1640,7 @@ class Executor(object):
         node = cast(command__Proc, UP_node)
         if mylib.PYTHON:
           UP_proc_sig = node.sig
-          if UP_proc_sig.tag == proc_sig_e.Closed:
+          if UP_proc_sig.tag_() == proc_sig_e.Closed:
             proc_sig = cast(proc_sig__Closed, UP_proc_sig)
             defaults = [None] * len(proc_sig.params)
             for i, param in enumerate(proc_sig.params):

--- a/osh/cmd_parse.py
+++ b/osh/cmd_parse.py
@@ -37,6 +37,7 @@ from _devbuild.gen import syntax_asdl  # token, etc.
 from asdl import runtime
 from core import error
 from core import ui
+from core import process
 from core.util import log, p_die
 from frontend import match
 from frontend import reader
@@ -482,7 +483,7 @@ class CommandParser(object):
     assert self.c_kind == Kind.Redir, self.cur_word
     op_tok = cast(Token, self.cur_word)  # for MyPy
 
-    fd = runtime.NO_SPID
+    fd = process.NO_FD
     fd_name = None
     if op_tok.val[0] == '{':
       index = op_tok.val.find('}')

--- a/osh/cmd_parse.py
+++ b/osh/cmd_parse.py
@@ -487,7 +487,7 @@ class CommandParser(object):
     if op_tok.val[0] == '{':
       index = op_tok.val.find('}')
       if index < 0:
-        p_die('Invalid token after redirect operator', word = self.cur_word)
+        p_die('Invalid token after redirect operator', word=self.cur_word)
       fd_name = op_tok.val[1:index]
     else:
       index = 0

--- a/osh/runtime.asdl
+++ b/osh/runtime.asdl
@@ -79,12 +79,12 @@ module runtime
 
   -- evaluated version of syntax.redir
   redirect = 
-    Path(id op_id, int fd, string? fd_name, string filename, int op_spid)
-  | FileDesc(id op_id, int fd, string? fd_name, int target_fd, int op_spid)
-  | CloseFd(id op_id, int fd, string? fd_name, int op_spid)
-  | MoveFd(id op_id, int fd, string? fd_name, int target_fd, int op_spid)
+    Path(id op_id, string fdspec, string filename, int op_spid)
+  | FileDesc(id op_id, string fdspec, int target_fd, int op_spid)
+  | CloseFd(id op_id, string fdspec, int op_spid)
+  | MoveFd(id op_id, string fdspec, int target_fd, int op_spid)
     -- here doc or here word
-  | HereDoc(int fd, string? fd_name, string body, int op_spid)
+  | HereDoc(string fdspec, string body, int op_spid)
 
   job_status =
     Proc(int code)

--- a/osh/runtime.asdl
+++ b/osh/runtime.asdl
@@ -81,6 +81,8 @@ module runtime
   redirect = 
     Path(id op_id, int fd, string filename, int op_spid)
   | FileDesc(id op_id, int fd, int target_fd, int op_spid)
+  | CloseFd(id op_id, int fd, int op_spid)
+  | MoveFd(id op_id, int fd, int target_fd, int op_spid)
     -- here doc or here word
   | HereDoc(int fd, string body, int op_spid)
 

--- a/osh/runtime.asdl
+++ b/osh/runtime.asdl
@@ -79,12 +79,12 @@ module runtime
 
   -- evaluated version of syntax.redir
   redirect = 
-    Path(id op_id, int fd, string filename, int op_spid)
-  | FileDesc(id op_id, int fd, int target_fd, int op_spid)
-  | CloseFd(id op_id, int fd, int op_spid)
-  | MoveFd(id op_id, int fd, int target_fd, int op_spid)
+    Path(id op_id, int fd, string? fd_name, string filename, int op_spid)
+  | FileDesc(id op_id, int fd, string? fd_name, int target_fd, int op_spid)
+  | CloseFd(id op_id, int fd, string? fd_name, int op_spid)
+  | MoveFd(id op_id, int fd, string? fd_name, int target_fd, int op_spid)
     -- here doc or here word
-  | HereDoc(int fd, string body, int op_spid)
+  | HereDoc(int fd, string? fd_name, string body, int op_spid)
 
   job_status =
     Proc(int code)

--- a/test/spec.sh
+++ b/test/spec.sh
@@ -518,7 +518,7 @@ here-doc() {
 }
 
 redirect() {
-  sh-spec spec/redirect.test.sh --osh-failures-allowed 7 \
+  sh-spec spec/redirect.test.sh --osh-failures-allowed 2 \
     ${REF_SHELLS[@]} $OSH_LIST "$@"
 }
 


### PR DESCRIPTION
## 1. 328e6361 Support redirections 5<>, 6>&5- and 6>&-

## 2. 7ea281a7 Update test

The arguments don't match with the function declaration? I guess the test is old. If this is not the right fix, please let me know.

## 3. 8dd5a020 Add tests for redirections

This demonstrates bugs related to the subsequent fixes (4., 5., and 6.) and also includes tests for `20> file` and a Bash bug.

## 4. 10136ceb Fix "Bad file descriptor" on 3>&3
This is a bug fix. The file descriptor was broken with `echo 3>&3`. The following test case (in `spec/redirect.test.sh`) had been failing due to this bug.

```bash
#### : 3>&3 (OSH regression)
: 3>&3
echo hello
## stdout: hello
## BUG mksh stdout-json: ""
## BUG mksh status: 1
```

## 5. 17e2f052 Fix fd-restoring order in FdState.Pop

This is another fix. The order of restoring original fds in `saved` and `need_close` were mixed. The ordering should be preserved. The following test case (in `spec/redirect.test.sh`) had failed due to this problem:

```bash
#### : 3>&- << EOF (OSH regression: fail to restore fds)
exec 3> "$TMP/fd.txt"
echo hello 3>&- << EOF
EOF
echo world >&3
exec 3>&-
cat "$TMP/fd.txt"
## STDOUT:
hello
world
## END
```

## 6. f5c21786  Fix fd-leak on `: 5> file`
See the following test case. The file descriptor `9` was still alive after the end of the command.

```bash
#### : 9> fdleak (OSH regression)
: 9> "$TMP/fd.txt"
( echo world >&9 )
cat "$TMP/fd.txt"
## stdout-json: ""
```

## 7. 0af7781f Fix fd-leak on `exec 5>&1`

The saved fds are not released on `FdState.MakePermanent()`. See the following example. In Oil, there were remaining fds as many as the invokations of `exec 5>&1`.

```
bash$ echo /proc/self/fd/* | wc -w
9
bash$ for i in {1..100}; do exec 5>&1; done
bash$ echo /proc/self/fd/* | wc -w
10

osh$ echo /proc/self/fd/* | wc -w
8
osh$ for i in {1..100}; do exec 5>&1; done
osh$ echo /proc/self/fd/* | wc -w
108
```

I didn't add a test to `spec/redirect.test.sh` because I don't know how to make it portable (`/proc/self/fd` is available in Linux but not portable). I tried to use `ulimit -n 100` for this, but it turned out that the limit cannot be changed in Oil (see below). Maybe I could have implemented the test case to generate fds as many as `$(ulimit -n)`, but I'm afraid that `$(ulimit -n)` might be extremely large in some system (but I don't know actually).

```
osh$ ulimit -n 100
osh$ ulimit -n
1024
```

## 8. da16c453 Support redirection {fd}>, {fd}<, etc.

Also, it includes the support of more-than-single-digit redirections such as `20> file`. Actually, I'm not familiar with ASDL, so maybe I'm doing weird things although it works as expected superficially. I would appreciate it if you could check this commit in detail.


