### PR TITLE
Throw OSError* from posix::execve() to match python

### DIFF
--- a/cpp/leaky_posix.h
+++ b/cpp/leaky_posix.h
@@ -3,6 +3,10 @@
 #ifndef POSIX_H
 #define POSIX_H
 
+// clang-format off
+#include "mycpp/myerror.h"  // for OSError; must come first
+// clang-format on
+
 #include <errno.h>
 #include <stdlib.h>  // putenv
 #include <unistd.h>
@@ -134,7 +138,7 @@ inline void execve(Str* argv0, List<Str*>* argv, Dict<Str*, Str*>* environ) {
 
   int ret = ::execve(_argv0.Get(), _argv, nullptr);
   if (ret == -1) {
-    throw IOError(errno);
+    throw new OSError(errno);
   }
 
   // NOTE(Jesse): ::execve() is specified to never return on success.  If we


### PR DESCRIPTION
Previously this was throwing IOError (by value) for which there is no matching handler.

Now it throws OSError* to match its python equivalent (and exception handler in the translated code that calls it).

With this change there's no delta cpp for command_ spec tests!