### PR TITLE
Remove instances of "the the" from documentation.

### DIFF
--- a/doc/framing.md
+++ b/doc/framing.md
@@ -27,7 +27,7 @@ contain newlines, but not `NUL` (`\0`).
 
 ### NUL as delimiter: `read -0`
 
-So naturally we also support the the format that `find -print0` emits, and
+So naturally we also support the format that `find -print0` emits, and
 `xargs -0` consumes.
 
 ## Solutions That Can Express Arbitrary Bytes

--- a/doc/idioms.md
+++ b/doc/idioms.md
@@ -136,7 +136,7 @@ These are discussed in the next two sections, but here's a summary.
 
     read --line --qsn :myline     # read a single line
 
-That is, take advantage of the the invariants that the [IO
+That is, take advantage of the invariants that the [IO
 builtins](io-builtins.html) respect.  (doc in progress)
 
 <!--

--- a/doc/options.md
+++ b/doc/options.md
@@ -100,7 +100,7 @@ For compatibility, these styles works in Oil:
 
 ### Setting Options Via Command Line Flags
 
-You typically invoke the `shopt` builtin at the the top of a script, but you
+You typically invoke the `shopt` builtin at the top of a script, but you
 can also set options at the command line:
 
     osh -O errexit -c 'shopt -p -o'  # turn on Bourne option


### PR DESCRIPTION
As discussed, some simple fixes to remove this common typo, based on a simple grep search.