### PR TITLE
[cpp] posix::_exit() now calls _exit(), not exit() (#1233)

### DIFF
--- a/cpp/leaky_stdlib.h
+++ b/cpp/leaky_stdlib.h
@@ -86,7 +86,7 @@ inline int fork() {
 }
 
 inline void _exit(int status) {
-  exit(status);
+  ::_exit(status);
 }
 
 inline void write(int fd, Str* s) {

--- a/spec/bugs.test.sh
+++ b/spec/bugs.test.sh
@@ -153,3 +153,17 @@ echo status=$?
 status=1
 status=1
 ## END
+
+#### subshell while running a script (regression)
+# Ensures that spawning a subshell doesn't cause a seek on the file input stream
+# representing the current script (issue #1233).
+cat >tmp.sh <<'EOF'
+echo start
+(:)
+echo end
+EOF
+$SH tmp.sh
+## STDOUT:
+start
+end
+## END


### PR DESCRIPTION
Calls in python to posix._exit() were being translated into calls to
exit(), which has different semantics. Now it calls _exit() as expected.

Testing:
```bash
> cat >/tmp/f.sh <<'EOF'
echo start
$(:)
echo end
EOF

# before this change
> _bin/cxx-dbg/osh_eval /tmp/f.sh
start
end
end

# with this change
> _bin/cxx-dbg/osh_eval /tmp/f.sh
start
end
```

@andychu Sorry if this is mentioned somewhere and I missed it. Will the CI automatically flag any regressions caused by a change like this? I'm not sure if I should be running something locally to verify or not