### PR TITLE
Fix some bad math in Str::split causing invalid writes.

### DIFF
--- a/mycpp/my_runtime.cc
+++ b/mycpp/my_runtime.cc
@@ -440,9 +440,10 @@ List<Str*>* Str::split(Str* sep) {
   // Find breaks first so we can allocate the right number of strings ALL AT
   // ONCE. We want to avoid invalidating self->data_.
   int num_bytes = 0;
-  int prev_pos = 0;
+  int prev_pos = -1;
   std::vector<int> breaks;
   breaks.push_back(-1);  // beginning of first part
+
   for (int i = 0; i < length; ++i) {
     if (data_[i] == sep_char) {
       breaks.push_back(i);
@@ -455,7 +456,15 @@ List<Str*>* Str::split(Str* sep) {
   }
   breaks.push_back(length);  // end of last part
 
+  if (length) {
+    int last_part_len = length - prev_pos - 1;
+    if (last_part_len > 0) {
+      num_bytes += aligned(kStrHeaderSize + last_part_len + 1);
+    }
+  }
+
   result = NewList<Str*>(nullptr, breaks.size() - 1);  // reserve enough space
+
   place = reinterpret_cast<char*>(gHeap.Allocate(num_bytes));
   int n = breaks.size();
   for (int i = 1; i < n; ++i) {

--- a/mycpp/mylib2.h
+++ b/mycpp/mylib2.h
@@ -155,7 +155,13 @@ class BufWriter : public Writer {
   // For cStringIO API
   Str* getvalue() {
     if (data_) {
+      // NOTE(Jesse): @copy_str_possible_gc_crash_no_stack_root
+      //
+      // If data_ is a pointer into the managed heap and the allocation in
+      // CopyStr() collects this will result in an invalid read.
+      //
       Str* ret = gc_heap::CopyStr(data_, len_);
+
       reset();  // Invalidate this instance
       return ret;
     } else {


### PR DESCRIPTION
I wrote a bunch of code to aid in debugging.  Not sure if we should keep it around, but I'm guessing it'll be useful again at some point so I've left it in for now.