### PR TITLE
[builtin/printf] Support printf %d \'.

### DIFF
--- a/osh/builtin_printf.py
+++ b/osh/builtin_printf.py
@@ -311,10 +311,11 @@ class Printf(object):
             try:
               d = int(s)
             except ValueError:
-              if len(s) >= 2 and s[0] in '\'"':
+              if len(s) >= 1 and s[0] in '\'"':
                 # TODO: utf-8 decode s[1:] to be more correct.  Probably
                 # depends on issue #366, a utf-8 library.
-                d = ord(s[1])
+                # Note: len(s) == 1 means there is a NUL (0) after the quote..
+                d = ord(s[1]) if len(s) >= 2 else 0
               elif part.type.id == Id.Format_Time and len(s) == 0 and word_spid == runtime.NO_SPID:
                 # Note: No argument means -1 for %(...)T as in Bash Reference
                 #   Manual 4.2 "If no argument is specified, conversion behaves

--- a/spec/builtin-printf.test.sh
+++ b/spec/builtin-printf.test.sh
@@ -276,12 +276,12 @@ printf '%d\n' ''
 #### No char after ' (osh is more strict)
 
 # most shells use 0 here
-printf '%d\n' \' 
+printf '%d\n' \'
+printf '%d\n' \"
 
-## OK osh stdout-json: ""
-## OK osh status: 1
 ## OK mksh status: 1
 ## STDOUT:
+0
 0
 ## END
 

--- a/spec/builtin-printf.test.sh
+++ b/spec/builtin-printf.test.sh
@@ -254,7 +254,7 @@ printf '[%o]\n' 42
 printf '[%x]\n' 42
 printf '[%X]\n' 42
 printf '[%X]\n' \'a  # if first character is a quote, use character code
-printf '[%X]\n' \'ab  # extra chars ignored
+printf '[%X]\n' \'ab # extra chars ignored
 ## STDOUT:
 [42]
 [52]


### PR DESCRIPTION
`ble.sh` needs this to read <kbd>NUL</kbd> (which is the terminal sequence of <Kbd>C-@</kbd>) for emulated `read`.