### PR TITLE
Implement failglob

### DIFF
--- a/core/error.py
+++ b/core/error.py
@@ -153,11 +153,8 @@ if mylib.PYTHON:
     argument.
     """
 
-  class FailGlob(Exception):
+  class FailGlob(_ErrorWithLocation):
     """Raised when a glob matches nothing when failglob is set."""
-
-    def __init__(self, glob):
-      self.glob = glob
 
 
   class Strict(FatalRuntime):

--- a/core/error.py
+++ b/core/error.py
@@ -158,7 +158,6 @@ if mylib.PYTHON:
 
     def __init__(self, glob):
       self.glob = glob
-      self.msg = 'No match: %s' % glob
 
 
   class Strict(FatalRuntime):

--- a/core/error.py
+++ b/core/error.py
@@ -153,6 +153,13 @@ if mylib.PYTHON:
     argument.
     """
 
+  class FailGlob(Exception):
+    """Raised when a glob matches nothing when failglob is set."""
+
+    def __init__(self, glob):
+      self.glob = glob
+      self.msg = 'No match: %s' % glob
+
 
   class Strict(FatalRuntime):
     """Depending on shell options, these errors may be caught and ignored.

--- a/doc/osh-help-topics.md
+++ b/doc/osh-help-topics.md
@@ -151,7 +151,7 @@ X [Unsupported]   enable
 
 ```osh-help-topics
   [Errors]        nounset   pipefail   errexit   inherit_errexit
-  [Globbing]      noglob   nullglob   X failglob   dashglob
+  [Globbing]      noglob   nullglob   failglob   dashglob
   [Debugging]     xtrace   X verbose   X extdebug
   [Interactive]   emacs   vi
   [Other Option]  X noclobber

--- a/frontend/option_def.py
+++ b/frontend/option_def.py
@@ -258,7 +258,7 @@ def _Init(opt_def):
   #
 
   # shopt options that aren't in any groups.
-  opt_def.Add('failglob')  # not implemented.
+  opt_def.Add('failglob')
   opt_def.Add('extglob')
 
   # Compatibility

--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -1367,7 +1367,7 @@ class CommandEvaluator(object):
               # handle this error here as it can occur in many places
               # in _Dispatch
               e.span_id = self.mem.CurrentSpanId()
-              ui.PrettyPrintError(e, self.arena)
+              ui.PrettyPrintError(e, self.arena, prefix='failglob: ')
               status, check_errexit = 1, True
 
           codes = pipeline_st.codes 

--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -595,12 +595,7 @@ class CommandEvaluator(object):
         # - $() and <() can have failures.  This can happen in DBracket,
         #   DParen, etc. too
         # - Tracing: this can start processes for proc sub and here docs!
-        try:
-          cmd_val = self.word_ev.EvalWordSequence2(words, allow_assign=True)
-        except error.FailGlob as e:
-          e.word = words[0]
-          ui.PrettyPrintError(e, self.arena)
-          return 1, True
+        cmd_val = self.word_ev.EvalWordSequence2(words, allow_assign=True)
 
         UP_cmd_val = cmd_val
         if UP_cmd_val.tag_() == cmd_value_e.Argv:
@@ -1100,12 +1095,7 @@ class CommandEvaluator(object):
           iter_list = self.mem.GetArgv()
         else:
           words = braces.BraceExpandWords(node.iter_words)
-          try:
-            iter_list = self.word_ev.EvalWordSequence(words)
-          except error.FailGlob as e:
-            e.span_id = node.spids[0]
-            ui.PrettyPrintError(e, self.arena)
-            return 1, True
+          iter_list = self.word_ev.EvalWordSequence(words)
 
         status = 0  # in case we don't loop
         self.loop_level += 1
@@ -1371,7 +1361,14 @@ class CommandEvaluator(object):
         if self.shell_ex.PushRedirects(redirects):
           # Asymmetry because of applying redirects can fail.
           with vm.ctx_Redirect(self.shell_ex):
-            status, check_errexit = self._Dispatch(node, pipeline_st)
+            try:
+              status, check_errexit = self._Dispatch(node, pipeline_st)
+            except error.FailGlob as e:
+              # handle this error here as it can occur in many places
+              # in _Dispatch
+              e.span_id = self.mem.CurrentSpanId()
+              ui.PrettyPrintError(e, self.arena)
+              status, check_errexit = 1, True
 
           codes = pipeline_st.codes 
           if len(codes):  # Did we run a pipeline?

--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -594,7 +594,6 @@ class CommandEvaluator(object):
         # Note: Individual WORDS can fail
         # - $() and <() can have failures.  This can happen in DBracket,
         #   DParen, etc. too
-        # - we could catch the 'failglob' exception here and return 1, e.g. *.bad
         # - Tracing: this can start processes for proc sub and here docs!
         cmd_val = self.word_ev.EvalWordSequence2(words, allow_assign=True)
 
@@ -1539,6 +1538,9 @@ class CommandEvaluator(object):
     except error.Parse as e:
       self.dumper.MaybeCollect(self, e)  # Do this before unwinding stack
       raise
+    except error.FailGlob as e:
+      status = 1
+      self.errfmt.StderrLine(e.msg)
     except error.ErrExit as e:
       err = e
       is_errexit = True

--- a/osh/glob_.py
+++ b/osh/glob_.py
@@ -455,7 +455,7 @@ class Globber(object):
 
     # Nothing matched
     if self.exec_opts.failglob():
-      raise error.FailGlob('no match')
+      raise error.FailGlob('Pattern %r matched no files' % arg)
 
     if self.exec_opts.nullglob():
       return 0

--- a/osh/glob_.py
+++ b/osh/glob_.py
@@ -10,6 +10,7 @@ from _devbuild.gen.syntax_asdl import (
     glob_part_e, glob_part, glob_part_t,
     glob_part__Literal, glob_part__Operator, glob_part__CharClass,
 )
+from core import error
 from core import pyutil
 from core.pyutil import stderr_line
 from core.pyerror import log
@@ -453,11 +454,8 @@ class Globber(object):
       return n
 
     # Nothing matched
-    #if self.exec_opts.failglob():
-      # note: to match bash, the whole command has to return 1.  But this also
-      # happens in for loop and array literal contexts.  It might not be worth
-      # it?
-    #  raise NotImplementedError()
+    if self.exec_opts.failglob():
+      raise error.FailGlob(arg)
 
     if self.exec_opts.nullglob():
       return 0

--- a/osh/glob_.py
+++ b/osh/glob_.py
@@ -455,7 +455,7 @@ class Globber(object):
 
     # Nothing matched
     if self.exec_opts.failglob():
-      raise error.FailGlob(arg)
+      raise error.FailGlob('no match')
 
     if self.exec_opts.nullglob():
       return 0

--- a/spec/glob.test.sh
+++ b/spec/glob.test.sh
@@ -251,6 +251,24 @@ status=0
 ## END
 ## N-I dash/mksh/ash status: 127
 
+#### shopt -s failglob behavior on single line with semicolon
+# bash behaves differently for two commands separated by a semicolon
+# than for two commands separated by a newline. This behavior doesn't
+# make sense or seem to be intentional, so osh does not mimic it.
+shopt -s failglob
+echo *.ZZ; echo status=$? # bash doesn't execute the second part!
+echo *.ZZ
+echo status=$? # bash executes this
+## STDOUT:
+status=1
+## END
+## N-I dash/mksh/ash STDOUT:
+*.ZZ
+status=0
+*.ZZ
+status=0
+## END
+
 #### Don't glob flags on file system with GLOBIGNORE
 # This is a bash-specific extension.
 expr $0 : '.*/osh$' >/dev/null && exit 99  # disabled until cd implemented

--- a/spec/glob.test.sh
+++ b/spec/glob.test.sh
@@ -201,6 +201,23 @@ status=0
 status=0
 ## END
 
+#### shopt -s failglob in array literal context
+myarr=(*.ZZ)
+echo "${myarr[@]}"
+shopt -s failglob
+myarr=(*.ZZ)
+echo status=$?
+## STDOUT:
+*.ZZ
+status=1
+## END
+## N-I mksh STDOUT:
+*.ZZ
+status=0
+## END
+## N-I dash/ash stdout-json: ""
+## N-I dash/ash status: 2
+
 #### shopt -s failglob exits properly in command context with set -e
 set -e
 argv.py *.ZZ
@@ -215,7 +232,6 @@ echo status=$?
 ['*.ZZ']
 ## END
 ## N-I dash/mksh/ash status: 127
-
 
 #### shopt -s failglob exits properly in loop context with set -e
 set -e

--- a/spec/glob.test.sh
+++ b/spec/glob.test.sh
@@ -214,6 +214,7 @@ echo status=$?
 ## N-I dash/mksh/ash STDOUT:
 ['*.ZZ']
 ## END
+## N-I dash/mksh/ash status: 127
 
 
 #### shopt -s failglob exits properly in loop context with set -e

--- a/spec/glob.test.sh
+++ b/spec/glob.test.sh
@@ -201,6 +201,39 @@ status=0
 status=0
 ## END
 
+#### shopt -s failglob exits properly in command context with set -e
+set -e
+argv.py *.ZZ
+shopt -s failglob
+argv.py *.ZZ
+echo status=$?
+## STDOUT:
+['*.ZZ']
+## END
+## status: 1
+## N-I dash/mksh/ash STDOUT:
+['*.ZZ']
+## END
+
+
+#### shopt -s failglob exits properly in loop context with set -e
+set -e
+for x in *.ZZ; do echo $x; done
+echo status=$?
+shopt -s failglob
+for x in *.ZZ; do echo $x; done
+echo status=$?
+## STDOUT:
+*.ZZ
+status=0
+## END
+## status: 1
+## N-I dash/mksh/ash STDOUT:
+*.ZZ
+status=0
+## END
+## N-I dash/mksh/ash status: 127
+
 #### Don't glob flags on file system with GLOBIGNORE
 # This is a bash-specific extension.
 expr $0 : '.*/osh$' >/dev/null && exit 99  # disabled until cd implemented
@@ -292,7 +325,7 @@ touch $TMP/__a__
 touch $TMP/__μ__
 cd $TMP
 
-echo __?__ 
+echo __?__
 
 ## STDOUT:
 __a__ __μ__
@@ -318,4 +351,3 @@ other
 other
 other
 ## END
-

--- a/test/spec.sh
+++ b/test/spec.sh
@@ -484,7 +484,7 @@ sh-func() {
 
 glob() {
   # Note: can't pass because it assumes 'bin' exists, etc.
-  sh-spec spec/glob.test.sh --osh-failures-allowed 6 \
+  sh-spec spec/glob.test.sh --osh-failures-allowed 4 \
     ${REF_SHELLS[@]} $BUSYBOX_ASH $OSH_LIST "$@"
 }
 

--- a/test/spec.sh
+++ b/test/spec.sh
@@ -484,7 +484,7 @@ sh-func() {
 
 glob() {
   # Note: can't pass because it assumes 'bin' exists, etc.
-  sh-spec spec/glob.test.sh --osh-failures-allowed 4 \
+  sh-spec spec/glob.test.sh --osh-failures-allowed 5 \
     ${REF_SHELLS[@]} $BUSYBOX_ASH $OSH_LIST "$@"
 }
 


### PR DESCRIPTION
This implements failglob for osh. I'm not sure about the error message setup here, it could be too verbose, but bash prints a message for this in addition to setting a non-zero status. Also could be missing some contexts, but this appears to do the right thing for command context, loop context, and array literals.

In reference to #1036