### PR TITLE
[builtin/read] Fix 'IFS= read -n' bug.

### DIFF
--- a/osh/builtin_misc.py
+++ b/osh/builtin_misc.py
@@ -225,7 +225,7 @@ class Read(object):
           arg.n -= len(buf)
           s += buf
 
-      state.SetLocalString(self.mem, name, s)
+      state.SetStringDynamic(self.mem, name, s)
       # NOTE: Even if we don't get n bytes back, there is no error?
       return 0
 

--- a/spec/builtin-io.test.sh
+++ b/spec/builtin-io.test.sh
@@ -277,6 +277,13 @@ argv.py $x $REPLY
 ## stdout: ['1234', '12']
 ## N-I dash/zsh stdout: []
 
+#### IFS= read -n (OSH regression: value saved in tempenv)
+echo XYZ > "$TMP/readn.txt"
+IFS= TMOUT= read -n 1 char < "$TMP/readn.txt"
+argv.py "$char"
+## stdout: ['X']
+## N-I dash/zsh stdout: ['']
+
 #### Read uses $REPLY (without -n)
 echo 123 > $TMP/readreply.txt
 read < $TMP/readreply.txt


### PR DESCRIPTION
This fixes the problem that when `read -n` is used with tempenv, the resulting variable is created in the tempenv frame so that one cannot access the results:

```bash
$ bash -c 'v= read -n 1 <<< X; echo "[$REPLY]"'
[X]
$ osh -c 'v= read -n 1 <<< X; echo "[$REPLY]"'
[]
```
