### PR TITLE
[cpp] Survey a fair number of assert(0) function calls

### DIFF
--- a/cpp/core_pyos.cc
+++ b/cpp/core_pyos.cc
@@ -59,7 +59,7 @@ Tuple2<int, int> ReadByte(int fd) {
 
 // for read --line
 Str* ReadLine() {
-  assert(0);
+  assert(0); // Does this get called?
 }
 
 Dict<Str*, Str*>* Environ() {

--- a/cpp/frontend_flag_spec.cc
+++ b/cpp/frontend_flag_spec.cc
@@ -59,7 +59,7 @@ void _CreateDefaults(DefaultPair_c* in,
       }
     } break;
     default:
-      assert(0);
+      assert(0); // NOTE(Jesse): Pretty sure this is InvalidCodePath()
     }
     out->set(new Str(pair->name), val);
     ++i;

--- a/cpp/libc.h
+++ b/cpp/libc.h
@@ -36,11 +36,11 @@ List<Str*>* regex_match(Str* pattern, Str* str);
 Tuple2<int, int>* regex_first_group_match(Str* pattern, Str* str, int pos);
 
 inline void print_time(double real, double user, double sys) {
-  assert(0);
+  NotImplemented();
 }
 
 inline Str* realpath(Str* path) {
-  assert(0);
+  NotImplemented();
 }
 
 }  // namespace libc

--- a/cpp/osh_bool_stat.cc
+++ b/cpp/osh_bool_stat.cc
@@ -115,7 +115,7 @@ bool DoUnaryOp(Id_t op_id, Str* s) {
     }
   }
 
-  assert(0);
+  InvalidCodePath();
 
   return false;
 }
@@ -145,7 +145,7 @@ bool DoBinaryOp(Id_t op_id, Str* s1, Str* s2) {
     return st1.st_dev == st2.st_dev && st1.st_ino == st2.st_ino;
   }
 
-  assert(0);
+  InvalidCodePath();
 }
 
 }  // namespace bool_stat

--- a/cpp/posix.h
+++ b/cpp/posix.h
@@ -62,11 +62,11 @@ inline Str* uname() {
 // TODO: write proper signatures
 // stat returns stat_result
 inline void stat() {
-  assert(0);
+  NotImplemented(); // Uncalled
 }
 
 inline void lstat() {
-  assert(0);
+  NotImplemented(); // Uncalled
 }
 
 inline Tuple2<int, int> pipe() {
@@ -84,12 +84,12 @@ inline int close(int fd) {
 }
 
 inline int putenv(Str* name, Str* value) {
-  assert(0);
+  NotImplemented();
 }
 
 // TODO: errors
 inline int chdir(Str* path) {
-  assert(0);
+  NotImplemented(); // Uncalled
 }
 
 inline int fork() {

--- a/cpp/qsn_qsn.h
+++ b/cpp/qsn_qsn.h
@@ -50,11 +50,11 @@ inline Str* UEscape(int codepoint) {
 }
 #else
 inline Str* XEscape(Str* ch) {
-  assert(0);
+  NotImplemented(); // Unused
 }
 
 inline Str* UEscape(int codepoint) {
-  assert(0);
+  NotImplemented(); // Unused
 }
 #endif
 

--- a/cpp/time_.h
+++ b/cpp/time_.h
@@ -10,7 +10,7 @@
 namespace time_ {
 
 inline void* tzset() {
-  assert(0);
+  NotImplemented();
 }
 
 inline int time() {
@@ -19,11 +19,11 @@ inline int time() {
 
 // TODO: Should these be bigger integers?
 inline int localtime(int ts) {
-  assert(0);
+  NotImplemented();
 }
 
 inline Str* strftime(Str* s, int ts) {
-  assert(0);
+  NotImplemented();
 }
 
 }  // namespace time_

--- a/mycpp/demo/gc_heap.cc
+++ b/mycpp/demo/gc_heap.cc
@@ -276,6 +276,8 @@ class AtomEntry {
 class AtomTable {
  public:
   int Intern(Slice_2 slice) {
+    // TODO(Jesse): Does this get called?
+    // Is this NotImplemented() or InvalidCodePath() ??
     assert(0);
   }
 

--- a/mycpp/examples/parse_preamble.h
+++ b/mycpp/examples/parse_preamble.h
@@ -3,5 +3,5 @@
 
 // For hnode::External in asdl/format.py
 inline Str* repr(void* obj) {
-  assert(0);
+  NotImplemented(); // Uncalled
 }

--- a/mycpp/gc_heap.h
+++ b/mycpp/gc_heap.h
@@ -352,12 +352,16 @@ class Local {
 
   // IMPLICIT conversion.  No 'explicit'.
   Local(T* raw_pointer) : raw_pointer_(raw_pointer) {
+    // TODO(Jesse): Does this get called?
+    // Is this NotImplemented() or InvalidCodePath() ??
     assert(0);
     // gHeap.PushRoot(this);
   }
 
   // Copy constructor, e.g. f(mylocal) where f(Local<T> param);
   Local(const Local& other) : raw_pointer_(other.raw_pointer_) {
+    // TODO(Jesse): Does this get called?
+    // Is this NotImplemented() or InvalidCodePath() ??
     assert(0);
     // gHeap.PushRoot(this);
   }
@@ -633,11 +637,11 @@ class Str : public gc_heap::Obj {
   bool isupper();
 
   Str* upper() {
-    assert(0);
+    NotImplemented(); // Uncalled
   }
 
   Str* lower() {
-    assert(0);
+    NotImplemented(); // Uncalled
   }
 
   // Other options for fast comparison / hashing / string interning:
@@ -1175,7 +1179,7 @@ class Dict : public gc_heap::Obj {
   V index_(K key) {
     int pos = position_of_key(key);
     if (pos == -1) {
-      assert(0); // NOTE(Jesse): Should we really crash if asking for a key not in a dict?
+      InvalidCodePath(); // NOTE(Jesse): Should we really crash if asking for a key not in a dict?
     } else {
       return values_->items_[pos];
     }

--- a/mycpp/my_runtime.cc
+++ b/mycpp/my_runtime.cc
@@ -232,7 +232,7 @@ Str* Str::strip() {
 
 // Used for CommandSub in osh/cmd_exec.py
 Str* Str::rstrip(Str* chars) {
-  assert(0);
+  NotImplemented(); // Uncalled
 }
 
 Str* Str::rstrip() {

--- a/mycpp/my_runtime.h
+++ b/mycpp/my_runtime.h
@@ -143,7 +143,7 @@ inline bool to_bool(Str* s) {
 }
 
 inline double to_float(Str* s) {
-  assert(0);
+  NotImplemented(); // Uncalled
 }
 
 // https://stackoverflow.com/questions/3919995/determining-sprintf-buffer-size-whats-the-standard/11092994#11092994
@@ -162,7 +162,7 @@ inline Str* str(int i) {
 }
 
 inline Str* str(double f) {  // TODO: should be double
-  assert(0);
+  NotImplemented(); // Uncalled
 }
 
 inline int ord(Str* s) {
@@ -247,6 +247,8 @@ inline bool str_contains(Str* haystack, Str* needle) {
   if (len(needle) == 1) {
     return memchr(haystack->data_, needle->data_[0], len(haystack));
   }
+
+  // NOTE(Jesse): Not sure what this TODO means.  Remove strstr and do it ourselves maybe?
   // TODO: Implement substring
   assert(0);
 

--- a/mycpp/mylib.h
+++ b/mycpp/mylib.h
@@ -335,11 +335,11 @@ class Str : public gc_heap::Obj {
   }
 
   Str* upper() {
-    assert(0);
+    NotImplemented();
   }
 
   Str* lower() {
-    assert(0);
+    NotImplemented();
   }
 
   Str* ljust(int width, Str* fillchar);
@@ -496,8 +496,9 @@ class List : public gc_heap::Obj {
   // TODO: Don't accept arbitrary index?
   T pop(int index) {
     if (v_.size() == 0) {
-      // TODO: Handle this better?
-      assert(0);
+      // TODO(Jesse): Probably shouldn't crash if we try to pop a List with
+      // nothing on it
+      InvalidCodePath();
     }
 
     T result = v_.at(index);
@@ -786,7 +787,8 @@ Dict<K, V>* NewDict() {
 template <typename K, typename V>
 Dict<K, V>* NewDict(std::initializer_list<K> keys,
                     std::initializer_list<V> values) {
-  assert(0);
+  // TODO(Jesse): Is this NotImplemented() or InvalidCodePath() ?
+  assert(0); // Uncalled
 }
 
 #endif  // USING_OLD_MYLIB
@@ -956,7 +958,7 @@ inline Str* str(int i) {
 }
 
 inline Str* str(double f) {  // TODO: should be double
-  assert(0);
+  NotImplemented(); // Uncalled
 }
 
 // Display a quoted representation of a string.  word_.Pretty() uses it.
@@ -987,7 +989,7 @@ inline bool to_bool(Str* s) {
 }
 
 inline double to_float(Str* s) {
-  assert(0);
+  NotImplemented();
 }
 
 // e.g. ('a' in 'abc')
@@ -1097,7 +1099,7 @@ inline void dict_remove(Dict<Str*, V>* haystack, Str* needle) {
 // TODO: how to do the int version of this?  Do you need an extra bit?
 template <typename V>
 inline void dict_remove(Dict<int, V>* haystack, int needle) {
-  assert(0);
+  NotImplemented();
 }
 
 // A class for interfacing Str* slices with C functions that expect a NUL
@@ -1158,8 +1160,9 @@ class LineReader {
   virtual bool isatty() {
     return false;
   }
+
   virtual int fileno() {
-    assert(0);  // shouldn't be called here
+    NotImplemented();
   }
 };
 

--- a/mycpp/mylib2.h
+++ b/mycpp/mylib2.h
@@ -61,7 +61,7 @@ class LineReader : gc_heap::Obj {
     return false;
   }
   virtual int fileno() {
-    assert(0);  // shouldn't be called here
+    NotImplemented(); // Uncalled
   }
 };
 


### PR DESCRIPTION
Searched out a fair number of `assert(0)` functions and marked them in one of four ways:

1. Left it as `assert(0)` as I was unable to determine its purpose, or if the function is called.
2. Changed it to `InvalidCodePath()` if it's there to intentionally cause a crash.
3. Changed to `NotImplemented(); // Uncalled` if the function does not get called in the codebase.
4. Changed to `NotImplemented():` if the function gets called.