### PR TITLE
[builtin/assign] Do not remove existing arrays by 'declare -a array'.

### DIFF
--- a/osh/builtin_assign.py
+++ b/osh/builtin_assign.py
@@ -377,15 +377,15 @@ class NewVar(object):
       flags |= state.ClearNameref
 
     for pair in cmd_val.pairs:
-      if pair.rval is None:
+      rval = pair.rval
+      if rval is None and (arg.a or arg.A):
+        old_val = self.mem.GetVar(pair.var_name)
         if arg.a:
-          rval = value.MaybeStrArray([])  # type: value_t
+          if old_val.tag_() != value_e.MaybeStrArray:
+            rval = value.MaybeStrArray([])
         elif arg.A:
-          rval = value.AssocArray({})
-        else:
-          rval = None
-      else:
-        rval = pair.rval
+          if old_val.tag_() != value_e.AssocArray:
+            rval = value.AssocArray({})
 
       rval = _ReconcileTypes(rval, arg, pair.spid)
       self.mem.SetVar(lvalue.Named(pair.var_name), rval, lookup_mode, flags=flags)

--- a/spec/assign.test.sh
+++ b/spec/assign.test.sh
@@ -643,3 +643,30 @@ declare -- foo=bar
 ## N-I dash stderr-json: ""
 ## stdout-json: ""
 
+#### declare -a arr does not remove existing arrays (OSH regression)
+case $SH in (dash) exit 99;; esac # dash does not support arrays
+
+declare -a arr
+arr=(foo bar baz)
+declare -a arr
+echo arr:${#arr[@]}
+## STDOUT:
+arr:3
+## END
+## N-I dash status: 99
+## N-I dash stdout-json: ""
+
+#### declare -A dict does not remove existing arrays (OSH regression)
+case $SH in (dash|mksh) exit 99;; esac # dash/mksh does not support associative arrays
+
+declare -A dict
+dict['foo']=hello
+dict['bar']=oil
+dict['baz']=world
+declare -A dict
+echo dict:${#dict[@]}
+## STDOUT:
+dict:3
+## END
+## N-I dash/mksh status: 99
+## N-I dash/mksh stdout-json: ""


### PR DESCRIPTION
When `declare -a array` is performed on existing arrays, the array becomes empty. In this PR, the arrays are initialized only when the variable contains another type of value. This also fixes the same problem for associative arrays.

```bash
# Normal variables are not removed

$ bash -c 'var=hello; declare -r var; declare -p var'
declare -r var="hello"
$ osh -c 'var=hello; declare -r var; declare -p var'
declare -r var=hello

# Arrays and associative arrays are removed in Oil

$ bash -c 'arr=(1 2 3); declare -a arr; declare -p arr'
declare -a arr=([0]="1" [1]="2" [2]="3")
$ osh -c 'arr=(1 2 3); declare -a arr; declare -p arr'
declare -a arr=()
```