### PR TITLE
Give a more helpful error if all `help` is missing

### DIFF
--- a/core/pyutil.py
+++ b/core/pyutil.py
@@ -86,6 +86,9 @@ class _FileResourceLoader(_ResourceLoader):
       contents = f.read()
     return contents
 
+  def Exists(self, rel_path):
+    # type: (str) -> bool
+    return os_path.exists(os_path.join(self.root_dir, rel_path))
 
 class _ZipResourceLoader(_ResourceLoader):
   """Open resources INSIDE argv[0] as a zip file."""

--- a/core/pyutil.py
+++ b/core/pyutil.py
@@ -9,7 +9,7 @@ import zipimport  # NOT the zipfile module.
 
 from mycpp import mylib
 from pgen2 import grammar
-from pylib import os_path
+from pylib import os_path, path_stat
 
 import posix_ as posix
 
@@ -88,7 +88,7 @@ class _FileResourceLoader(_ResourceLoader):
 
   def Exists(self, rel_path):
     # type: (str) -> bool
-    return os_path.exists(os_path.join(self.root_dir, rel_path))
+    return path_stat.exists(os_path.join(self.root_dir, rel_path))
 
 class _ZipResourceLoader(_ResourceLoader):
   """Open resources INSIDE argv[0] as a zip file."""

--- a/osh/builtin_misc.py
+++ b/osh/builtin_misc.py
@@ -593,13 +593,15 @@ class Help(vm._Builtin):
       # help help
       # We should do something smarter.
 
-      # 2. This also happens on 'build/dev.sh minimal', which isn't quite
-      # accurate.  We don't have an exact list of help topics!
-
-      # 3. This is mostly an interactive command.  Is it obnoxious to
-      # quote the line of code?
-      self.errfmt.Print_('no help topics match %r' % topic,
-                         span_id=blame_spid)
+      # On 'build/dev.sh minimal', we're missing help altogether.
+      # Give a more helpful error message.
+      if not self.loader.Exists('_devbuild/help'):
+        self.errfmt.Print_('help is not available in the `minimal` build of OSH\nhelp: try `build/dev.sh all` instead\nnote: see https://github.com/oilshell/oil/issues/623 for more information', span_id=blame_spid)
+      else:
+        # 3. This is mostly an interactive command.  Is it obnoxious to
+        # quote the line of code?
+        self.errfmt.Print_('no help topics match %r' % topic,
+                           span_id=blame_spid)
       return 1
 
     print(contents)


### PR DESCRIPTION
This is failing because `os_path` doesn't implement the `exists` function:

```
  File "/home/joshua/src/oil/osh/builtin_misc.py", line 598, in Run
    if not self.loader.Exists('_devbuild/help'):
  File "/home/joshua/src/oil/core/pyutil.py", line 91, in Exists
    return os_path.exists(os_path.join(self.root_dir, rel_path))
AttributeError: 'module' object has no attribute 'exists'
```

I'm not sure how to implement it in pure python, I thought I'd reach out for help.

Addresses #623.