### PR TITLE
Add -l and --login flags as no-op

### DIFF
--- a/frontend/flag_def.py
+++ b/frontend/flag_def.py
@@ -206,6 +206,8 @@ OSH_SPEC.LongFlag('--help')
 OSH_SPEC.LongFlag('--version')
 
 OSH_SPEC.ShortFlag('-i')  # interactive
+OSH_SPEC.ShortFlag('-l')  # login - currently no-op
+OSH_SPEC.LongFlag('--login')  # login - currently no-op
 OSH_SPEC.LongFlag('--headless')  # accepts ECMD, etc.
 
 # TODO: -h too

--- a/spec/sh-usage.test.sh
+++ b/spec/sh-usage.test.sh
@@ -81,3 +81,14 @@ warned=0
 warned=1
 warned=1
 ## END
+
+#### accepts -l flag
+$SH -l -c 'exit 0'
+## status: 0
+
+
+#### accepts --login flag (dash and mksh don't accept long flags)
+$SH --login -c 'exit 0'
+## status: 0
+## OK dash status: 2
+## OK mksh status: 1


### PR DESCRIPTION
Bash supports these flags to indicate that it should run as a login shell. This adds these flags as a no-op to osh since osh doesn't currently behave differently as a login vs. non-login shell.

Please let me know if this is the wrong place/way to test or fix this.

Fixes #1052