### PR TITLE
idiom: fix run failures

### DIFF
--- a/doc/idioms.md
+++ b/doc/idioms.md
@@ -318,6 +318,7 @@ No:
 
 Yes:
 
+    var not_mutated = 'bar'
     forkwait {
       setvar not_mutated = 'foo'
     }


### PR DESCRIPTION
running the idiom with the not_mutated example will currently yield a failure
```
 echo $not_mutated
       ^~~~~~~~~~~~
./backup.sh:5: fatal: Undefined variable 'not_mutated'
```

It seems to me that the examples should run as is.
Let me know if you need anything else.