### PR TITLE
[core/process] Fix redirections

### DIFF
--- a/core/process.py
+++ b/core/process.py
@@ -441,6 +441,7 @@ class FdState(object):
       try:
         self._ApplyRedirect(r, waiter)
       except (IOError, OSError) as e:
+        self.Pop()
         return False  # for bad descriptor, etc.
       finally:
         self.errfmt.PopLocation()

--- a/core/process.py
+++ b/core/process.py
@@ -302,10 +302,11 @@ class FdState(object):
 
     elif loc.tag_() == redir_loc_e.Fd:
       fd = cast(redir_loc__Fd, UP_loc).fd
-      self._PushSave(fd)
 
     else:
       raise AssertionError()
+
+    self._PushSave(fd)
 
     return True
 

--- a/core/process.py
+++ b/core/process.py
@@ -257,6 +257,13 @@ class FdState(object):
         # already returned 3, e.g. echo 3>out.txt
         return NO_FD
 
+      # Check the validity of fd1 before _PushSave(fd2)
+      try:
+        fcntl.fcntl(fd1, fcntl.F_GETFD)
+      except IOError as e:
+        self.errfmt.Print('%d: %s', fd1, posix.strerror(e.errno))
+        raise
+
       need_restore = self._PushSave(fd2)
 
       #log('==== dup2 %s %s\n' % (fd1, fd2))

--- a/spec/redirect.test.sh
+++ b/spec/redirect.test.sh
@@ -551,3 +551,38 @@ hi
 hi
 hi
 ## END
+
+#### : >/dev/null 2> / (OSH regression: fail to pop fd frame)
+# oil 0.8.pre4 fails to restore fds after redirection failure In the
+# following case, the fd frame remains after the redirection failure
+# "2> /" so that the effect of redirection ">/dev/null" remains after
+# the completion of the command.
+: >/dev/null 2> /
+echo hello
+## stdout: hello
+## OK dash stdout-json: ""
+## OK dash status: 2
+## OK mksh stdout-json: ""
+## OK mksh status: 1
+# dash/mksh terminates the execution of script on the redirection.
+
+#### echo foo >&100 (OSH regression: does not fail with invalid fd 100)
+# oil 0.8.pre4 does not fail with non-existent fd 100.
+fd=100
+echo foo >&$fd
+## stdout-json: ""
+## status: 1
+## OK dash status: 2
+
+#### exec {fd}>&- (OSH regression: fails to close fd)
+# mksh, dash do not implement {fd} redirections.
+case $SH in (mksh|dash) exit 1 ;; esac
+# oil 0.8.pre4 fails to close fd by {fd}&-.
+exec {fd}>file1
+echo foo >&$fd
+exec {fd}>&-
+echo bar >&$fd
+cat file1
+## stdout: foo
+## N-I mksh/dash stdout-json: ""
+## N-I mksh/dash status: 1

--- a/spec/redirect.test.sh
+++ b/spec/redirect.test.sh
@@ -553,7 +553,7 @@ hi
 ## END
 
 #### : >/dev/null 2> / (OSH regression: fail to pop fd frame)
-# oil 0.8.pre4 fails to restore fds after redirection failure In the
+# oil 0.8.pre4 fails to restore fds after redirection failure. In the
 # following case, the fd frame remains after the redirection failure
 # "2> /" so that the effect of redirection ">/dev/null" remains after
 # the completion of the command.
@@ -569,6 +569,27 @@ echo hello
 #### echo foo >&100 (OSH regression: does not fail with invalid fd 100)
 # oil 0.8.pre4 does not fail with non-existent fd 100.
 fd=100
+echo foo >&$fd
+## stdout-json: ""
+## status: 1
+## OK dash status: 2
+
+#### echo foo >&N where N is first unused fd
+# 1. prepare default fd for internal uses
+minfd=10
+case ${SH##*/} in
+(mksh) minfd=24 ;;
+(osh) minfd=100 ;;
+esac
+
+# 2. prepare first unused fd
+fd=$minfd
+is-fd-open() { : >&$1; }
+while is-fd-open "$fd"; do
+  : $((fd+=1))
+done
+
+# 3. test
 echo foo >&$fd
 ## stdout-json: ""
 ## status: 1


### PR DESCRIPTION
- 77e3af8 Add failing test cases which are fixed by the subsequent fixes.
- abe89a5 Fix *"#653 33. BUG: Redirection of 2 is persistent after `: 2>/dev/null >&30`"*
- 4ed53e1 Fix *"#653 37. BUG: `{fd}>&-` does not close the fd"*
- 7f86a1a Fix a problem that `>&100` does not fail even if fd 100 does not exist.
