### PR TITLE
Handle error when sourcing a directory

### DIFF
--- a/osh/builtin_meta.py
+++ b/osh/builtin_meta.py
@@ -98,7 +98,7 @@ class Source(vm._Builtin):
       resolved = path
     try:
       f = self.fd_state.Open(resolved)  # Shell can't use descriptors 3-9
-    except OSError as e:
+    except (IOError, OSError) as e:
       self.errfmt.Print_('source %r failed: %s' % (path, pyutil.strerror(e)),
                         span_id=cmd_val.arg_spids[1])
       return 1

--- a/spec/builtin-eval-source.test.sh
+++ b/spec/builtin-eval-source.test.sh
@@ -225,13 +225,12 @@ rm dir/cmd
 ## STDOUT:
 path
 ## END
- 
+
 #### exit within eval (regression)
 eval 'exit 42'
 echo 'should not get here'
 ## stdout-json: ""
 ## status: 42
-
 
 #### exit within source (regression)
 cd $TMP
@@ -241,3 +240,10 @@ echo 'should not get here'
 ## stdout-json: ""
 ## status: 42
 
+#### source doesn't crash when targeting a directory
+cd $TMP
+mkdir -p dir
+. ./dir/
+echo status=$?
+## stdout: status=1
+## OK dash/zsh/mksh stdout: status=0

--- a/spec/redirect.test.sh
+++ b/spec/redirect.test.sh
@@ -652,3 +652,11 @@ cat file1
 ## stdout: foo
 ## N-I mksh/dash stdout-json: ""
 ## N-I mksh/dash status: 1
+
+#### redirection from directory doesn't crash
+cd $TMP
+mkdir -p dir
+read x < ./dir
+echo status=$?
+## stdout: status=1
+## OK mksh stdout: status=2

--- a/test/spec.sh
+++ b/test/spec.sh
@@ -530,7 +530,7 @@ here-doc() {
 }
 
 redirect() {
-  sh-spec spec/redirect.test.sh --osh-failures-allowed 1 \
+  sh-spec spec/redirect.test.sh --osh-failures-allowed 2 \
     ${REF_SHELLS[@]} $OSH_LIST "$@"
 }
 


### PR DESCRIPTION
Most shells don't appear to complain about sourcing a directory, but bash does and it certainly seems like it should be an error. Regardless, this ensures that the whole shell doesn't exit in this case. This solves #1043 .

It was unclear to me where to look for the code for redirection that seems to have the same problem so I didn't attempt to fix that, but I did add a failing spec test for that mentioned in #1044 .