### PR TITLE
Ensure that the spec test tsv output directory exists

### DIFF
--- a/test/spec-cpp.sh
+++ b/test/spec-cpp.sh
@@ -61,6 +61,7 @@ run-with-osh-eval() {
   shift
 
   local base_dir=_tmp/spec/$SPEC_JOB
+  mkdir -p "$base_dir"
 
   # Run it with 3 versions of OSH.  And output TSV so we can compare the data.
   # 2022-01: Try 10 second timeout.


### PR DESCRIPTION
Previously, running `test/spec-cpp.sh run-with-osh-eval smoke` would
fail with:

    IOError: [Errno 2] No such file or directory: '_tmp/spec/cpp/smoke.tsv'

Now it succeeds.