### PR TITLE
[build] Fix broken macOS build from source

### DIFF
--- a/Python-2.7.13/Python/_warnings.c
+++ b/Python-2.7.13/Python/_warnings.c
@@ -1,5 +1,6 @@
 #include "Python.h"
 #include "frameobject.h"
+#include <ctype.h>
 
 #define MODULE_NAME "_warnings"
 


### PR DESCRIPTION
macOS release build of oil-0.10.1 throws an error on the `make` step.

This is with oil-0.10.1.tar.gz from the website; have not checked if the
brew version suffers from the same issue.

After running `make`, from Python-2.7.13/Python/_warnings.c:
> implicitly declaring library function 'tolower' with type 'int (int)'

with a helpful note to:
> include the header <ctype.h> or explicitly provide a declaration for 'tolower'

This appears to be the same error mentioned in https://github.com/oilshell/oil/issues/978 in the
“So I attempted to install from source” section.

There’s a bunch of warnings too and then at the strip substep there’s a
final error because:
> can't open file: _build/oil/ovm-opt (No such file or directory)

After nuking everything I included <ctype.h> then started the build steps
again to great success.

---
## Notes
I pretty much know just JavaScript so I don’t know what I’m doing.

I downloaded the tarball last Thursday, June 16.

I’m on an M1 Mac running macOS 12.3.1.

I did _not_ try running any of the [spec tests](https://github.com/oilshell/oil/wiki/Spec-Tests) nor setting up a Linux VM, as the issue I’m trying to fix here is just getting the release build to work on macOS.

### terminal output

first time
<details>

```
justin.hong@justin oil-0.10.1 % ./configure
./configure: Wrote _build/detected-config.sh and _build/detected-config.h
justin.hong@justin oil-0.10.1 % make
build/compile.sh build-opt _build/oil/ovm-opt _build/oil/module_init.c _build/oil/main_name.c _build/oil/c-module-srcs.txt
~/Downloads/oil-0.10.1/Python-2.7.13 ~/Downloads/oil-0.10.1
Python/_warnings.c:503:13: error: implicitly declaring library function 'tolower' with type 'int (int)' [-Werror,-Wimplicit-function-declaration]
            tolower(file_str[len-3]) == 'p' &&
            ^
Python/_warnings.c:503:13: note: include the header <ctype.h> or explicitly provide a declaration for 'tolower'
1 error generated.
Python/getargs.c:1034:21: warning: variable 'encoding' set but not used [-Wunused-but-set-variable]
        const char *encoding;
                    ^
1 warning generated.
../native/posixmodule.c:190:13: warning: result of comparison of constant 9223372036854775807 with expression of type 'uid_t' (aka 'unsigned int') is always true [-Wtautological-constant-out-of-range-compare]
    if (uid <= LONG_MAX)
        ~~~ ^  ~~~~~~~~
../native/posixmodule.c:198:13: warning: result of comparison of constant 9223372036854775807 with expression of type 'gid_t' (aka 'unsigned int') is always true [-Wtautological-constant-out-of-range-compare]
    if (gid <= LONG_MAX)
        ~~~ ^  ~~~~~~~~
2 warnings generated.
../py-yajl/decoder.c:224:5: warning: incompatible function pointer types initializing 'int (*)(void *, const char *, size_t)' (aka 'int (*)(void *, const char *, unsigned long)') with an expression of type 'int (void *, const char *, unsigned int)' [-Wincompatible-function-pointer-types]
    handle_number,
    ^~~~~~~~~~~~~
../py-yajl/decoder.c:225:5: warning: incompatible function pointer types initializing 'int (*)(void *, const unsigned char *, size_t)' (aka 'int (*)(void *, const unsigned char *, unsigned long)') with an expression of type 'int (void *, const unsigned char *, unsigned int)' [-Wincompatible-function-pointer-types]
    handle_string,
    ^~~~~~~~~~~~~
../py-yajl/decoder.c:227:5: warning: incompatible function pointer types initializing 'int (*)(void *, const unsigned char *, size_t)' (aka 'int (*)(void *, const unsigned char *, unsigned long)') with an expression of type 'int (void *, const unsigned char *, unsigned int)' [-Wincompatible-function-pointer-types]
    handle_dict_key,
    ^~~~~~~~~~~~~~~
../py-yajl/decoder.c:272:37: warning: passing 'char *' to parameter of type 'const unsigned char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Wpointer-sign]
    str = yajl_get_error(parser, 1, buffer, buflen);
                                    ^~~~~~
../py-yajl/yajl/yajl-2.1.1/include/yajl/yajl_parse.h:202:67: note: passing argument to parameter 'jsonText' here
                                            const unsigned char * jsonText,
                                                                  ^
4 warnings generated.
../py-yajl/encoder.c:173:51: warning: passing 'const unsigned char *' to parameter of type 'const char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Wpointer-sign]
    PyObject* result = PyString_FromStringAndSize(buf, len);
                                                  ^~~
Include/stringobject.h:62:63: note: passing argument to parameter here
PyAPI_FUNC(PyObject *) PyString_FromStringAndSize(const char *, Py_ssize_t);
                                                              ^
1 warning generated.
../py-yajl/yajl.c:107:16: warning: assigning to 'char *' from 'const char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
        spaces = IndentString(indent);
               ^ ~~~~~~~~~~~~~~~~~~~~
../py-yajl/yajl.c:206:16: warning: assigning to 'char *' from 'const char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
        spaces = IndentString(indent);
               ^ ~~~~~~~~~~~~~~~~~~~~
../py-yajl/yajl.c:218:15: warning: incompatible function pointer types initializing 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') with an expression of type 'PyCFunctionWithKeywords' (aka 'struct _object *(*)(struct _object *, struct _object *, struct _object *)') [-Wincompatible-function-pointer-types]
    {"dumps", (PyCFunctionWithKeywords)(py_dumps), METH_VARARGS | METH_KEYWORDS,
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../py-yajl/yajl.c:234:14: warning: incompatible function pointer types initializing 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') with an expression of type 'PyCFunctionWithKeywords' (aka 'struct _object *(*)(struct _object *, struct _object *, struct _object *)') [-Wincompatible-function-pointer-types]
    {"dump", (PyCFunctionWithKeywords)(py_dump), METH_VARARGS | METH_KEYWORDS,
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
4 warnings generated.

real	0m11.027s
user	0m8.813s
sys	0m1.162s
~/Downloads/oil-0.10.1
strip -o _build/oil/ovm-opt.stripped _build/oil/ovm-opt
error: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/strip: can't open file: _build/oil/ovm-opt (No such file or directory)
make: *** [_build/oil/ovm-opt.stripped] Error 1
justin.hong@justin oil-0.10.1 % sudo ./install
Password:
install: _bin/oil.ovm: No such file or directory
FATAL install error: Couldn't install oil binary
justin.hong@justin oil-0.10.1 %
```
</details>

ah darn it looks like I didn’t save the output from when I ran `configure` without the extra flag for readline, but here’s that below

after:
1. deleting everything
2. re-extracting tarball
3. adding the header file in _warnings.c

<details>

```
justin.hong@justin oil-0.10.1 % ./configure --with-readline --readline=/opt/homebrew/Cellar/readline/8.1.2
./configure: Wrote _build/detected-config.sh and _build/detected-config.h
justin.hong@justin oil-0.10.1 % make
build/compile.sh build-opt _build/oil/ovm-opt _build/oil/module_init.c _build/oil/main_name.c _build/oil/c-module-srcs.txt
~/Downloads/oil-0.10.1/Python-2.7.13 ~/Downloads/oil-0.10.1
Python/getargs.c:1034:21: warning: variable 'encoding' set but not used [-Wunused-but-set-variable]
        const char *encoding;
                    ^
1 warning generated.
In file included from ../native/line_input.c:64:
In file included from /opt/homebrew/Cellar/readline/8.1.2/include/readline/readline.h:36:
/opt/homebrew/Cellar/readline/8.1.2/include/readline/rltypedefs.h:35:22: warning: this function declaration is not a prototype [-Wstrict-prototypes]
typedef int Function () __attribute__ ((deprecated));
                     ^
                      void
/opt/homebrew/Cellar/readline/8.1.2/include/readline/rltypedefs.h:36:24: warning: this function declaration is not a prototype [-Wstrict-prototypes]
typedef void VFunction () __attribute__ ((deprecated));
                       ^
                        void
/opt/homebrew/Cellar/readline/8.1.2/include/readline/rltypedefs.h:37:26: warning: this function declaration is not a prototype [-Wstrict-prototypes]
typedef char *CPFunction () __attribute__ ((deprecated));
                         ^
                          void
/opt/homebrew/Cellar/readline/8.1.2/include/readline/rltypedefs.h:38:28: warning: this function declaration is not a prototype [-Wstrict-prototypes]
typedef char **CPPFunction () __attribute__ ((deprecated));
                           ^
                            void
In file included from ../native/line_input.c:64:
/opt/homebrew/Cellar/readline/8.1.2/include/readline/readline.h:408:23: warning: this function declaration is not a prototype [-Wstrict-prototypes]
extern int rl_message ();
                      ^
                       void
5 warnings generated.
../native/posixmodule.c:190:13: warning: result of comparison of constant 9223372036854775807 with expression of type 'uid_t' (aka 'unsigned int') is always true [-Wtautological-constant-out-of-range-compare]
    if (uid <= LONG_MAX)
        ~~~ ^  ~~~~~~~~
../native/posixmodule.c:198:13: warning: result of comparison of constant 9223372036854775807 with expression of type 'gid_t' (aka 'unsigned int') is always true [-Wtautological-constant-out-of-range-compare]
    if (gid <= LONG_MAX)
        ~~~ ^  ~~~~~~~~
2 warnings generated.
../py-yajl/decoder.c:224:5: warning: incompatible function pointer types initializing 'int (*)(void *, const char *, size_t)' (aka 'int (*)(void *, const char *, unsigned long)') with an expression of type 'int (void *, const char *, unsigned int)' [-Wincompatible-function-pointer-types]
    handle_number,
    ^~~~~~~~~~~~~
../py-yajl/decoder.c:225:5: warning: incompatible function pointer types initializing 'int (*)(void *, const unsigned char *, size_t)' (aka 'int (*)(void *, const unsigned char *, unsigned long)') with an expression of type 'int (void *, const unsigned char *, unsigned int)' [-Wincompatible-function-pointer-types]
    handle_string,
    ^~~~~~~~~~~~~
../py-yajl/decoder.c:227:5: warning: incompatible function pointer types initializing 'int (*)(void *, const unsigned char *, size_t)' (aka 'int (*)(void *, const unsigned char *, unsigned long)') with an expression of type 'int (void *, const unsigned char *, unsigned int)' [-Wincompatible-function-pointer-types]
    handle_dict_key,
    ^~~~~~~~~~~~~~~
../py-yajl/decoder.c:272:37: warning: passing 'char *' to parameter of type 'const unsigned char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Wpointer-sign]
    str = yajl_get_error(parser, 1, buffer, buflen);
                                    ^~~~~~
../py-yajl/yajl/yajl-2.1.1/include/yajl/yajl_parse.h:202:67: note: passing argument to parameter 'jsonText' here
                                            const unsigned char * jsonText,
                                                                  ^
4 warnings generated.
../py-yajl/encoder.c:173:51: warning: passing 'const unsigned char *' to parameter of type 'const char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Wpointer-sign]
    PyObject* result = PyString_FromStringAndSize(buf, len);
                                                  ^~~
Include/stringobject.h:62:63: note: passing argument to parameter here
PyAPI_FUNC(PyObject *) PyString_FromStringAndSize(const char *, Py_ssize_t);
                                                              ^
1 warning generated.
../py-yajl/yajl.c:107:16: warning: assigning to 'char *' from 'const char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
        spaces = IndentString(indent);
               ^ ~~~~~~~~~~~~~~~~~~~~
../py-yajl/yajl.c:206:16: warning: assigning to 'char *' from 'const char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
        spaces = IndentString(indent);
               ^ ~~~~~~~~~~~~~~~~~~~~
../py-yajl/yajl.c:218:15: warning: incompatible function pointer types initializing 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') with an expression of type 'PyCFunctio
nWithKeywords' (aka 'struct _object *(*)(struct _object *, struct _object *, struct _object *)') [-Wincompatible-function-pointer-types]
    {"dumps", (PyCFunctionWithKeywords)(py_dumps), METH_VARARGS | METH_KEYWORDS,
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../py-yajl/yajl.c:234:14: warning: incompatible function pointer types initializing 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') with an expression of type 'PyCFunctionWithKeywords' (aka 'struct _object *(*)(struct _object *, struct _object *, struct _object *)') [-Wincompatible-function-pointer-types]
    {"dump", (PyCFunctionWithKeywords)(py_dump), METH_VARARGS | METH_KEYWORDS,
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
4 warnings generated.

real	0m11.692s
user	0m8.978s
sys	0m1.618s
~/Downloads/oil-0.10.1
strip -o _build/oil/ovm-opt.stripped _build/oil/ovm-opt
cat _build/oil/ovm-opt.stripped _build/oil/bytecode-opy.zip > _bin/oil.ovm
chmod +x _bin/oil.ovm
justin.hong@justin oil-0.10.1 % chsh -s /usr/local/bin/osh
Changing shell for justin.hong.
Password for justin.hong:
chsh: WARNING: shell '/usr/local/bin/osh' does not exist
justin.hong@justin oil-0.10.1 % vi /etc/shells
justin.hong@justin oil-0.10.1 % sudo ./install
Password:
install: _bin/oil.ovm -> /usr/local/bin//oil.ovm
    Installed executable
    Created 'osh' symlink
    Created 'oil' symlink
    Installed man page
install: doc/osh.1 -> /usr/local/share/man/man1//osh.1
justin.hong@justin oil-0.10.1 % osh -c 'echo hi'
hi
justin.hong@justin oil-0.10.1 % osh -n configure
(command.CommandList
```
</details>