### PR TITLE
Jesse/bugfix/strftime static buffer

### DIFF
--- a/cpp/time_.h
+++ b/cpp/time_.h
@@ -6,6 +6,8 @@
 #include <time.h>
 
 #include "mycpp/mylib_leaky.h"
+#include "cpp/core_error.h"
+#include "cpp/core_pyerror.h"
 
 namespace time_ {
 
@@ -44,7 +46,7 @@ inline Str* strftime(Str* s, time_t ts) {
   {
     size_of_result = strftime(temp_buf, temp_buf_size, s->data_, loc_time);
 
-    while (temp_buf_size < Megabytes(10))
+    while (size_of_result == 0 && temp_buf_size < Megabytes(10))
     {
       temp_buf_size = temp_buf_size * 2;
       temp_buf = static_cast<char*>(realloc(temp_buf, temp_buf_size));
@@ -61,13 +63,7 @@ inline Str* strftime(Str* s, time_t ts) {
   }
   else
   {
-    snprintf(temp_buf,
-             temp_buf_size,
-             "Call strftime failed.  The result from the format string specified was too long to be accomodated. The buffer we allocated was (%lu) bytes.",
-             temp_buf_size);
-
-    fprintf(stderr, "%s", temp_buf);
-    /* e_die(new Str(temp_buf)); */
+    e_die(new Str("Call strftime failed.  The result from the format string specified was too long to be accomodated."));
   }
 
   free(temp_buf);

--- a/cpp/time_.h
+++ b/cpp/time_.h
@@ -30,6 +30,7 @@ inline time_t localtime(time_t ts) {
 }
 
 inline Str* strftime(Str* s, time_t ts) {
+  int size_of_result = 0;
   Str* result = kEmptyString;
 
   assert(s->IsNulTerminated());
@@ -39,19 +40,21 @@ inline Str* strftime(Str* s, time_t ts) {
   uint64_t temp_buf_size = (s->len_ + 1024) * 2; // NOTE(Jesse): Something completely arbitrary I came up with
   char *temp_buf = static_cast<char*>(malloc(temp_buf_size)); // Doesn't have to be cleared; malloc is fine.
 
-  int size_of_result = strftime(temp_buf, temp_buf_size, s->data_, loc_time);
-
-  int tries = 0;
-  int max_tries = 3; // Retry the allocation 3 times, then bail
-  while (tries < max_tries && size_of_result == 0)
+  if (temp_buf)
   {
-    temp_buf_size = temp_buf_size * 2;
-    temp_buf = realloc(temp_buf, temp_buf_size);
-    if (temp_buf)
+    size_of_result = strftime(temp_buf, temp_buf_size, s->data_, loc_time);
+
+    int tries = 0;
+    int max_tries = 3;
+    while (tries++ < max_tries && size_of_result == 0)
     {
-      size_of_result = strftime(temp_buf, temp_buf_size, s->data_, loc_time);
+      temp_buf_size = temp_buf_size * 2;
+      temp_buf = static_cast<char*>(realloc(temp_buf, temp_buf_size));
+      if (temp_buf)
+      {
+        size_of_result = strftime(temp_buf, temp_buf_size, s->data_, loc_time);
+      }
     }
-    ++tries;
   }
 
   if (size_of_result)

--- a/cpp/time_.h
+++ b/cpp/time_.h
@@ -44,9 +44,7 @@ inline Str* strftime(Str* s, time_t ts) {
   {
     size_of_result = strftime(temp_buf, temp_buf_size, s->data_, loc_time);
 
-    int tries = 0;
-    int max_tries = 3;
-    while (tries++ < max_tries && size_of_result == 0)
+    while (temp_buf_size < Megabytes(10))
     {
       temp_buf_size = temp_buf_size * 2;
       temp_buf = static_cast<char*>(realloc(temp_buf, temp_buf_size));
@@ -59,7 +57,7 @@ inline Str* strftime(Str* s, time_t ts) {
 
   if (size_of_result)
   {
-    result = new Str(temp_buf, size_of_result + 1);
+    result = new Str(temp_buf, size_of_result);
   }
   else
   {
@@ -68,7 +66,8 @@ inline Str* strftime(Str* s, time_t ts) {
              "Call strftime failed.  The result from the format string specified was too long to be accomodated. The buffer we allocated was (%lu) bytes.",
              temp_buf_size);
 
-    e_die(new Str(temp_buf));
+    fprintf(stderr, "%s", temp_buf);
+    /* e_die(new Str(temp_buf)); */
   }
 
   free(temp_buf);

--- a/mycpp/common.h
+++ b/mycpp/common.h
@@ -22,6 +22,16 @@
 #define NotImplemented() assert(!"Not Implemented")
 #define InvalidCodePath() assert(!"Invalid Code Path")
 
+#define Kilobytes(n) (n << 10)
+#define Megabytes(n) (n << 20)
+#define Gigabytes(n) (n << 30)
+#define Terabytes(n) ((uint64_t)((n##ul) << 40))
+
+static_assert(Kilobytes(1) == 1024, "");
+static_assert(Megabytes(1) == Kilobytes(1)*1024, "");
+static_assert(Gigabytes(1) == Megabytes(1)*1024, "");
+static_assert(Terabytes(1) == Gigabytes(1)*1024ul, "");
+
 // Prevent silent copies
 
 #define DISALLOW_COPY_AND_ASSIGN(TypeName) \


### PR DESCRIPTION
So I'm not sure how much we care about this kind of thing, but this patch would improve the handling of strftime.

I noticed that the python version of osh handles very large buffers (the test suite times out after 3 megabytes, but it probably handles much larger ones than that).  The C++ version is faster, so in the same time we can handle roughly 10 megabytes.

I guess my philosophical question here is, for the C++ version, are we willing to accept more complexity in exchange for compatibility with the Python version, or would we rather keep things simple and be on-par or slightly better than BASH?