### PR TITLE
INSTALL.txt: add install items from getting-started here (to move)

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -53,6 +53,37 @@ This parses and prints a syntax tree for the 'configure' script.
 
     osh -n configure
 
+Optional Configuration
+-----------------------
+
+After creating the directory:
+
+    mkdir -p ~/.config/oil
+
+OSH will create `osh_history` there to store your command history.
+
+You can also create your own startup files in this directory:
+
+- `bin/osh` runs `~/.config/oil/oshrc`
+- `bin/oil` runs `~/.config/oil/oilrc`
+
+These are the **only** files that are "sourced".  Other shells [have a
+confusing initialization sequence involving many files][mess] ([original][]).
+It's very hard to tell when and if `/etc/profile`, `~/.bashrc`,
+`~/.bash_profile`, etc. are executed.
+
+OSH and Oil intentionally avoid this.  If you want those files, simply `source`
+them in your `oshrc`.
+
+[mess]: https://shreevatsa.wordpress.com/2008/03/30/zshbash-startup-files-loading-order-bashrc-zshrc-etc/
+
+[original]: http://www.solipsys.co.uk/new/BashInitialisationFiles.html
+
+I describe my own `oshrc` file on the Wiki: [How To Test
+OSH](https://github.com/oilshell/oil/wiki/How-To-Test-OSH).
+
+- If you get tired of typing `~/.config/oil/oshrc`, symlink it to `~/.oshrc`.
+
 Documentation
 ------------------
 

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -9,7 +9,13 @@ This file describes how to configure, build, and install it from source code.
 Quick Start
 -----------
 
-If you haven't already done so, extract the tarball:
+If you haven't already done so, download the source code from 
+the [releases page](https://www.oilshell.org/releases.html).
+
+To get interactive features, install GNU readline library development 
+packages (see software requirements below).
+
+Extract the tarball:
  
     tar -x --xz < oil-0.10.1.tar.xz
     cd oil-0.10.1
@@ -47,14 +53,14 @@ This parses and prints a syntax tree for the 'configure' script.
 
     osh -n configure
 
-More Documentation
+Documentation
 ------------------
 
 Every release has a home page with links, e.g.
 
     https://oilshell.org/release/0.10.1/
 
-System Requirements
+Software Requirements
 -------------------
 
 Roughly speaking, you need:


### PR DESCRIPTION
(Once the ./install procedure creates a config dir and default rc files, the configuration info may be shortened to just the optional install of a bashrc include line.)