### PR TITLE
[arith] Support empty arith.

### DIFF
--- a/frontend/option_def.py
+++ b/frontend/option_def.py
@@ -231,6 +231,7 @@ def _Init(opt_def):
 
   opt_def.Add('eval_unsafe_arith')  # recursive parsing and evaluation (ble.sh)
   opt_def.Add('parse_dynamic_arith')  # dynamic LHS
+  opt_def.Add('parse_empty_arith')  # empty arithmetic expressions
   opt_def.Add('compat_array')  # ${array} is ${array[0]}
 
   # Two strict options that from bash's shopt

--- a/frontend/parse_lib.py
+++ b/frontend/parse_lib.py
@@ -285,7 +285,7 @@ class ParseContext(object):
     lx = self._MakeLexer(line_reader)
     w_parser = word_parse.WordParser(self, lx, line_reader)
     w_parser.Init(lex_mode_e.Arith)  # Special initialization
-    a_parser = tdop.TdopParser(arith_parse.Spec(), w_parser, self.parse_opts)
+    a_parser = arith_parse.ArithParser(w_parser, self.parse_opts)
     return a_parser
 
   def MakeParserForCommandSub(self, line_reader, lexer, eof_id):

--- a/frontend/syntax.asdl
+++ b/frontend/syntax.asdl
@@ -211,7 +211,8 @@ module syntax
   attributes (int* spids)
 
   arith_expr =
-    VarRef %Token  -- variable without $
+    Empty
+  | VarRef %Token  -- variable without $
   | Word %compound_word  -- a string that looks like an integer
 
   | UnaryAssign(id op_id, arith_expr child)

--- a/osh/arith_parse.py
+++ b/osh/arith_parse.py
@@ -97,8 +97,8 @@ if mylib.PYTHON:
     Following this table:
     http://en.cppreference.com/w/c/language/operator_precedence
 
-    Bash has a table in expr.c, but it's not as cmoplete (missing grouping () and
-    array[1]).  Although it has the ** exponentation operator, not in C.
+    Bash has a table in expr.c, but it's not as complete (missing grouping () and
+    array[1]).  Although it has the ** exponentiation operator, not in C.
 
     - Extensions:
       - function calls f(a,b)
@@ -182,3 +182,14 @@ if mylib.PYTHON:
   def Spec():
     # type: () -> ParserSpec
     return _SPEC
+
+class ArithParser(tdop.TdopParser):
+  def __init__(self, w_parser, parse_opts):
+    super(ArithParser, self).__init__(Spec(), w_parser, parse_opts)
+
+  def Parse(self):
+    # type: () -> arith_expr_t
+    self.Next()  # may raise ParseError
+    if self.op_id in (Id.Arith_RParen, Id.Arith_RBrace, Id.Arith_RBracket, Id.Arith_Colon):
+      return arith_expr.Empty()
+    return self.ParseUntil(0)

--- a/osh/arith_parse.py
+++ b/osh/arith_parse.py
@@ -190,6 +190,7 @@ class ArithParser(tdop.TdopParser):
   def Parse(self):
     # type: () -> arith_expr_t
     self.Next()  # may raise ParseError
-    if self.op_id in (Id.Arith_RParen, Id.Arith_RBrace, Id.Arith_RBracket, Id.Arith_Colon):
-      return arith_expr.Empty()
+    if self.parse_opts.parse_empty_arith():
+      if self.op_id in (Id.Arith_RParen, Id.Arith_RBrace, Id.Arith_RBracket, Id.Arith_Colon):
+        return arith_expr.Empty()
     return self.ParseUntil(0)

--- a/osh/sh_expr_eval.py
+++ b/osh/sh_expr_eval.py
@@ -630,6 +630,9 @@ class ArithEvaluator(object):
         else:
           return self.Eval(node.false_expr)
 
+      elif case(arith_expr_e.Empty):
+        return value.Int(0)
+
       else:
         raise AssertionError(node.tag_())
 

--- a/osh/word_parse.py
+++ b/osh/word_parse.py
@@ -944,7 +944,7 @@ class WordParser(WordEmitter):
     See the assertion in ArithParser.Parse() -- unexpected extra input.
     """
     # calls self.ReadWord(lex_mode_e.Arith)
-    a_parser = tdop.TdopParser(arith_parse.Spec(), self, self.parse_opts)
+    a_parser = arith_parse.ArithParser(self, self.parse_opts)
     anode = a_parser.Parse()
     return anode
 

--- a/spec/arith.test.sh
+++ b/spec/arith.test.sh
@@ -600,6 +600,7 @@ a=1
 
 #### Empty expression: $(())
 case $SH in (dash) exit 1;; esac
+shopt -s parse_empty_arith 2>/dev/null
 echo 1:$(())
 echo 2:$(( ))
 ## STDOUT:
@@ -613,6 +614,7 @@ echo 2:$(( ))
 # dash/mksh doesn't support $[]
 # oil has different meaning for $[]
 case ${SH##*/} in (dash|mksh|osh) exit 1;; esac
+shopt -s parse_empty_arith 2>/dev/null
 echo 3:$[]
 echo 4:$[ ]
 ## STDOUT:
@@ -624,6 +626,7 @@ echo 4:$[ ]
 
 #### Empty expression: (())
 case $SH in (dash) exit 1;; esac
+shopt -s parse_empty_arith 2>/dev/null
 (()) && echo unexpected || echo OK
 (( )) && echo unexpected || echo OK
 ! (()) && echo OK || echo unexpected
@@ -643,6 +646,7 @@ case $SH in
 (mksh|zsh) exit 1;; # mksh/zsh does not support.
 (bash)     exit 1;; # bash supports this from bash-5.0.
 esac
+shopt -s parse_empty_arith 2>/dev/null
 
 arr=(foo bar)
 echo "${arr[ ]}"
@@ -655,8 +659,10 @@ foo
 #### Empty expression: ${var::}
 case $SH in
 (dash) exit 1;; # dash does not support arrays.
-(dash) exit 1;; # zsh does not support empty offset/length.
+(zsh)  exit 1;; # zsh does not support empty offset/length.
 esac
+shopt -s parse_empty_arith 2>/dev/null
+
 var=abcd
 echo "1:[${var::1}]"
 echo "2:[${var: :1}]"
@@ -681,6 +687,7 @@ case $SH in
 (mksh) exit 1;; # mksh does not support ${array[@]:offset:length}
 (zsh)  exit 1;; # zsh does not support empty offset/length
 esac
+shopt -s parse_empty_arith 2>/dev/null
 array=(1 2 3)
 argv.py "${array[@]::1}"
 argv.py "${array[@]: :1}"

--- a/spec/arith.test.sh
+++ b/spec/arith.test.sh
@@ -597,3 +597,104 @@ a=1
 ## END
 ## BUG zsh stdout-json: ""
 ## BUG zsh status: 1
+
+#### Empty expression: $(())
+case $SH in (dash) exit 1;; esac
+echo 1:$(())
+echo 2:$(( ))
+## STDOUT:
+1:0
+2:0
+## END
+## N-I dash stdout-json: ""
+## N-I dash status: 1
+
+#### Empty expression: $[]
+# dash/mksh doesn't support $[]
+# oil has different meaning for $[]
+case ${SH##*/} in (dash|mksh|osh) exit 1;; esac
+echo 3:$[]
+echo 4:$[ ]
+## STDOUT:
+3:0
+4:0
+## END
+## N-I dash/mksh/osh stdout-json: ""
+## N-I dash/mksh/osh status: 1
+
+#### Empty expression: (())
+case $SH in (dash) exit 1;; esac
+(()) && echo unexpected || echo OK
+(( )) && echo unexpected || echo OK
+! (()) && echo OK || echo unexpected
+! (( )) && echo OK || echo unexpected
+## STDOUT:
+OK
+OK
+OK
+OK
+## END
+## N-I dash status: 1
+## N-I dash stdout-json: ""
+
+#### Empty expression: array subscript
+case $SH in
+(dash)     exit 1;; # dash does not support arrays.
+(mksh|zsh) exit 1;; # mksh/zsh does not support.
+(bash)     exit 1;; # bash supports this from bash-5.0.
+esac
+
+arr=(foo bar)
+echo "${arr[ ]}"
+## STDOUT:
+foo
+## END
+## N-I dash/mksh/zsh/bash status: 1
+## N-I dash/mksh/zsh/bash stdout-json: ""
+
+#### Empty expression: ${var::}
+case $SH in
+(dash) exit 1;; # dash does not support arrays.
+(dash) exit 1;; # zsh does not support empty offset/length.
+esac
+var=abcd
+echo "1:[${var::1}]"
+echo "2:[${var: :1}]"
+echo "3:[${var::}]"
+echo "4:[${var:: }]"
+echo "5:[${var: :}]"
+echo "6:[${var: : }]"
+## STDOUT:
+1:[a]
+2:[a]
+3:[]
+4:[]
+5:[]
+6:[]
+## END
+## N-I dash/zsh status: 1
+## N-I dash/zsh stdout-json: ""
+
+#### Empty expression: ${array[@]::}
+case $SH in
+(dash) exit 1;; # dash does not support arrays.
+(mksh) exit 1;; # mksh does not support ${array[@]:offset:length}
+(zsh)  exit 1;; # zsh does not support empty offset/length
+esac
+array=(1 2 3)
+argv.py "${array[@]::1}"
+argv.py "${array[@]: :1}"
+argv.py "${array[@]::}"
+argv.py "${array[@]:: }"
+argv.py "${array[@]: :}"
+argv.py "${array[@]: : }"
+## STDOUT:
+['1']
+['1']
+[]
+[]
+[]
+[]
+## END
+## N-I dash/mksh/zsh status: 1
+## N-I dash/mksh/zsh stdout-json: ""

--- a/spec/var-op-slice.test.sh
+++ b/spec/var-op-slice.test.sh
@@ -318,13 +318,3 @@ argv.py ${array[@]::0}
 ## END
 ## N-I mksh/zsh status: 1
 ## N-I mksh/zsh stdout-json: ""
-
-#### ${array[@]::}
-array=(1 2 3)
-argv.py ${array[@]::}
-## STDOUT:
-[]
-## END
-## N-I mksh/zsh status: 1
-## N-I mksh/zsh status: 1
-## N-I mksh/zsh stdout-json: ""


### PR DESCRIPTION
This fixes the following problem.

- *"#653 29. BUG: Cannot parse `${arr[@]::}`"*

Actually this was a N-I feature rather than a bug. It is related to an empty string in arithmetic context. I'm not sure if Oil should support this by default or not, but this is a patch to support empty strings in arithmetic context.

In this implementation, I derived a class `ArithParser` from `TdopParser` to add a special rule for empty arithmetic expressions.
