### PR TITLE
Jesse/refactor/continue porting old str layout to gcd layout

### DIFF
--- a/asdl/tool.py
+++ b/asdl/tool.py
@@ -81,7 +81,6 @@ def main(argv):
       f.write("""
 #ifdef LEAKY_BINDINGS
 #include "mycpp/mylib_old.h"
-using mylib::StrFromC;
 using mylib::NewList;
 #else
 #include "mycpp/gc_types.h"

--- a/asdl/tool.py
+++ b/asdl/tool.py
@@ -82,6 +82,7 @@ def main(argv):
 #ifdef LEAKY_BINDINGS
 #include "mycpp/mylib_old.h"
 using mylib::NewList;
+using mylib::StrFromC;
 #else
 #include "mycpp/gc_types.h"
 using gc_heap::Obj;

--- a/cpp/NINJA-steps.sh
+++ b/cpp/NINJA-steps.sh
@@ -93,7 +93,7 @@ setglobal_compile_flags() {
     (leaky)
       # Could this be ASAN?
       # For cpp/gc_binding_test
-      flags="$flags -O0 -g -D LEAKY_BINDINGS -D LEAKY_TEST_MODE"
+      flags="$flags -O0 -g -D LEAKY_BINDINGS"
       ;;
 
     (opt)

--- a/cpp/gc_binding_test.cc
+++ b/cpp/gc_binding_test.cc
@@ -4,7 +4,7 @@
 // This test runs primarily in the GC mode, but you can also run it in the
 // leaky mode!
 
-#ifdef LEAKY_TEST_MODE
+#ifdef LEAKY_BINDINGS
   #include "mycpp/gc_types.h"
   #include "mycpp/mylib_old.h"
 using gc_heap::StackRoots;  // no-op

--- a/cpp/leaky_binding_test.cc
+++ b/cpp/leaky_binding_test.cc
@@ -17,7 +17,6 @@
 #include "leaky_stdlib.h"
 #include "vendor/greatest.h"
 
-using mylib::StrFromC;
 
 namespace Id = id_kind_asdl::Id;
 

--- a/cpp/leaky_core.cc
+++ b/cpp/leaky_core.cc
@@ -17,7 +17,6 @@
 #include <unistd.h>        // getuid(), environ
 
 #include "mycpp/mylib_old.h"
-
 using mylib::StrFromC;
 using mylib::OverAllocatedStr;
 

--- a/cpp/leaky_core.cc
+++ b/cpp/leaky_core.cc
@@ -242,13 +242,13 @@ Str* ShowAppVersion(Str* app_name, _ResourceLoader* loader) {
 }
 
 Str* BackslashEscape(Str* s, Str* meta_chars) {
-  int upper_bound = s->len_ * 2;
+  int upper_bound = len(s) * 2;
   char* buf = static_cast<char*>(malloc(upper_bound));
   char* p = buf;
 
-  for (int i = 0; i < s->len_; ++i) {
+  for (int i = 0; i < len(s); ++i) {
     char c = s->data_[i];
-    if (memchr(meta_chars->data_, c, meta_chars->len_)) {
+    if (memchr(meta_chars->data_, c, len(meta_chars))) {
       *p++ = '\\';
     }
     *p++ = c;

--- a/cpp/leaky_frontend_match.cc
+++ b/cpp/leaky_frontend_match.cc
@@ -23,7 +23,7 @@ Tuple2<Id_t, int> OneToken(lex_mode_t lex_mode, Str* line, int start_pos) {
 
   // TODO: get rid of these casts
   MatchOshToken(static_cast<int>(lex_mode),
-                reinterpret_cast<const unsigned char*>(line->data_), line->len_,
+                reinterpret_cast<const unsigned char*>(line->data_), len(line),
                 start_pos, &id, &end_pos);
   return Tuple2<Id_t, int>(static_cast<Id_t>(id), end_pos);
 }
@@ -31,7 +31,7 @@ Tuple2<Id_t, int> OneToken(lex_mode_t lex_mode, Str* line, int start_pos) {
 Tuple2<Id_t, Str*> SimpleLexer::Next() {
   int id;
   int end_pos;
-  match_func_(reinterpret_cast<const unsigned char*>(s_->data_), s_->len_, pos_,
+  match_func_(reinterpret_cast<const unsigned char*>(s_->data_), len(s_), pos_,
               &id, &end_pos);
 
   int len = end_pos - pos_;
@@ -83,25 +83,25 @@ List<Tuple2<Id_t, Str*>*>* Ps1Tokens(Str* s) {
 
 Id_t BracketUnary(Str* s) {
   return ::BracketUnary(reinterpret_cast<const unsigned char*>(s->data_),
-                        s->len_);
+                        len(s));
 }
 Id_t BracketBinary(Str* s) {
   return ::BracketBinary(reinterpret_cast<const unsigned char*>(s->data_),
-                         s->len_);
+                         len(s));
 }
 Id_t BracketOther(Str* s) {
   return ::BracketOther(reinterpret_cast<const unsigned char*>(s->data_),
-                        s->len_);
+                        len(s));
 }
 
 bool IsValidVarName(Str* s) {
   return ::IsValidVarName(reinterpret_cast<const unsigned char*>(s->data_),
-                          s->len_);
+                          len(s));
 }
 
 bool ShouldHijack(Str* s) {
   return ::ShouldHijack(reinterpret_cast<const unsigned char*>(s->data_),
-                        s->len_);
+                        len(s));
 }
 
 }  // namespace match

--- a/cpp/leaky_osh.h
+++ b/cpp/leaky_osh.h
@@ -34,13 +34,13 @@ bool DoBinaryOp(Id_t op_id, Str* s1, Str* s2);
 namespace sh_expr_eval {
 
 inline bool IsLower(Str* ch) {
-  assert(ch->len_ == 1);
+  assert(len(ch) == 1);
   uint8_t c = ch->data_[0];
   return ('a' <= c && c <= 'z');
 }
 
 inline bool IsUpper(Str* ch) {
-  assert(ch->len_ == 1);
+  assert(len(ch) == 1);
   uint8_t c = ch->data_[0];
   return ('A' <= c && c <= 'Z');
 }

--- a/cpp/leaky_stdlib.cc
+++ b/cpp/leaky_stdlib.cc
@@ -19,7 +19,6 @@
 #include "cpp/leaky_core_pyerror.h"
 #include "mycpp/mylib_old.h"
 using mylib::OverAllocatedStr;
-using mylib::StrFromC;
 
 namespace fcntl_ {
 

--- a/cpp/leaky_stdlib.cc
+++ b/cpp/leaky_stdlib.cc
@@ -94,11 +94,11 @@ void execve(Str* argv0, List<Str*>* argv, Dict<Str*, Str*>* environ) {
   for (const auto& kv : environ->items_) {
     Str* k = kv.first;
     Str* v = kv.second;
-    int joined_len = k->len_ + v->len_ + 1;
+    int joined_len = len(k) + len(v) + 1;
     char* buf = static_cast<char*>(malloc(joined_len + 1));
-    memcpy(buf, k->data_, k->len_);
-    buf[k->len_] = '=';
-    memcpy(buf + k->len_ + 1, v->data_, v->len_);
+    memcpy(buf, k->data_, len(k));
+    buf[len(k)] = '=';
+    memcpy(buf + len(k) + 1, v->data_, len(v));
     buf[joined_len] = '\0';
     envp[i++] = buf;
   }

--- a/cpp/leaky_stdlib.h
+++ b/cpp/leaky_stdlib.h
@@ -88,7 +88,7 @@ inline void _exit(int status) {
 }
 
 inline void write(int fd, Str* s) {
-  ::write(fd, s->data_, s->len_);
+  ::write(fd, s->data_, len(s));
 }
 
 // Can we use fcntl instead?

--- a/cpp/qsn.h
+++ b/cpp/qsn.h
@@ -8,14 +8,12 @@
 using gc_heap::StackRoots;  // no-op
 using mylib::AllocStr;
 using mylib::OverAllocatedStr;
-using mylib::StrFromC;
 #else
   #include "mycpp/gc_types.h"
 using gc_heap::AllocStr;
 using gc_heap::OverAllocatedStr;
 using gc_heap::StackRoots;
 using gc_heap::Str;
-using gc_heap::StrFromC;
 #endif
 
 namespace qsn {

--- a/cpp/segfault_handler.h
+++ b/cpp/segfault_handler.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef SEGFAULT_HANDLER_H
+#define SEGFAULT_HANDLER_H
 
 static int segfault_handler_initialized;
 
@@ -22,3 +23,5 @@ void complain_loudly_on_segfault() {
     segfault_handler_initialized = 1;
   }
 }
+
+#endif

--- a/cpp/test.sh
+++ b/cpp/test.sh
@@ -99,7 +99,7 @@ gc-binding-test() {
   local bin=$out_dir/gc_binding_test
 
   compile_and_link $compiler $variant '' $bin \
-    "${GC_TEST_SRC[@]}" cpp/dumb_alloc.cc
+    "${GC_TEST_SRC[@]}" cpp/dumb_alloc.cc 
 
   run-test $bin $compiler $variant
 }

--- a/frontend/consts_gen.py
+++ b/frontend/consts_gen.py
@@ -68,8 +68,8 @@ def GenStringLookup(type_name, func_name, pairs, f):
 
   f.write("""\
 %s %s(Str* s) {
-  int len = s->len_;
-  if (len == 0) return 0;  // consts.NO_INDEX
+  int length = len(s);
+  if (length == 0) return 0;  // consts.NO_INDEX
 
   const char* data = s->data_;
   switch (data[0]) {
@@ -81,7 +81,7 @@ def GenStringLookup(type_name, func_name, pairs, f):
     for name, index in pairs:
       # NOTE: we have to check the length because they're not NUL-terminated
       f.write('''\
-    if (len == %d && memcmp("%s", data, %d) == 0) return %d;
+    if (length == %d && memcmp("%s", data, %d) == 0) return %d;
 ''' % (len(name), name, len(name), index))
     f.write('    break;\n')
 
@@ -102,8 +102,8 @@ def GenStringMembership(func_name, strs, f):
 
   f.write("""\
 bool %s(Str* s) {
-  int len = s->len_;
-  if (len == 0) return false;
+  int length = len(s);
+  if (length == 0) return false;
 
   const char* data = s->data_;
   switch (data[0]) {
@@ -115,7 +115,7 @@ bool %s(Str* s) {
     for s in strs:
       # NOTE: we have to check the length because they're not NUL-terminated
       f.write('''\
-    if (len == %d && memcmp("%s", data, %d) == 0) return true;
+    if (length == %d && memcmp("%s", data, %d) == 0) return true;
 ''' % (len(s), s, len(s)))
     f.write('    break;\n')
 

--- a/frontend/consts_gen.py
+++ b/frontend/consts_gen.py
@@ -152,7 +152,7 @@ def CChar(c):
 def GenCharLookup(func_name, lookup, f, required=False):
   f.write("""\
 Str* %s(Str* c) {
-  assert(c->len_ == 1);
+  assert(len(c) == 1);
 
   char ch = c->data_[0];
 

--- a/frontend/flag_gen.py
+++ b/frontend/flag_gen.py
@@ -179,7 +179,6 @@ def Cpp(specs, header_f, cc_f):
 #include "cpp/leaky_frontend_flag_spec.h"  // for FlagSpec_c
 #ifdef LEAKY_BINDINGS
   #include "mycpp/mylib_old.h"
-  using mylib::StrFromC;
 #else
   #include "mycpp/gc_types.h"
   using gc_heap::StrFromC;

--- a/mycpp/error_types.h
+++ b/mycpp/error_types.h
@@ -1,0 +1,36 @@
+#ifndef ERROR_TYPES_H
+#define ERROR_TYPES_H
+
+class Str;
+
+class IndexError {};
+class ValueError {};
+class KeyError {};
+
+class EOFError {};
+
+class NotImplementedError {
+ public:
+  NotImplementedError() {
+  }
+  explicit NotImplementedError(int i) {  // e.g. in expr_to_ast
+  }
+  explicit NotImplementedError(const char* s) {
+  }
+  explicit NotImplementedError(Str* s) {
+  }
+};
+
+class AssertionError {
+ public:
+  AssertionError() {
+  }
+  explicit AssertionError(int i) {  // e.g. in expr_to_ast
+  }
+  explicit AssertionError(const char* s) {
+  }
+  explicit AssertionError(Str* s) {
+  }
+};
+
+#endif

--- a/mycpp/error_types.h
+++ b/mycpp/error_types.h
@@ -1,7 +1,11 @@
 #ifndef ERROR_TYPES_H
 #define ERROR_TYPES_H
 
+#ifdef LEAKY_BINDINGS
 class Str;
+#else
+using gc_heap::Str;
+#endif
 
 class IndexError {};
 class ValueError {};

--- a/mycpp/error_types.h
+++ b/mycpp/error_types.h
@@ -1,5 +1,4 @@
-#ifndef ERROR_TYPES_H
-#define ERROR_TYPES_H
+#pragma once
 
 #ifdef LEAKY_BINDINGS
 class Str;
@@ -37,4 +36,11 @@ class AssertionError {
   }
 };
 
-#endif
+// Python's RuntimeError looks like this.  . libc::regex_match and other
+// bindings raise it.
+class RuntimeError {
+ public:
+  RuntimeError(Str* message) : message(message) {
+  }
+  Str* message;
+};

--- a/mycpp/error_types.h
+++ b/mycpp/error_types.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef ERROR_TYPES_H
+#define ERROR_TYPES_H
 
 #ifdef LEAKY_BINDINGS
 class Str;
@@ -44,3 +45,5 @@ class RuntimeError {
   }
   Str* message;
 };
+
+#endif // ERROR_TYPES_H

--- a/mycpp/gc_builtins.h
+++ b/mycpp/gc_builtins.h
@@ -11,6 +11,7 @@
 #include <climits>    // CHAR_BIT
 
 #include "mycpp/gc_types.h"
+#include "mycpp/error_types.h"
 
 // TODO: Don't use 'using' in header
 using gc_heap::AllocStr;
@@ -19,36 +20,6 @@ using gc_heap::List;
 using gc_heap::StackRoots;
 using gc_heap::Str;
 using gc_heap::StrFromC;
-
-class IndexError {};
-class ValueError {};
-class KeyError {};
-
-class EOFError {};
-
-class NotImplementedError {
- public:
-  NotImplementedError() {
-  }
-  explicit NotImplementedError(int i) {  // e.g. in expr_to_ast
-  }
-  explicit NotImplementedError(const char* s) {
-  }
-  explicit NotImplementedError(Str* s) {
-  }
-};
-
-class AssertionError {
- public:
-  AssertionError() {
-  }
-  explicit AssertionError(int i) {  // e.g. in expr_to_ast
-  }
-  explicit AssertionError(const char* s) {
-  }
-  explicit AssertionError(Str* s) {
-  }
-};
 
 template <class A, class B>
 class Tuple2 {

--- a/mycpp/gc_builtins.h
+++ b/mycpp/gc_builtins.h
@@ -13,6 +13,7 @@
 #include "mycpp/gc_types.h"
 #include "mycpp/error_types.h"
 #include "mycpp/tuple_types.h"
+#include "mycpp/mylib_types.h"
 
 // TODO: Don't use 'using' in header
 using gc_heap::AllocStr;
@@ -51,13 +52,6 @@ inline bool to_bool(Str* s) {
 inline double to_float(Str* s) {
   NotImplemented();  // Uncalled
 }
-
-// https://stackoverflow.com/questions/3919995/determining-sprintf-buffer-size-whats-the-standard/11092994#11092994
-// Notes:
-// - Python 2.7's intobject.c has an erroneous +6
-// - This is 13, but len('-2147483648') is 11, which means we only need 12?
-// - This formula is valid for octal(), because 2^(3 bits) = 8
-const int kIntBufSize = CHAR_BIT * sizeof(int) / 3 + 3;
 
 inline Str* str(int i) {
   // Use a static buffer first because we don't know what n is until we call

--- a/mycpp/gc_builtins.h
+++ b/mycpp/gc_builtins.h
@@ -12,77 +12,14 @@
 
 #include "mycpp/gc_types.h"
 #include "mycpp/error_types.h"
+#include "mycpp/tuple_types.h"
 
 // TODO: Don't use 'using' in header
 using gc_heap::AllocStr;
 using gc_heap::Dict;
 using gc_heap::List;
 using gc_heap::StackRoots;
-using gc_heap::Str;
 using gc_heap::StrFromC;
-
-template <class A, class B>
-class Tuple2 {
- public:
-  Tuple2(A a, B b) : a_(a), b_(b) {
-  }
-  A at0() {
-    return a_;
-  }
-  B at1() {
-    return b_;
-  }
-
- private:
-  A a_;
-  B b_;
-};
-
-template <class A, class B, class C>
-class Tuple3 {
- public:
-  Tuple3(A a, B b, C c) : a_(a), b_(b), c_(c) {
-  }
-  A at0() {
-    return a_;
-  }
-  B at1() {
-    return b_;
-  }
-  C at2() {
-    return c_;
-  }
-
- private:
-  A a_;
-  B b_;
-  C c_;
-};
-
-template <class A, class B, class C, class D>
-class Tuple4 {
- public:
-  Tuple4(A a, B b, C c, D d) : a_(a), b_(b), c_(c), d_(d) {
-  }
-  A at0() {
-    return a_;
-  }
-  B at1() {
-    return b_;
-  }
-  C at2() {
-    return c_;
-  }
-  D at3() {
-    return d_;
-  }
-
- private:
-  A a_;
-  B b_;
-  C c_;
-  D d_;
-};
 
 void println_stderr(Str* s);
 

--- a/mycpp/gc_mylib.h
+++ b/mycpp/gc_mylib.h
@@ -8,7 +8,6 @@
 
 #include "mycpp/gc_builtins.h"  // Tuple2
 #include "mycpp/gc_types.h"
-#include "mycpp/mylib_types.h"
 
 using gc_heap::Alloc;
 using gc_heap::kZeroMask;
@@ -35,6 +34,8 @@ void dict_remove(Dict<Str*, V>* haystack, Str* needle) {
 
 // These 3 functions use a static buffer first because we don't know what n is
 // until we call snprintf().
+
+#include "mycpp/mylib_types.h"
 
 class LineReader : gc_heap::Obj {
  public:

--- a/mycpp/gc_mylib.h
+++ b/mycpp/gc_mylib.h
@@ -8,6 +8,7 @@
 
 #include "mycpp/gc_builtins.h"  // Tuple2
 #include "mycpp/gc_types.h"
+#include "mycpp/mylib_types.h"
 
 using gc_heap::Alloc;
 using gc_heap::kZeroMask;
@@ -34,24 +35,6 @@ void dict_remove(Dict<Str*, V>* haystack, Str* needle) {
 
 // These 3 functions use a static buffer first because we don't know what n is
 // until we call snprintf().
-
-inline Str* hex_lower(int i) {
-  char buf[kIntBufSize];
-  int length = snprintf(buf, kIntBufSize, "%x", i);
-  return StrFromC(buf, length);
-}
-
-inline Str* hex_upper(int i) {
-  char buf[kIntBufSize];
-  int length = snprintf(buf, kIntBufSize, "%X", i);
-  return StrFromC(buf, length);
-}
-
-inline Str* octal(int i) {
-  char buf[kIntBufSize];
-  int length = snprintf(buf, kIntBufSize, "%o", i);
-  return StrFromC(buf, length);
-}
 
 class LineReader : gc_heap::Obj {
  public:

--- a/mycpp/gc_mylib_test.cc
+++ b/mycpp/gc_mylib_test.cc
@@ -47,7 +47,7 @@ TEST split_once_test() {
 }
 
 TEST int_to_str_test() {
-  int int_min = -(1 << 31);
+  int int_min = INT_MIN;
   Str* int_str;
 
   int_str = mylib::hex_lower(15);

--- a/mycpp/leaky_types.cc
+++ b/mycpp/leaky_types.cc
@@ -351,3 +351,4 @@ Str* Str::lstrip() {
 #ifndef LEAKY_BINDINGS
 }  // namespace gc_heap
 #endif
+

--- a/mycpp/leaky_types_test.cc
+++ b/mycpp/leaky_types_test.cc
@@ -4,7 +4,6 @@
   #include "mycpp/mylib_old.h"
 
 using gc_heap::gHeap;
-using mylib::StrFromC;
 
 #else
 

--- a/mycpp/mylib_old.cc
+++ b/mycpp/mylib_old.cc
@@ -131,6 +131,7 @@ Tuple2<Str*, Str*> split_once(Str* s, Str* delim) {
 
 LineReader* gStdin;
 
+#if 1
 Str* CFileLineReader::readline() {
   char* line = nullptr;
   size_t allocated_size = 0;  // unused
@@ -152,6 +153,7 @@ Str* CFileLineReader::readline() {
   // Note: it's NUL terminated
   return new Str(line, len);
 }
+#endif
 
 // problem: most Str methods like index() and slice() COPY so they have a
 // NUL terminator.

--- a/mycpp/mylib_old.cc
+++ b/mycpp/mylib_old.cc
@@ -12,10 +12,10 @@
 Str* kEmptyString = new Str("", 0);
 
 List<Str*>* Str::split(Str* sep) {
-  assert(sep->len_ == 1);  // we can only split one char
+  assert(len(sep) == 1);  // we can only split one char
   char sep_char = sep->data_[0];
 
-  if (len_ == 0) {
+  if (len(this) == 0) {
     // weird case consistent with Python: ''.split(':') == ['']
     return new List<Str*>({kEmptyString});
   }
@@ -25,9 +25,9 @@ List<Str*>* Str::split(Str* sep) {
 
   auto result = new List<Str*>({});
 
-  int n = len_;
+  int n = len(this);
   const char* pos = data_;
-  const char* end = data_ + len_;
+  const char* end = data_ + n;
 
   // log("pos %p", pos);
   while (true) {
@@ -58,22 +58,23 @@ List<Str*>* Str::splitlines(bool keep) {
 }
 
 Str* Str::join(List<Str*>* items) {
-  int len = 0;
+  int length = 0;
   const std::vector<Str*>& v = items->v_;
   int num_parts = v.size();
   if (num_parts == 0) {  // " ".join([]) == ""
     return kEmptyString;
   }
   for (int i = 0; i < num_parts; ++i) {
-    len += v[i]->len_;
+    length += len(v[i]);
   }
   // add length of all the separators
-  len += len_ * (num_parts - 1);
+  int len_ = len(this);
+  length += len_ * (num_parts - 1);
 
-  // log("len: %d", len);
+  // log("length: %d", length);
   // log("v.size(): %d", v.size());
 
-  char* result = static_cast<char*>(malloc(len + 1));
+  char* result = static_cast<char*>(malloc(length + 1));
   char* p_result = result;  // advances through
 
   for (int i = 0; i < num_parts; ++i) {
@@ -84,15 +85,15 @@ Str* Str::join(List<Str*>* items) {
       // log("len_ %d", len_);
     }
 
-    int n = v[i]->len_;
+    int n = len(v[i]);
     // log("n: %d", n);
     memcpy(p_result, v[i]->data_, n);  // copy the list item
     p_result += n;
   }
 
-  result[len] = '\0';  // NUL terminator
+  result[length] = '\0';  // NUL terminator
 
-  return new Str(result, len);
+  return new Str(result, length);
 }
 
 // Get a string with one character
@@ -106,19 +107,19 @@ Str* StrIter::Value() {
 namespace mylib {
 
 Tuple2<Str*, Str*> split_once(Str* s, Str* delim) {
-  assert(delim->len_ == 1);
+  assert(len(delim) == 1);
 
   const char* start = s->data_;
   char c = delim->data_[0];
-  int len = s->len_;
+  int length = len(s);
 
-  const char* p = static_cast<const char*>(memchr(start, c, len));
+  const char* p = static_cast<const char*>(memchr(start, c, length));
 
   if (p) {
     // NOTE: Using SHARED SLICES, not memcpy() like some other functions.
     int len1 = p - start;
     Str* first = new Str(start, len1);
-    Str* second = new Str(p + 1, len - len1 - 1);
+    Str* second = new Str(p + 1, length - len1 - 1);
     return Tuple2<Str*, Str*>(first, second);
   } else {
     return Tuple2<Str*, Str*>(s, nullptr);
@@ -160,7 +161,7 @@ Str* CFileLineReader::readline() {
 // log("%s") falls back on sprintf, so it expects a NUL terminator.
 // It would be easier for us to just share.
 Str* BufLineReader::readline() {
-  const char* end = s_->data_ + s_->len_;
+  const char* end = s_->data_ + len(s_);
   if (pos_ == end) {
     return kEmptyString;
   }
@@ -196,7 +197,7 @@ Writer* gStderr;
 
 void BufWriter::write(Str* s) {
   int orig_len = len_;
-  len_ += s->len_;
+  len_ += len(s);
 
   // BUG: This is quadratic!
 
@@ -204,7 +205,7 @@ void BufWriter::write(Str* s) {
   data_ = static_cast<char*>(realloc(data_, len_ + 1));
 
   // Append to the end
-  memcpy(data_ + orig_len, s->data_, s->len_);
+  memcpy(data_ + orig_len, s->data_, len(s));
   data_[len_] = '\0';
 }
 
@@ -241,20 +242,20 @@ void BufWriter::format_o(int i) {
 // because of \u{}.
 void BufWriter::format_r(Str* s) {
   // Worst case: \0 becomes 4 bytes as '\\x00', and then two quote bytes.
-  int upper_bound = s->len_ * 4 + 2;
+  int upper_bound = len(s) * 4 + 2;
 
   // Extend the buffer
   data_ = static_cast<char*>(realloc(data_, len_ + upper_bound + 1));
 
   char quote = '\'';
-  if (memchr(s->data_, '\'', s->len_) && !memchr(s->data_, '"', s->len_)) {
+  if (memchr(s->data_, '\'', len(s)) && !memchr(s->data_, '"', len(s))) {
     quote = '"';
   }
   char* p = data_ + len_;  // end of valid data
 
   // From PyString_Repr()
   *p++ = quote;
-  for (int i = 0; i < s->len_; ++i) {
+  for (int i = 0; i < len(s); ++i) {
     char c = s->data_[i];
     if (c == quote || c == '\\') {
       *p++ = '\\';
@@ -290,7 +291,7 @@ void BufWriter::format_r(Str* s) {
 
 void CFileWriter::write(Str* s) {
   // note: throwing away the return value
-  fwrite(s->data_, s->len_, 1, f_);
+  fwrite(s->data_, len(s), 1, f_);
 
   // Necessary for 'echo hi > x' to work.  Otherwise it gets buffered so the
   // write() happens AFTER ~ctx_Redirect().
@@ -325,3 +326,9 @@ Str* repr(Str* s) {
 //
 
 mylib::BufWriter gBuf;
+
+int len(Str *s)
+{
+  return s->len__;
+}
+

--- a/mycpp/mylib_old.cc
+++ b/mycpp/mylib_old.cc
@@ -327,8 +327,3 @@ Str* repr(Str* s) {
 
 mylib::BufWriter gBuf;
 
-int len(Str *s)
-{
-  return s->len__;
-}
-

--- a/mycpp/mylib_old.h
+++ b/mycpp/mylib_old.h
@@ -21,6 +21,7 @@
 // if this file is even included, we're using the old mylib
 #define MYLIB_LEAKY 1
 #include "mycpp/gc_types.h"  // for Obj
+#include "mycpp/error_types.h"
 
 #ifdef DUMB_ALLOC
   #include "cpp/dumb_alloc.h"
@@ -58,36 +59,6 @@ void print(Str* s);
 // log() generates code that writes this
 void println_stderr(Str* s);
 
-class IndexError {};
-class ValueError {};
-class KeyError {};
-
-class EOFError {};
-
-class NotImplementedError {
- public:
-  NotImplementedError() {
-  }
-  explicit NotImplementedError(int i) {  // e.g. in expr_to_ast
-  }
-  explicit NotImplementedError(const char* s) {
-  }
-  explicit NotImplementedError(Str* s) {
-  }
-};
-
-class AssertionError {
- public:
-  AssertionError() {
-  }
-  explicit AssertionError(int i) {  // e.g. in expr_to_ast
-  }
-  explicit AssertionError(const char* s) {
-  }
-  explicit AssertionError(Str* s) {
-  }
-};
-
 // Python's RuntimeError looks like this.  . libc::regex_match and other
 // bindings raise it.
 class RuntimeError {
@@ -101,7 +72,6 @@ class RuntimeError {
 // Data Types
 //
 
-#ifdef MYLIB_LEAKY
 class Str : public gc_heap::Obj {
  public:
   Str(const char* data, int len)
@@ -736,7 +706,6 @@ Dict<K, V>* NewDict(std::initializer_list<K> keys,
   assert(0);  // Uncalled
 }
 
-#endif  // MYLIB_LEAKY
 
 template <class A, class B>
 class Tuple2 {
@@ -805,7 +774,6 @@ class Tuple4 {
 // Overloaded free function len()
 //
 
-#ifdef MYLIB_LEAKY
 inline int len(const Str* s) {
   return s->len_;
 }
@@ -833,7 +801,6 @@ inline int len(const Dict<Str*, V>* d) {
   }
   return len;
 }
-#endif
 
 //
 // Free functions
@@ -844,7 +811,6 @@ Str* str_concat3(Str* a, Str* b, Str* c);  // for os_path::join()
 
 Str* str_repeat(Str* s, int times);  // e.g. ' ' * 3
 
-#if MYLIB_LEAKY
 inline bool str_equals(Str* left, Str* right) {
   if (left->len_ == right->len_) {
     return memcmp(left->data_, right->data_, left->len_) == 0;
@@ -873,7 +839,6 @@ inline bool are_equal(Tuple2<Str*, int>* t1, Tuple2<Str*, int>* t2) {
   result = result && (t1->at1() == t2->at1());
   return result;
 }
-#endif
 
 inline bool str_equals0(const char* c_string, Str* s) {
   int n = strlen(c_string);

--- a/mycpp/mylib_old.h
+++ b/mycpp/mylib_old.h
@@ -21,6 +21,7 @@
 // if this file is even included, we're using the old mylib
 #define MYLIB_LEAKY 1
 #include "mycpp/gc_types.h"  // for Obj
+#include "mycpp/tuple_types.h"
 #include "mycpp/error_types.h"
 
 #ifdef DUMB_ALLOC
@@ -40,7 +41,6 @@ class Dict;
 template <class K, class V>
 class DictIter;
 
-bool are_equal(Str* left, Str* right);
 bool str_equals(Str* left, Str* right);
 
 namespace mylib {
@@ -706,70 +706,6 @@ Dict<K, V>* NewDict(std::initializer_list<K> keys,
   assert(0);  // Uncalled
 }
 
-
-template <class A, class B>
-class Tuple2 {
- public:
-  Tuple2(A a, B b) : a_(a), b_(b) {
-  }
-  A at0() {
-    return a_;
-  }
-  B at1() {
-    return b_;
-  }
-
- private:
-  A a_;
-  B b_;
-};
-
-template <class A, class B, class C>
-class Tuple3 {
- public:
-  Tuple3(A a, B b, C c) : a_(a), b_(b), c_(c) {
-  }
-  A at0() {
-    return a_;
-  }
-  B at1() {
-    return b_;
-  }
-  C at2() {
-    return c_;
-  }
-
- private:
-  A a_;
-  B b_;
-  C c_;
-};
-
-template <class A, class B, class C, class D>
-class Tuple4 {
- public:
-  Tuple4(A a, B b, C c, D d) : a_(a), b_(b), c_(c), d_(d) {
-  }
-  A at0() {
-    return a_;
-  }
-  B at1() {
-    return b_;
-  }
-  C at2() {
-    return c_;
-  }
-  D at3() {
-    return d_;
-  }
-
- private:
-  A a_;
-  B b_;
-  C c_;
-  D d_;
-};
-
 //
 // Overloaded free function len()
 //
@@ -827,7 +763,6 @@ inline bool are_equal(id_kind_asdl::Kind left, id_kind_asdl::Kind right);
 
 inline bool are_equal(int left, int right) {
   return left == right;
-  ;
 }
 
 inline bool are_equal(Str* left, Str* right) {

--- a/mycpp/mylib_old.h
+++ b/mycpp/mylib_old.h
@@ -271,6 +271,12 @@ class Str : public gc_heap::Obj {
   DISALLOW_COPY_AND_ASSIGN(Str)
 };
 
+inline int len(Str *s)
+{
+  return s->len__;
+}
+
+
 // NOTE: This iterates over bytes.
 class StrIter {
  public:

--- a/mycpp/mylib_old.h
+++ b/mycpp/mylib_old.h
@@ -23,6 +23,7 @@
 #include "mycpp/gc_types.h"  // for Obj
 #include "mycpp/tuple_types.h"
 #include "mycpp/error_types.h"
+#include "mycpp/mylib_types.h"
 
 #ifdef DUMB_ALLOC
   #include "cpp/dumb_alloc.h"
@@ -41,8 +42,6 @@ class Dict;
 template <class K, class V>
 class DictIter;
 
-bool str_equals(Str* left, Str* right);
-
 namespace mylib {
 template <typename V>
 void dict_remove(Dict<Str*, V>* haystack, Str* needle);
@@ -58,15 +57,6 @@ void print(Str* s);
 
 // log() generates code that writes this
 void println_stderr(Str* s);
-
-// Python's RuntimeError looks like this.  . libc::regex_match and other
-// bindings raise it.
-class RuntimeError {
- public:
-  RuntimeError(Str* message) : message(message) {
-  }
-  Str* message;
-};
 
 //
 // Data Types
@@ -561,6 +551,14 @@ class DictIter {
   int i_;
 };
 
+inline bool str_equals(Str* left, Str* right) {
+  if (left->len_ == right->len_) {
+    return memcmp(left->data_, right->data_, left->len_) == 0;
+  } else {
+    return false;
+  }
+}
+
 // Specialized functions
 template <class V>
 int find_by_key(const std::vector<std::pair<Str*, V>>& items, Str* key) {
@@ -747,14 +745,6 @@ Str* str_concat3(Str* a, Str* b, Str* c);  // for os_path::join()
 
 Str* str_repeat(Str* s, int times);  // e.g. ' ' * 3
 
-inline bool str_equals(Str* left, Str* right) {
-  if (left->len_ == right->len_) {
-    return memcmp(left->data_, right->data_, left->len_) == 0;
-  } else {
-    return false;
-  }
-}
-
 namespace id_kind_asdl {
 enum class Kind;
 };
@@ -809,13 +799,6 @@ inline int ord(Str* s) {
   uint8_t c = static_cast<uint8_t>(s->data_[0]);
   return c;
 }
-
-// https://stackoverflow.com/questions/3919995/determining-sprintf-buffer-size-whats-the-standard/11092994#11092994
-// Notes:
-// - Python 2.7's intobject.c has an erroneous +6
-// - This is 13, but len('-2147483648') is 11, which means we only need 12?
-// - This formula is valid for octal(), because 2^(3 bits) = 8
-const int kIntBufSize = CHAR_BIT * sizeof(int) / 3 + 3;
 
 inline Str* str(int i) {
   char* buf = static_cast<char*>(malloc(kIntBufSize));
@@ -1187,23 +1170,6 @@ inline Writer* Stderr() {
   return gStderr;
 }
 
-inline Str* hex_lower(int i) {
-  char* buf = static_cast<char*>(malloc(kIntBufSize));
-  int len = snprintf(buf, kIntBufSize, "%x", i);
-  return new Str(buf, len);
-}
-
-inline Str* hex_upper(int i) {
-  char* buf = static_cast<char*>(malloc(kIntBufSize));
-  int len = snprintf(buf, kIntBufSize, "%X", i);
-  return new Str(buf, len);
-}
-
-inline Str* octal(int i) {
-  char* buf = static_cast<char*>(malloc(kIntBufSize));
-  int len = snprintf(buf, kIntBufSize, "%o", i);
-  return new Str(buf, len);
-}
 
 }  // namespace mylib
 

--- a/mycpp/mylib_old.h
+++ b/mycpp/mylib_old.h
@@ -23,7 +23,6 @@
 #include "mycpp/gc_types.h"  // for Obj
 #include "mycpp/tuple_types.h"
 #include "mycpp/error_types.h"
-#include "mycpp/mylib_types.h"
 
 #ifdef DUMB_ALLOC
   #include "cpp/dumb_alloc.h"
@@ -43,6 +42,9 @@ template <class K, class V>
 class DictIter;
 
 namespace mylib {
+
+  inline Str* StrFromC(const char* s, int len);
+  inline Str* StrFromC(const char* s);
 
   template <typename V>
   void dict_remove(Dict<Str*, V>* haystack, Str* needle);
@@ -808,6 +810,8 @@ inline int ord(Str* s) {
   uint8_t c = static_cast<uint8_t>(s->data_[0]);
   return c;
 }
+
+#include "mycpp/mylib_types.h"
 
 inline Str* str(int i) {
   char* buf = static_cast<char*>(malloc(kIntBufSize));

--- a/mycpp/mylib_old_test.cc
+++ b/mycpp/mylib_old_test.cc
@@ -8,12 +8,12 @@
 
 // Emulating the gc_heap API.  COPIED from gc_heap_test.cc
 TEST test_str_creation() {
-  Str* s = mylib::StrFromC("foo");
+  Str* s = StrFromC("foo");
   ASSERT_EQ(3, len(s));
   ASSERT_EQ(0, strcmp("foo", s->data_));
 
   // String with internal NUL
-  Str* s2 = mylib::StrFromC("foo\0bar", 7);
+  Str* s2 = StrFromC("foo\0bar", 7);
   ASSERT_EQ(7, len(s2));
   ASSERT_EQ(0, memcmp("foo\0bar\0", s2->data_, 8));
 

--- a/mycpp/mylib_old_test.cc
+++ b/mycpp/mylib_old_test.cc
@@ -6,6 +6,8 @@
 
 #include "vendor/greatest.h"
 
+using mylib::StrFromC;
+
 // Emulating the gc_heap API.  COPIED from gc_heap_test.cc
 TEST test_str_creation() {
   Str* s = StrFromC("foo");

--- a/mycpp/mylib_old_test.cc
+++ b/mycpp/mylib_old_test.cc
@@ -481,12 +481,12 @@ TEST test_sizeof() {
   PASS();
 }
 
-#define PRINT_STRING(str) printf("(%.*s)\n", (str)->len_, (str)->data_)
+#define PRINT_STRING(str) printf("(%.*s)\n", len(str), (str)->data_)
 
 #define PRINT_LIST(list)                                         \
   for (ListIter<Str*> iter((list)); !iter.Done(); iter.Next()) { \
     Str* piece = iter.Value();                                   \
-    printf("(%.*s) ", piece->len_, piece->data_);                \
+    printf("(%.*s) ", len(piece), piece->data_);                \
   }                                                              \
   printf("\n")
 
@@ -729,7 +729,7 @@ TEST test_str_slice() {
 
   //  NOTE(Jesse): testing all permutations of boundary conditions for
   //  assertions
-  int max_len = (s0->len_ + 2);
+  int max_len = (len(s0) + 2);
   int min_len = -max_len;
 
   for (int outer = min_len; outer <= max_len; ++outer) {

--- a/mycpp/mylib_types.h
+++ b/mycpp/mylib_types.h
@@ -1,5 +1,12 @@
 #pragma once
 
+#if MYLIB_LEAKY
+using mylib::StrFromC;
+#else
+using gc_heap::StrFromC;
+#endif
+
+
 // https://stackoverflow.com/questions/3919995/determining-sprintf-buffer-size-whats-the-standard/11092994#11092994
 // Notes:
 // - Python 2.7's intobject.c has an erroneous +6
@@ -9,9 +16,6 @@ const int kIntBufSize = CHAR_BIT * sizeof(int) / 3 + 3;
 
 namespace mylib
 {
-  inline Str* StrFromC(const char* s, int len);
-  inline Str* StrFromC(const char* s);
-
   inline Str* hex_lower(int i) {
     char* buf = static_cast<char*>(malloc(kIntBufSize));
     int len = snprintf(buf, kIntBufSize, "%x", i);

--- a/mycpp/mylib_types.h
+++ b/mycpp/mylib_types.h
@@ -1,0 +1,32 @@
+#pragma once
+
+// https://stackoverflow.com/questions/3919995/determining-sprintf-buffer-size-whats-the-standard/11092994#11092994
+// Notes:
+// - Python 2.7's intobject.c has an erroneous +6
+// - This is 13, but len('-2147483648') is 11, which means we only need 12?
+// - This formula is valid for octal(), because 2^(3 bits) = 8
+const int kIntBufSize = CHAR_BIT * sizeof(int) / 3 + 3;
+
+namespace mylib
+{
+  inline Str* StrFromC(const char* s, int len);
+  inline Str* StrFromC(const char* s);
+
+  inline Str* hex_lower(int i) {
+    char* buf = static_cast<char*>(malloc(kIntBufSize));
+    int len = snprintf(buf, kIntBufSize, "%x", i);
+    return StrFromC(buf, len);
+  }
+
+  inline Str* hex_upper(int i) {
+    char* buf = static_cast<char*>(malloc(kIntBufSize));
+    int len = snprintf(buf, kIntBufSize, "%X", i);
+    return StrFromC(buf, len);
+  }
+
+  inline Str* octal(int i) {
+    char* buf = static_cast<char*>(malloc(kIntBufSize));
+    int len = snprintf(buf, kIntBufSize, "%o", i);
+    return StrFromC(buf, len);
+  }
+} // namespace mylib

--- a/mycpp/mylib_types.h
+++ b/mycpp/mylib_types.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef MYLIB_TYPES_H
+#define MYLIB_TYPES_H
 
 #if MYLIB_LEAKY
 using mylib::StrFromC;
@@ -34,3 +35,5 @@ namespace mylib
     return StrFromC(buf, len);
   }
 } // namespace mylib
+
+#endif // MYLIB_TYPES_H

--- a/mycpp/str_types.h
+++ b/mycpp/str_types.h
@@ -1,0 +1,2 @@
+#pragma once
+

--- a/mycpp/str_types.h
+++ b/mycpp/str_types.h
@@ -1,2 +1,5 @@
-#pragma once
+#ifndef STR_TYPES_H
+#define STR_TYPES_H
+
+#endif // STR_TYPES_H
 

--- a/mycpp/tuple_types.h
+++ b/mycpp/tuple_types.h
@@ -1,5 +1,4 @@
-#ifndef TUPLE_TYPES_H
-#define TUPLE_TYPES_H
+#pragma once
 
 template <class A, class B>
 class Tuple2 {
@@ -63,5 +62,3 @@ class Tuple4 {
   C c_;
   D d_;
 };
-
-#endif  // TUPLE_TYPES_H

--- a/mycpp/tuple_types.h
+++ b/mycpp/tuple_types.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef TUPLE_TYPES_H
+#define TUPLE_TYPES_H
 
 template <class A, class B>
 class Tuple2 {
@@ -62,3 +63,5 @@ class Tuple4 {
   C c_;
   D d_;
 };
+
+#endif

--- a/mycpp/tuple_types.h
+++ b/mycpp/tuple_types.h
@@ -1,0 +1,67 @@
+#ifndef TUPLE_TYPES_H
+#define TUPLE_TYPES_H
+
+template <class A, class B>
+class Tuple2 {
+ public:
+  Tuple2(A a, B b) : a_(a), b_(b) {
+  }
+  A at0() {
+    return a_;
+  }
+  B at1() {
+    return b_;
+  }
+
+ private:
+  A a_;
+  B b_;
+};
+
+template <class A, class B, class C>
+class Tuple3 {
+ public:
+  Tuple3(A a, B b, C c) : a_(a), b_(b), c_(c) {
+  }
+  A at0() {
+    return a_;
+  }
+  B at1() {
+    return b_;
+  }
+  C at2() {
+    return c_;
+  }
+
+ private:
+  A a_;
+  B b_;
+  C c_;
+};
+
+template <class A, class B, class C, class D>
+class Tuple4 {
+ public:
+  Tuple4(A a, B b, C c, D d) : a_(a), b_(b), c_(c), d_(d) {
+  }
+  A at0() {
+    return a_;
+  }
+  B at1() {
+    return b_;
+  }
+  C at2() {
+    return c_;
+  }
+  D at3() {
+    return d_;
+  }
+
+ private:
+  A a_;
+  B b_;
+  C c_;
+  D d_;
+};
+
+#endif  // TUPLE_TYPES_H

--- a/test/baseline.spec-cpp.assertion_fails
+++ b/test/baseline.spec-cpp.assertion_fails
@@ -1,4 +1,4 @@
-(cpp/leaky_core.cc:196: bool pyos::InputAvailable(int): Assertion `!"Not Implemented"' failed.) _tmp/spec/cpp/builtin-io.html
+(cpp/leaky_core.cc:192: bool pyos::InputAvailable(int): Assertion `!"Not Implemented"' failed.) _tmp/spec/cpp/builtin-io.html
 (cpp/leaky_pgen2.cc:8: void parse::Parser::setup(int): Assertion `0' failed.) _tmp/spec/cpp/arith-context.html
 (cpp/leaky_pgen2.cc:8: void parse::Parser::setup(int): Assertion `0' failed.) _tmp/spec/cpp/bugs.html
 (cpp/leaky_pgen2.cc:8: void parse::Parser::setup(int): Assertion `0' failed.) _tmp/spec/cpp/bugs.html
@@ -9,4 +9,4 @@
 (/home/scallywag/work/oil/cpp/leaky_osh_eval_stubs.h:45: int signal_def::GetNumber(Str*): Assertion `!"Not Implemented"' failed.) _tmp/spec/cpp/builtin-trap.html
 (/home/scallywag/work/oil/cpp/leaky_osh_eval_stubs.h:45: int signal_def::GetNumber(Str*): Assertion `!"Not Implemented"' failed.) _tmp/spec/cpp/builtin-trap.html
 (/home/scallywag/work/oil/cpp/leaky_osh_eval_stubs.h:45: int signal_def::GetNumber(Str*): Assertion `!"Not Implemented"' failed.) _tmp/spec/cpp/builtin-trap.html
-(mycpp/mylib_old.cc:345: void mylib::BufWriter::format_o(int): Assertion `!"Not Implemented"' failed.) _tmp/spec/cpp/builtins.html
+(mycpp/mylib_old.cc:236: void mylib::BufWriter::format_o(int): Assertion `!"Not Implemented"' failed.) _tmp/spec/cpp/builtins.html

--- a/test/baseline.spec-cpp.assertion_fails
+++ b/test/baseline.spec-cpp.assertion_fails
@@ -1,4 +1,4 @@
-(cpp/leaky_core.cc:192: bool pyos::InputAvailable(int): Assertion `!"Not Implemented"' failed.) _tmp/spec/cpp/builtin-io.html
+(cpp/leaky_core.cc:191: bool pyos::InputAvailable(int): Assertion `!"Not Implemented"' failed.) _tmp/spec/cpp/builtin-io.html
 (cpp/leaky_pgen2.cc:8: void parse::Parser::setup(int): Assertion `0' failed.) _tmp/spec/cpp/arith-context.html
 (cpp/leaky_pgen2.cc:8: void parse::Parser::setup(int): Assertion `0' failed.) _tmp/spec/cpp/bugs.html
 (cpp/leaky_pgen2.cc:8: void parse::Parser::setup(int): Assertion `0' failed.) _tmp/spec/cpp/bugs.html

--- a/test/baseline.spec-cpp.results
+++ b/test/baseline.spec-cpp.results
@@ -633,6 +633,7 @@
 6 _tmp/spec/cpp/builtin-special.tsv
 0 _tmp/spec/cpp/builtins.tsv
 1 _tmp/spec/cpp/builtins.tsv
+2 _tmp/spec/cpp/builtins.tsv
 3 _tmp/spec/cpp/builtins.tsv
 4 _tmp/spec/cpp/builtins.tsv
 5 _tmp/spec/cpp/builtins.tsv

--- a/test/baseline.spec-cpp.results
+++ b/test/baseline.spec-cpp.results
@@ -616,6 +616,7 @@
 46 _tmp/spec/cpp/builtin-printf.tsv
 47 _tmp/spec/cpp/builtin-printf.tsv
 48 _tmp/spec/cpp/builtin-printf.tsv
+50 _tmp/spec/cpp/builtin-printf.tsv
 0 _tmp/spec/cpp/builtins2.tsv
 1 _tmp/spec/cpp/builtins2.tsv
 2 _tmp/spec/cpp/builtins2.tsv
@@ -1100,6 +1101,7 @@
 2 _tmp/spec/cpp/nocasematch-match.tsv
 4 _tmp/spec/cpp/nocasematch-match.tsv
 5 _tmp/spec/cpp/nocasematch-match.tsv
+4 _tmp/spec/cpp/nul-bytes.tsv
 0 _tmp/spec/cpp/osh-only.tsv
 2 _tmp/spec/cpp/osh-only.tsv
 0 _tmp/spec/cpp/parse-errors.tsv


### PR DESCRIPTION
I did two things here:

1) Move some code common to both `mylib_old` and `gc_heap` into headers that can be included by both of them
2) Changed all reads of  `Str::len_` to function calls `len(Str*)`