### PR TITLE
[arith] Fix reversed digits in $((base#num)).

### DIFF
--- a/osh/sh_expr_eval.py
+++ b/osh/sh_expr_eval.py
@@ -229,7 +229,6 @@ class ArithEvaluator(object):
         e_strict('Invalid base for numeric constant %r',  b, span_id=span_id)
 
       integer = 0
-      n = 1
       for ch in digits:
         if 'a' <= ch and ch <= 'z':
           digit = ord(ch) - ord('a') + 10
@@ -247,8 +246,7 @@ class ArithEvaluator(object):
         if digit >= base:
           e_strict('Digits %r out of range for base %d', digits, base, span_id=span_id)
 
-        integer += digit * n
-        n *= base
+        integer = integer * base + digit
       return integer
 
     try:

--- a/spec/arith.test.sh
+++ b/spec/arith.test.sh
@@ -237,6 +237,12 @@ echo $((64#a))-$((64#z)), $((64#A))-$((64#Z)), $((64#@)), $(( 64#_ ))
 ## N-I mksh/zsh stdout-json: ""
 ## N-I mksh/zsh status: 1
 
+#### Multiple digit constants with base N
+echo $((10#0123)), $((16#1b))
+## stdout: 123, 27
+## N-I dash stdout-json: ""
+## N-I dash status: 2
+
 #### Dynamic base constants
 base=16
 echo $(( ${base}#a ))


### PR DESCRIPTION
This fixes the problem that `echo $((10#0123))` outputs `3210`.

```bash
$ osh -c 'echo $((10#0123))'
3210
```