### PR TITLE
[word_eval] Implement 'shopt -s compat_array'.

### DIFF
--- a/osh/sh_expr_eval.py
+++ b/osh/sh_expr_eval.py
@@ -331,7 +331,7 @@ class ArithEvaluator(object):
     # BASH_LINENO, etc.
     if val.tag_() in (value_e.MaybeStrArray, value_e.AssocArray) and lval.tag_() == lvalue_e.Named:
       named_lval = cast(lvalue__Named, lval)
-      if word_eval.CheckCompatArray(named_lval.name):
+      if word_eval.CheckCompatArray(named_lval.name, self.exec_opts):
         val = word_eval.ResolveCompatArray(val)
 
     # This error message could be better, but we already have one
@@ -358,7 +358,7 @@ class ArithEvaluator(object):
     # BASH_LINENO, etc.
     if val.tag_() in (value_e.MaybeStrArray, value_e.AssocArray) and node.tag_() == arith_expr_e.VarRef:
       tok = cast(Token, node)
-      if word_eval.CheckCompatArray(tok.val):
+      if word_eval.CheckCompatArray(tok.val, self.exec_opts):
         val = word_eval.ResolveCompatArray(val)
 
     # TODO: Can we avoid the runtime cost of adding location info?

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -61,9 +61,9 @@ if TYPE_CHECKING:
 # For compatibility, ${BASH_SOURCE} and ${BASH_SOURCE[@]} are both valid.
 # ${FUNCNAME} and ${BASH_LINENO} are also the same type of of special variables.
 _STRING_AND_ARRAY = ['BASH_SOURCE', 'FUNCNAME', 'BASH_LINENO']
-def CheckCompatArray(var_name, opts):
-  # type: (str, optview.Exec) -> bool
-  return opts.compat_array() or var_name in _STRING_AND_ARRAY
+def CheckCompatArray(var_name, opts, compat_introspect=True):
+  # type: (str, optview.Exec, bool?) -> bool
+  return opts.compat_array() or (compat_introspect and var_name in _STRING_AND_ARRAY)
 
 def ResolveCompatArray(val):
   # type: (value_t) -> value_t
@@ -990,7 +990,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
           # ${array@a} is a string
           # TODO: An IR for ${} might simplify these lengthy conditions
           pass
-        elif CheckCompatArray(var_name, self.exec_opts):
+        elif CheckCompatArray(var_name, self.exec_opts, not (part.prefix_op or part.suffix_op)):
           # for ${BASH_SOURCE}, etc.
           val = ResolveCompatArray(val)
         else:

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -61,9 +61,9 @@ if TYPE_CHECKING:
 # For compatibility, ${BASH_SOURCE} and ${BASH_SOURCE[@]} are both valid.
 # ${FUNCNAME} and ${BASH_LINENO} are also the same type of of special variables.
 _STRING_AND_ARRAY = ['BASH_SOURCE', 'FUNCNAME', 'BASH_LINENO']
-def CheckCompatArray(var_name):
-  # type: (str) -> bool
-  return var_name in _STRING_AND_ARRAY
+def CheckCompatArray(var_name, opts):
+  # type: (str, optview.Exec) -> bool
+  return opts.compat_array() or var_name in _STRING_AND_ARRAY
 
 def ResolveCompatArray(val):
   # type: (value_t) -> value_t
@@ -990,7 +990,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
           # ${array@a} is a string
           # TODO: An IR for ${} might simplify these lengthy conditions
           pass
-        elif CheckCompatArray(var_name):
+        elif CheckCompatArray(var_name, self.exec_opts):
           # for ${BASH_SOURCE}, etc.
           val = ResolveCompatArray(val)
         else:
@@ -1219,7 +1219,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
       # TODO: Special case for LINENO
       val = self.mem.GetVar(var_name)
       if val.tag_() in (value_e.MaybeStrArray, value_e.AssocArray):
-        if CheckCompatArray(var_name):
+        if CheckCompatArray(var_name, self.exec_opts):
           # for $BASH_SOURCE, etc.
           val = ResolveCompatArray(val)
         else:

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -61,9 +61,9 @@ if TYPE_CHECKING:
 # For compatibility, ${BASH_SOURCE} and ${BASH_SOURCE[@]} are both valid.
 # ${FUNCNAME} and ${BASH_LINENO} are also the same type of of special variables.
 _STRING_AND_ARRAY = ['BASH_SOURCE', 'FUNCNAME', 'BASH_LINENO']
-def CheckCompatArray(var_name, opts, compat_introspect=True):
+def CheckCompatArray(var_name, opts, is_plain_var_sub=True):
   # type: (str, optview.Exec, bool?) -> bool
-  return opts.compat_array() or (compat_introspect and var_name in _STRING_AND_ARRAY)
+  return opts.compat_array() or (is_plain_var_sub and var_name in _STRING_AND_ARRAY)
 
 def ResolveCompatArray(val):
   # type: (value_t) -> value_t

--- a/spec/ble-features.test.sh
+++ b/spec/ble-features.test.sh
@@ -576,3 +576,16 @@ v=tempenv1 f4_unset global,tempenv1
 [global,tempenv1,tempenv2,tempenv3] v: (unset) (unset 3)
 [global,tempenv1,tempenv2,tempenv3] v: (unset) (unset 4)
 ## END
+
+#### [compat_array] ${arr} is ${arr[0]}
+case ${SH##*/} in (dash|ash) exit 1;; esac # dash/ash does not have arrays
+case ${SH##*/} in (osh) shopt -s compat_array;; esac
+case ${SH##*/} in (zsh) setopt KSH_ARRAYS;; esac
+arr=(foo bar baz)
+echo "$arr"
+## stdout: foo
+
+## N-I dash/ash status: 1
+## N-I dash/ash stdout-json: ""
+
+## OK yash stdout: foo bar baz

--- a/spec/ble-features.test.sh
+++ b/spec/ble-features.test.sh
@@ -589,3 +589,24 @@ echo "$arr"
 ## N-I dash/ash stdout-json: ""
 
 ## OK yash stdout: foo bar baz
+
+#### [compat_array] scalar access to arrays
+case ${SH##*/} in
+(dash|ash) exit 1;; # dash/ash does not have arrays
+(osh) shopt -s compat_array;;
+(zsh) setopt KSH_ARRAYS;;
+esac
+
+a=(1 0 0)
+: $(( a++ ))
+argv.py "${a[@]}"
+## stdout: ['2', '0', '0']
+
+## N-I dash/ash status: 1
+## N-I dash/ash stdout-json: ""
+
+## OK yash STDOUT:
+# yash does not support scalar access. Instead, it replaces the array
+# with a scalar.
+['1']
+## END

--- a/spec/introspect.test.sh
+++ b/spec/introspect.test.sh
@@ -140,7 +140,7 @@ ____
 ## END
 
 
-#### ${FUNCNAME} with prefix/suffix operators (OSH regression)
+#### ${FUNCNAME} with prefix/suffix operators
 shopt -s compat_array
 
 check() {
@@ -180,6 +180,13 @@ set -u
 argv.py "$FUNCNAME"
 ## status: 1
 ## stdout-json: ""
+
+#### $((BASH_LINENO)) (scalar form in arith)
+check() {
+  echo $((BASH_LINENO))
+}
+check
+## stdout: 4
 
 #### ${BASH_SOURCE[@]} with source and function name
 argv.py "${BASH_SOURCE[@]}"


### PR DESCRIPTION
Ref #726 

- Fix a problem that the scalar form cannot be used in arithmetic expressions (9fc20e7f Test c2365f5f Fix):

```bash
$ osh -c '$((BASH_LINENO))'
  $((BASH_LINENO))
     ^~~~~~~~~~~
[ -c flag ]:1: fatal: Expected a value convertible to integer, got value.MaybeStrArray
```

- Implement `shopt -s compat_array` to allow `$array` (Test bf9f3328, Fix 67047709)

- Disallow `${#BASH_SOURCE}`, `${BASH_SOURCE:1:1}`, `${BASH_SOURCE#X}`, `${BASH_SOURCE-X}`, etc. by default (Fix b1a16c25). In this implementation, everything with additional suffix/prefix are disallowed.

