### PR TITLE
Fix minor typo in core/completion.py

### DIFF
--- a/core/completion.py
+++ b/core/completion.py
@@ -526,7 +526,7 @@ class VariablesAction(CompletionAction):
 class ExternalCommandAction(CompletionAction):
   """Complete commands in $PATH.
 
-  This is PART of compge -A command.
+  This is PART of compgen -A command.
   """
   def __init__(self, mem):
     # type: (Mem) -> None


### PR DESCRIPTION
While trying to figure out why [aliases and functions were not getting
suggested by the completion system](https://github.com/oilshell/oil/issues/1064), I noticed a small typo in a comment, that prevented it from showing up when I searched for appearances of `compgen` in the repository.