### PR TITLE
Add Linux-only guard around HAVE_EPOLL

### DIFF
--- a/Python-2.7.13/pyconfig.h
+++ b/Python-2.7.13/pyconfig.h
@@ -197,7 +197,9 @@
 #define HAVE_DYNAMIC_LOADING 1
 
 /* Define if you have the 'epoll' functions. */
+#ifdef __linux__
 #define HAVE_EPOLL 1
+#endif
 
 /* Define to 1 if you have the `erf' function. */
 #define HAVE_ERF 1


### PR DESCRIPTION
This should do the right thing across all platforms, especially macOS.