### PR TITLE
Init BraceGroup() with empty array

### DIFF
--- a/osh/cmd_parse.py
+++ b/osh/cmd_parse.py
@@ -1097,7 +1097,7 @@ class CommandParser(object):
     self._Eat(Id.Lit_RBrace)
     right_spid = word_.LeftMostSpanForWord(self.cur_word)
 
-    node = BraceGroup(doc_token, c_list.children, None)  # no redirects yet
+    node = BraceGroup(doc_token, c_list.children, [])  # no redirects yet
     node.spids.append(left_spid)
     node.spids.append(right_spid)
     return node

--- a/test/baseline.spec-cpp.assertion_fails
+++ b/test/baseline.spec-cpp.assertion_fails
@@ -8,4 +8,3 @@
 (/home/scallywag/work/oil/cpp/core_pyos.h:122: bool pyos::InputAvailable(int): Assertion `0' failed.) _tmp/spec/cpp/builtin-io.html
 (/home/scallywag/work/oil/mycpp/gc_heap.h:268: void gc_heap::Heap::PushRoot(gc_heap::Obj**): Assertion `roots_top_ &lt; kMaxRoots' failed.) _tmp/spec/cpp/alias.html
 (/home/scallywag/work/oil/mycpp/gc_heap.h:268: void gc_heap::Heap::PushRoot(gc_heap::Obj**): Assertion `roots_top_ &lt; kMaxRoots' failed.) _tmp/spec/cpp/ble-idioms.html
-IF YOU SEE THIS OSH IS CRASHING (_tmp/spec/cpp/for-expr.html:<pre>OSH_CPP_SEGFAULT)

--- a/test/baseline.spec-cpp.results
+++ b/test/baseline.spec-cpp.results
@@ -863,6 +863,7 @@
 4 _tmp/spec/cpp/fatal-errors.tsv
 0 _tmp/spec/cpp/for-expr.tsv
 1 _tmp/spec/cpp/for-expr.tsv
+2 _tmp/spec/cpp/for-expr.tsv
 3 _tmp/spec/cpp/for-expr.tsv
 4 _tmp/spec/cpp/for-expr.tsv
 5 _tmp/spec/cpp/for-expr.tsv


### PR DESCRIPTION
Long story short, we've got to initialize these with an empty array or
the code that executes for loops tries to dereference 0 and crashes.