### PR TITLE
[word_eval] Fix ${#BASH_SOURCE}, ${BASH_SOURCE:offset:length}, etc.

### DIFF
--- a/spec/introspect.test.sh
+++ b/spec/introspect.test.sh
@@ -139,6 +139,25 @@ ____
 ['11']
 ## END
 
+#### ${FUNCNAME} with prefix/suffix operators (OSH regression)
+check() {
+  argv.py "${#FUNCNAME}"
+  argv.py "${FUNCNAME::1}"
+  argv.py "${FUNCNAME:1}"
+}
+check
+## STDOUT:
+['5']
+['c']
+['heck']
+## END
+
+#### ${FUNCNAME} and "set -u" (OSH regression)
+set -u
+argv.py "$FUNCNAME"
+## status: 1
+## stdout-json: ""
+
 #### ${BASH_SOURCE[@]} with source and function name
 argv.py "${BASH_SOURCE[@]}"
 source spec/testdata/bash-source-simple.sh


### PR DESCRIPTION
This fixes the following issues:

- The parameter expansions of the form `${#BASH_SOURCE}` for array variables counts the number of elements instead of the number of characters of the first element.

```bash
$ osh -c 'f1() { echo ${#BASH_SOURCE}; }; f1'
1
```


- Slices of the parameter expansions `${BASH_SOURCE:offset:length}` are used to select array elements

```bash
$ osh -c 'f1() { echo ${BASH_SOURCE::1}; }; f1'
-c flag
$ osh -c 'f1() { echo ${BASH_SOURCE:1}; }; f1'

```

- `set -u` doesn't detect undefined first elements with the scalar form `$BASH_SOURCE`.

```bash
# Error with the following form:
$ osh -uc 'echo ${BASH_SOURCE[0]}'
  echo ${BASH_SOURCE[0]}
  ^~~~
[ -c flag ]:1: fatal: Undefined variable

# No errors generated with the following form
$ osh -uc 'echo $BASH_SOURCE'

```
