### PR TITLE
Jesse/refactor/move str out of gc heap namespace

### DIFF
--- a/asdl/tool.py
+++ b/asdl/tool.py
@@ -89,7 +89,6 @@ using gc_heap::Obj;
 using gc_heap::Dict;
 using gc_heap::List;
 using gc_heap::NewList;
-using gc_heap::Str;
 using gc_heap::StrFromC;
 #endif
 """)

--- a/cpp/aligned.h
+++ b/cpp/aligned.h
@@ -1,0 +1,19 @@
+#ifndef ALIGNED_H
+#define ALIGNED_H
+
+// I'm not sure why this matters but we get crashes when aligning to 8 bytes.
+// That is annoying.
+// Example: we get a crash in cpp/frontend_flag_spec.cc
+// auto out = new flag_spec::_FlagSpecAndMore();
+//
+// https://stackoverflow.com/questions/52531695/int128-alignment-segment-fault-with-gcc-o-sse-optimize
+constexpr int kMask = alignof(max_align_t) - 1;  // e.g. 15 or 7
+
+// Align returned pointers to the worst case of 8 bytes (64-bit pointers)
+inline size_t aligned(size_t n) {
+  // https://stackoverflow.com/questions/2022179/c-quick-calculation-of-next-multiple-of-4
+  // return (n + 7) & ~7;
+  return (n + kMask) & ~kMask;
+}
+
+#endif

--- a/cpp/dumb_alloc.cc
+++ b/cpp/dumb_alloc.cc
@@ -11,21 +11,7 @@ int gMemPos = 0;
 int gNumNew = 0;
 int gNumDelete = 0;
 
-// I'm not sure why this matters but we get crashes when aligning to 8 bytes.
-// That is annoying.
-// Example: we get a crash in cpp/frontend_flag_spec.cc
-// auto out = new flag_spec::_FlagSpecAndMore();
-//
-// https://stackoverflow.com/questions/52531695/int128-alignment-segment-fault-with-gcc-o-sse-optimize
-constexpr int kMask = alignof(max_align_t) - 1;  // e.g. 15 or 7
-
-// Align returned pointers to the worst case of 8 bytes (64-bit pointers)
-inline size_t aligned(size_t n) {
-  // https://stackoverflow.com/questions/2022179/c-quick-calculation-of-next-multiple-of-4
-  // return (n + 7) & ~7;
-
-  return (n + kMask) & ~kMask;
-}
+#include "cpp/aligned.h"
 
 // This global interface is silly ...
 

--- a/cpp/gc_binding_test.cc
+++ b/cpp/gc_binding_test.cc
@@ -5,7 +5,7 @@
 // leaky mode!
 
 #ifdef LEAKY_BINDINGS
-  #include "mycpp/gc_types.h"
+  /* #include "mycpp/gc_types.h" */
   #include "mycpp/mylib_old.h"
 using gc_heap::StackRoots;  // no-op
 using mylib::StrFromC;

--- a/cpp/leaky_frontend_flag_spec.cc
+++ b/cpp/leaky_frontend_flag_spec.cc
@@ -288,7 +288,6 @@ args::_Attributes* ParseMore(Str* spec_name, args::Reader* arg_r) {
   // TODO: Fill this in from constant data!
   flag_spec::_FlagSpecAndMore* spec = LookupFlagSpec2(spec_name);
   assert(spec);
-  // assert(spec);  // should always be found
   return args::ParseMore(spec, arg_r);
 #endif
 }

--- a/cpp/leaky_frontend_flag_spec.h
+++ b/cpp/leaky_frontend_flag_spec.h
@@ -12,7 +12,6 @@
   #include "mycpp/gc_types.h"
 using gc_heap::Dict;
 using gc_heap::List;
-using gc_heap::Str;
 #endif
 
 // Forward declarations (can't include osh_eval.h)

--- a/cpp/qsn.h
+++ b/cpp/qsn.h
@@ -13,7 +13,6 @@ using mylib::OverAllocatedStr;
 using gc_heap::AllocStr;
 using gc_heap::OverAllocatedStr;
 using gc_heap::StackRoots;
-using gc_heap::Str;
 #endif
 
 namespace qsn {

--- a/devtools/oil_gdb.py
+++ b/devtools/oil_gdb.py
@@ -152,10 +152,6 @@ class TypeLookup(object):
       #print('target name %r' % target.name)
       #print('target tag %r' % target.tag)
 
-      if target.name == 'gc_heap::Str':
-          return GcStrPrinter(val)
-
-      # TODO: remove Str when we remove mylib_old.cc
       if target.name == 'Str':
           return StrPrinter(val)
 

--- a/devtools/oil_gdb.py
+++ b/devtools/oil_gdb.py
@@ -153,7 +153,7 @@ class TypeLookup(object):
       #print('target tag %r' % target.tag)
 
       if target.name == 'Str':
-          return StrPrinter(val)
+          return GcStrPrinter(val)
 
       if target.name in self.sum_type_lookup:
           return AsdlPrinter(val, self.sum_type_lookup[target.name])

--- a/mycpp/common.h
+++ b/mycpp/common.h
@@ -22,8 +22,9 @@
 #define NotImplemented() assert(!"Not Implemented")
 #define InvalidCodePath() assert(!"Invalid Code Path")
 
-// Prevent silent copies
+#define COMMA ,
 
+// Prevent silent copies
 #define DISALLOW_COPY_AND_ASSIGN(TypeName) \
   TypeName(TypeName&) = delete;            \
   void operator=(TypeName) = delete;

--- a/mycpp/demo/gc_heap.cc
+++ b/mycpp/demo/gc_heap.cc
@@ -139,12 +139,7 @@ int gNumDelete = 0;
 
 #ifdef DUMB_ALLOC
 
-constexpr int kMask = alignof(max_align_t) - 1;  // e.g. 15 or 7
-
-// Align returned pointers to the worst case of 8 bytes (64-bit pointers)
-inline size_t aligned(size_t n) {
-  return (n + kMask) & ~kMask;
-}
+#include "cpp/aligned.h"
 
 void* operator new(size_t size) {
   char* p = &(kMem[gMemPos]);

--- a/mycpp/error_types.h
+++ b/mycpp/error_types.h
@@ -1,11 +1,7 @@
 #ifndef ERROR_TYPES_H
 #define ERROR_TYPES_H
 
-#ifdef LEAKY_BINDINGS
 class Str;
-#else
-using gc_heap::Str;
-#endif
 
 class IndexError {};
 class ValueError {};

--- a/mycpp/examples/varargs_preamble.h
+++ b/mycpp/examples/varargs_preamble.h
@@ -4,8 +4,6 @@
 
 #include "mycpp/gc_types.h"
 
-using gc_heap::Str;
-
 //
 // Copied from cpp/core_error.h
 //

--- a/mycpp/gc_alloc.h
+++ b/mycpp/gc_alloc.h
@@ -1,0 +1,27 @@
+#ifndef GC_ALLOC_H
+#define GC_ALLOC_H
+
+/* class Heap; */
+/* extern Heap gHeap; */
+
+#ifdef MYLIB_LEAKY
+
+#define ALLOCATE(byte_count) calloc(byte_count, 1)
+
+#else
+  using gc_heap::Heap;
+  using gc_heap::gHeap;
+#define ALLOCATE(byte_count) gHeap.Allocate(byte_count)
+#endif
+
+// Variadic templates:
+// https://eli.thegreenplace.net/2014/variadic-templates-in-c/
+template <typename T, typename... Args>
+T* Alloc(Args&&... args) {
+  void* place = ALLOCATE(sizeof(T)); 
+  assert(place != nullptr);
+  // placement new
+  return new (place) T(std::forward<Args>(args)...);
+}
+
+#endif  // GC_ALLOC_H

--- a/mycpp/gc_builtins.cc
+++ b/mycpp/gc_builtins.cc
@@ -11,6 +11,18 @@
 
 using gc_heap::kEmptyString;
 using gc_heap::StackRoots;
+/* using gc_heap::len; */
+
+
+constexpr int kMask = alignof(max_align_t) - 1;  // e.g. 15 or 7
+// Align returned pointers to the worst case of 8 bytes (64-bit pointers)
+inline size_t aligned(size_t n) {
+  // https://stackoverflow.com/questions/2022179/c-quick-calculation-of-next-multiple-of-4
+  // return (n + 7) & ~7;
+
+  return (n + kMask) & ~kMask;
+}
+
 
 #if 0
 // Translation of Python's print().
@@ -349,7 +361,7 @@ List<Str*>* Str::split(Str* sep) {
   int length = len(this);
   if (length == 0) {
     // weird case consistent with Python: ''.split(':') == ['']
-    return NewList<Str*>(std::initializer_list<Str*>{kEmptyString});
+    return gc_heap::NewList<Str*>(std::initializer_list<Str*>{kEmptyString});
   }
 
   // Find breaks first so we can allocate the right number of strings ALL AT
@@ -378,9 +390,9 @@ List<Str*>* Str::split(Str* sep) {
     }
   }
 
-  result = NewList<Str*>(nullptr, breaks.size() - 1);  // reserve enough space
+  result = gc_heap::NewList<Str*>(nullptr, breaks.size() - 1);  // reserve enough space
 
-  place = reinterpret_cast<char*>(gHeap.Allocate(num_bytes));
+  place = reinterpret_cast<char*>(gc_heap::gHeap.Allocate(num_bytes));
   int n = breaks.size();
   for (int i = 1; i < n; ++i) {
     int prev_pos = breaks[i - 1];

--- a/mycpp/gc_builtins.cc
+++ b/mycpp/gc_builtins.cc
@@ -1,28 +1,17 @@
 // gc_builtins.cc
 
-#include "gc_builtins.h"
 
 #include <ctype.h>  // isspace(), isdigit()
-
 #include <cstdarg>  // va_list, etc.
 #include <vector>
 
+#include "gc_builtins.h"
 #include "gc_mylib.h"  // BufWriter
+#include "cpp/aligned.h"
 
 using gc_heap::kEmptyString;
 using gc_heap::StackRoots;
-/* using gc_heap::len; */
-
-
-constexpr int kMask = alignof(max_align_t) - 1;  // e.g. 15 or 7
-// Align returned pointers to the worst case of 8 bytes (64-bit pointers)
-inline size_t aligned(size_t n) {
-  // https://stackoverflow.com/questions/2022179/c-quick-calculation-of-next-multiple-of-4
-  // return (n + 7) & ~7;
-
-  return (n + kMask) & ~kMask;
-}
-
+using gc_heap::aligned;
 
 #if 0
 // Translation of Python's print().

--- a/mycpp/gc_builtins.h
+++ b/mycpp/gc_builtins.h
@@ -90,7 +90,7 @@ inline int int_cmp(int a, int b) {
 }
 
 // Used by [[ a > b ]] and so forth
-inline int str_cmp(gc_heap::Str* a, gc_heap::Str* b) {
+inline int str_cmp(Str* a, Str* b) {
   int len_a = len(a);
   int len_b = len(b);
 
@@ -105,7 +105,7 @@ inline int str_cmp(gc_heap::Str* a, gc_heap::Str* b) {
   return comp;
 }
 
-inline bool _cmp(gc_heap::Str* a, gc_heap::Str* b) {
+inline bool _cmp(Str* a, Str* b) {
   return str_cmp(a, b) < 0;
 }
 

--- a/mycpp/gc_heap.h
+++ b/mycpp/gc_heap.h
@@ -98,20 +98,10 @@
 // GC_VERBOSE: Log when we collect
 // GC_STATS: Collect more stats.  TODO: Rename this?
 
-// Obj::heap_tag_ values.  They're odd numbers to distinguish them from vtable
-// pointers.
-namespace Tag {
-const int Forwarded = 1;  // For the Cheney algorithm.
-const int Global = 3;     // Neither copy nor scan.
-const int Opaque = 5;     // Copy but don't scan.  List<int> and Str
-const int FixedSize = 7;  // Fixed size headers: consult field_mask_
-const int Scanned = 9;    // Copy AND scan for non-NULL pointers.
-}  // namespace Tag
-
 // Silly definition for passing types like GlobalList<T, N> and initializer
 // lists like {1, 2, 3} to macros
 
-#define COMMA ,
+#include "mycpp/gc_tag.h"
 
 namespace gc_heap {
 
@@ -460,15 +450,9 @@ class Param : public Local<T> {
   // operator= -- I don't think we need to PushRoot()
 };
 
-// Variadic templates:
-// https://eli.thegreenplace.net/2014/variadic-templates-in-c/
-template <typename T, typename... Args>
-T* Alloc(Args&&... args) {
-  void* place = gHeap.Allocate(sizeof(T));
-  assert(place != nullptr);
-  // placement new
-  return new (place) T(std::forward<Args>(args)...);
-}
+
+#include "mycpp/gc_alloc.h"
+
 
 // Return the size of a resizeable allocation.  For now we just round up by
 // powers of 2. This could be optimized later.  CPython has an interesting
@@ -491,10 +475,6 @@ inline int RoundUp(int n) {
   n++;
   return n;
 }
-
-const int kZeroMask = 0;  // for types with no pointers
-// no obj_len_ computed for global List/Slab/Dict
-const int kNoObjLen = 0x0eadbeef;
 
 #include "mycpp/gc_obj.h"
 

--- a/mycpp/gc_heap.h
+++ b/mycpp/gc_heap.h
@@ -108,15 +108,7 @@ namespace gc_heap {
 template <class T>
 class List;
 
-constexpr int kMask = alignof(max_align_t) - 1;  // e.g. 15 or 7
-
-// Align returned pointers to the worst case of 8 bytes (64-bit pointers)
-inline size_t aligned(size_t n) {
-  // https://stackoverflow.com/questions/2022179/c-quick-calculation-of-next-multiple-of-4
-  // return (n + 7) & ~7;
-
-  return (n + kMask) & ~kMask;
-}
+#include "cpp/aligned.h"
 
 class Obj;
 

--- a/mycpp/gc_heap.h
+++ b/mycpp/gc_heap.h
@@ -496,61 +496,7 @@ const int kZeroMask = 0;  // for types with no pointers
 // no obj_len_ computed for global List/Slab/Dict
 const int kNoObjLen = 0x0eadbeef;
 
-// Why do we need this macro instead of using inheritance?
-// - Because ASDL uses multiple inheritance for first class variants, but we
-//   don't want multiple IMPLEMENTATION inheritance.  Instead we just generate
-//   compatible layouts.
-// - Similarly, GlobalStr is layout-compatible with Str.  It can't inherit from
-//   Obj like Str, because of the constexpr issue with char[N].
-
-// heap_tag_: one of Tag::
-// type_tag_: ASDL tag (variant)
-// field_mask_: for fixed length records, so max 16 fields
-// obj_len_: number of bytes to copy
-//   TODO: with a limitation of ~15 fields, we can encode obj_len_ in
-//   field_mask_, and save space on many ASDL types.
-//   And we can sort integers BEFORE pointers.
-
-// TODO: ./configure could detect big or little endian, and then flip the
-// fields in OBJ_HEADER?
-//
-// https://stackoverflow.com/questions/2100331/c-macro-definition-to-determine-big-endian-or-little-endian-machine
-//
-// Because we want to do (obj->heap_tag_ & 1 == 0) to distinguish it from
-// vtable pointer.  We assume low bits of a pointer are 0 but not high bits.
-
-#define OBJ_HEADER()    \
-  uint8_t heap_tag_;    \
-  uint8_t type_tag_;    \
-  uint16_t field_mask_; \
-  uint32_t obj_len_;
-
-class Obj {
-  // The unit of garbage collection.  It has a header describing how to find
-  // the pointers within it.
-  //
-  // Note: Sorting ASDL fields by (non-pointer, pointer) is a good idea, but it
-  // breaks down because mycpp has inheritance.  Could do this later.
-
- public:
-  // Note: ASDL types are layout-compatible with Obj, but don't actually
-  // inherit from it because of the 'multiple inheritance of implementation'
-  // issue.  So they don't call this constructor.
-  constexpr Obj(uint8_t heap_tag, uint16_t field_mask, int obj_len)
-      : heap_tag_(heap_tag),
-        type_tag_(0),
-        field_mask_(field_mask),
-        obj_len_(obj_len) {
-  }
-
-  void SetObjLen(int obj_len) {
-    this->obj_len_ = obj_len;
-  }
-
-  OBJ_HEADER()
-
-  DISALLOW_COPY_AND_ASSIGN(Obj)
-};
+#include "mycpp/gc_obj.h"
 
 }  // namespace gc_heap
 

--- a/mycpp/gc_heap_test.cc
+++ b/mycpp/gc_heap_test.cc
@@ -25,13 +25,11 @@ using gc_heap::NewList;
 using gc_heap::OverAllocatedStr;
 using gc_heap::Slab;
 using gc_heap::StackRoots;
-using gc_heap::Str;
 using gc_heap::StrFromC;
 
 // Constants
 using gc_heap::kEmptyString;
 using gc_heap::kSlabHeaderSize;
-using gc_heap::kStrHeaderSize;
 using gc_heap::kZeroMask;
 
 // Functions

--- a/mycpp/gc_mylib.cc
+++ b/mycpp/gc_mylib.cc
@@ -8,7 +8,6 @@
 #include "gc_builtins.h"  // kIntBufSize
 
 using gc_heap::gHeap;
-using gc_heap::kStrHeaderSize;
 using gc_heap::StackRoots;
 
 mylib::BufWriter gBuf;

--- a/mycpp/gc_obj.h
+++ b/mycpp/gc_obj.h
@@ -1,0 +1,61 @@
+#ifndef GC_OBJ_H
+#define GC_OBJ_H
+
+// Why do we need this macro instead of using inheritance?
+// - Because ASDL uses multiple inheritance for first class variants, but we
+//   don't want multiple IMPLEMENTATION inheritance.  Instead we just generate
+//   compatible layouts.
+// - Similarly, GlobalStr is layout-compatible with Str.  It can't inherit from
+//   Obj like Str, because of the constexpr issue with char[N].
+
+// heap_tag_: one of Tag::
+// type_tag_: ASDL tag (variant)
+// field_mask_: for fixed length records, so max 16 fields
+// obj_len_: number of bytes to copy
+//   TODO: with a limitation of ~15 fields, we can encode obj_len_ in
+//   field_mask_, and save space on many ASDL types.
+//   And we can sort integers BEFORE pointers.
+
+// TODO: ./configure could detect big or little endian, and then flip the
+// fields in OBJ_HEADER?
+//
+// https://stackoverflow.com/questions/2100331/c-macro-definition-to-determine-big-endian-or-little-endian-machine
+//
+// Because we want to do (obj->heap_tag_ & 1 == 0) to distinguish it from
+// vtable pointer.  We assume low bits of a pointer are 0 but not high bits.
+
+#define OBJ_HEADER()    \
+  uint8_t heap_tag_;    \
+  uint8_t type_tag_;    \
+  uint16_t field_mask_; \
+  uint32_t obj_len_;
+
+class Obj {
+  // The unit of garbage collection.  It has a header describing how to find
+  // the pointers within it.
+  //
+  // Note: Sorting ASDL fields by (non-pointer, pointer) is a good idea, but it
+  // breaks down because mycpp has inheritance.  Could do this later.
+
+ public:
+  // Note: ASDL types are layout-compatible with Obj, but don't actually
+  // inherit from it because of the 'multiple inheritance of implementation'
+  // issue.  So they don't call this constructor.
+  constexpr Obj(uint8_t heap_tag, uint16_t field_mask, int obj_len)
+      : heap_tag_(heap_tag),
+        type_tag_(0),
+        field_mask_(field_mask),
+        obj_len_(obj_len) {
+  }
+
+  void SetObjLen(int obj_len) {
+    this->obj_len_ = obj_len;
+  }
+
+  OBJ_HEADER()
+
+  DISALLOW_COPY_AND_ASSIGN(Obj)
+};
+
+
+#endif  // GC_OBJ_H

--- a/mycpp/gc_obj.h
+++ b/mycpp/gc_obj.h
@@ -1,6 +1,11 @@
 #ifndef GC_OBJ_H
 #define GC_OBJ_H
 
+const int kZeroMask = 0;  // for types with no pointers
+// no obj_len_ computed for global List/Slab/Dict
+const int kNoObjLen = 0x0eadbeef;
+
+
 // Why do we need this macro instead of using inheritance?
 // - Because ASDL uses multiple inheritance for first class variants, but we
 //   don't want multiple IMPLEMENTATION inheritance.  Instead we just generate

--- a/mycpp/gc_slab.h
+++ b/mycpp/gc_slab.h
@@ -1,0 +1,51 @@
+#ifndef GC_SLAB_H
+#define GC_SLAB_H
+
+template <typename T>
+inline void InitSlabCell(Obj* obj) {
+  // log("SCANNED");
+  obj->heap_tag_ = Tag::Scanned;
+}
+
+template <>
+inline void InitSlabCell<int>(Obj* obj) {
+  // log("OPAQUE");
+  obj->heap_tag_ = Tag::Opaque;
+}
+
+// don't include items_[1]
+const int kSlabHeaderSize = sizeof(Obj);
+
+// Opaque slab, e.g. for List<int>
+template <typename T>
+class Slab : public Obj {
+ public:
+  Slab(int obj_len) : Obj(0, 0, obj_len) {
+    InitSlabCell<T>(this);
+  }
+  T items_[1];  // variable length
+};
+
+template <typename T, int N>
+class GlobalSlab {
+  // A template type with the same layout as Str with length N-1 (which needs a
+  // buffer of size N).  For initializing global constant instances.
+ public:
+  OBJ_HEADER()
+
+  T items_[N];
+
+  DISALLOW_COPY_AND_ASSIGN(GlobalSlab)
+};
+
+// Note: entries will be zero'd because the Heap is zero'd.
+template <typename T>
+inline Slab<T>* NewSlab(int len) {
+  int obj_len = RoundUp(kSlabHeaderSize + len * sizeof(T));
+  void* place = gHeap.Allocate(obj_len);
+  auto slab = new (place) Slab<T>(obj_len);  // placement new
+  return slab;
+}
+
+
+#endif  // GC_SLAB_H

--- a/mycpp/gc_stress_test.cc
+++ b/mycpp/gc_stress_test.cc
@@ -12,7 +12,6 @@ using gc_heap::Dict;
 using gc_heap::List;
 using gc_heap::NewList;
 using gc_heap::StackRoots;
-using gc_heap::Str;
 using gc_heap::StrFromC;
 // using gc_heap::kEmptyString;
 

--- a/mycpp/gc_tag.h
+++ b/mycpp/gc_tag.h
@@ -1,0 +1,18 @@
+#ifndef GC_TAG_H
+#define GC_TAG_H
+
+// Obj::heap_tag_ values.  They're odd numbers to distinguish them from vtable
+// pointers.
+//
+// NOTE(Jesse): Changed to an enum because namespaces can't be typedef'd.
+// ie can't be included using the 'using' keyword
+//
+enum Tag {
+  Forwarded = 1,  // For the Cheney algorithm.
+  Global = 3,     // Neither copy nor scan.
+  Opaque = 5,     // Copy but don't scan.  List<int> and Str
+  FixedSize = 7,  // Fixed size headers: consult field_mask_
+  Scanned = 9,    // Copy AND scan for non-NULL pointers.
+};
+
+#endif  // GC_TAG_H

--- a/mycpp/gc_types.h
+++ b/mycpp/gc_types.h
@@ -9,51 +9,7 @@
 
 namespace gc_heap {
 
-template <typename T>
-inline void InitSlabCell(Obj* obj) {
-  // log("SCANNED");
-  obj->heap_tag_ = Tag::Scanned;
-}
-
-template <>
-inline void InitSlabCell<int>(Obj* obj) {
-  // log("OPAQUE");
-  obj->heap_tag_ = Tag::Opaque;
-}
-
-// don't include items_[1]
-const int kSlabHeaderSize = sizeof(Obj);
-
-// Opaque slab, e.g. for List<int>
-template <typename T>
-class Slab : public Obj {
- public:
-  Slab(int obj_len) : Obj(0, 0, obj_len) {
-    InitSlabCell<T>(this);
-  }
-  T items_[1];  // variable length
-};
-
-template <typename T, int N>
-class GlobalSlab {
-  // A template type with the same layout as Str with length N-1 (which needs a
-  // buffer of size N).  For initializing global constant instances.
- public:
-  OBJ_HEADER()
-
-  T items_[N];
-
-  DISALLOW_COPY_AND_ASSIGN(GlobalSlab)
-};
-
-// Note: entries will be zero'd because the Heap is zero'd.
-template <typename T>
-inline Slab<T>* NewSlab(int len) {
-  int obj_len = RoundUp(kSlabHeaderSize + len * sizeof(T));
-  void* place = gHeap.Allocate(obj_len);
-  auto slab = new (place) Slab<T>(obj_len);  // placement new
-  return slab;
-}
+#include "mycpp/gc_slab.h"
 
 #ifdef MYLIB_LEAKY
   #define GLOBAL_STR(name, val) Str* name = StrFromC(val);
@@ -745,7 +701,6 @@ void Dict<K, V>::set(K key, V val) {
 // Do some extra calculation to avoid storing redundant lengths.
 inline int len(const gc_heap::Str* s) {
   assert(s->obj_len_ > gc_heap::kStrHeaderSize - 1);
-
   return s->obj_len_ - gc_heap::kStrHeaderSize - 1;
 }
 

--- a/mycpp/gc_types.h
+++ b/mycpp/gc_types.h
@@ -6,24 +6,14 @@
 #define GC_TYPES_H
 
 #include "mycpp/gc_heap.h"
+#include "mycpp/str_types.h"
+
 
 namespace gc_heap {
 
 #include "mycpp/gc_slab.h"
 
-#ifdef MYLIB_LEAKY
-  #define GLOBAL_STR(name, val) Str* name = StrFromC(val);
-  #define GLOBAL_LIST(T, N, name, array) List<T>* name = new List<T>(array);
-#endif
-
 #ifndef MYLIB_LEAKY
-
-//
-// Str
-//
-
-#include "mycpp/str_types.h"
-
 
 template <int N>
 class GlobalStr {
@@ -50,10 +40,10 @@ extern Str* kEmptyString;
 
   #define GLOBAL_STR(name, val)                 \
     gc_heap::GlobalStr<sizeof(val)> _##name = { \
-        Tag::Global,                            \
+        Tag::Global,                   \
         0,                                      \
         gc_heap::kZeroMask,                     \
-        gc_heap::kStrHeaderSize + sizeof(val),  \
+        kStrHeaderSize + sizeof(val),  \
         -1,                                     \
         val};                                   \
     Str* name = reinterpret_cast<Str*>(&_##name);
@@ -698,10 +688,8 @@ void Dict<K, V>::set(K key, V val) {
 
 #ifndef MYLIB_LEAKY
 
-// Do some extra calculation to avoid storing redundant lengths.
-inline int len(const gc_heap::Str* s) {
-  assert(s->obj_len_ > gc_heap::kStrHeaderSize - 1);
-  return s->obj_len_ - gc_heap::kStrHeaderSize - 1;
+inline int len(const Str* s) {
+  return s->obj_len_ - kStrHeaderSize - 1;
 }
 
 template <typename T>

--- a/mycpp/gc_types.h
+++ b/mycpp/gc_types.h
@@ -688,10 +688,6 @@ void Dict<K, V>::set(K key, V val) {
 
 #ifndef MYLIB_LEAKY
 
-inline int len(const Str* s) {
-  return s->obj_len_ - kStrHeaderSize - 1;
-}
-
 template <typename T>
 int len(const gc_heap::List<T>* L) {
   return L->len_;

--- a/mycpp/leaky_types.cc
+++ b/mycpp/leaky_types.cc
@@ -9,7 +9,6 @@ using mylib::CopyBufferIntoNewStr;
 using gc_heap::CopyBufferIntoNewStr;
 using gc_heap::kEmptyString;
 using gc_heap::StackRoots;
-using gc_heap::Str;
 #endif
 
 #include <ctype.h>  // isalpha(), isdigit()
@@ -301,28 +300,6 @@ List<Str*>* Str::splitlines(bool keep) {
   return nullptr;
 }
 
-#ifndef LEAKY_BINDINGS
-namespace gc_heap {
-#endif
-
-enum class StripWhere {
-  Left,
-  Right,
-  Both,
-};
-
-const int kWhitespace = -1;
-
-bool OmitChar(uint8_t ch, int what) {
-  if (what == kWhitespace) {
-    return isspace(ch);
-  } else {
-    return what == ch;
-  }
-}
-
-// #######################################
-
 Str* Str::upper() {
   int len_ = len(this);
   Str* result = AllocStr(len_);
@@ -342,8 +319,6 @@ Str* Str::lower() {
   }
   return result;
 }
-
-// #######################################
 
 Str* Str::ljust(int width, Str* fillchar) {
   assert(len(fillchar) == 1);
@@ -439,6 +414,23 @@ Str* Str::replace(Str* old, Str* new_str) {
   return CopyBufferIntoNewStr(result, result_len);
 }
 
+
+enum class StripWhere {
+  Left,
+  Right,
+  Both,
+};
+
+const int kWhitespace = -1;
+
+bool OmitChar(uint8_t ch, int what) {
+  if (what == kWhitespace) {
+    return isspace(ch);
+  } else {
+    return what == ch;
+  }
+}
+
 // StripAny is modeled after CPython's do_strip() in stringobject.c, and can
 // implement 6 functions:
 //
@@ -509,8 +501,4 @@ Str* Str::lstrip(Str* chars) {
 Str* Str::lstrip() {
   return StripAny(this, StripWhere::Left, kWhitespace);
 }
-
-#ifndef LEAKY_BINDINGS
-}  // namespace gc_heap
-#endif
 

--- a/mycpp/leaky_types_test.cc
+++ b/mycpp/leaky_types_test.cc
@@ -1,9 +1,10 @@
-/* #define LEAKY_BINDINGS 1 */
-
 #ifdef LEAKY_BINDINGS
-  #include "mycpp/mylib_old.h"
 
+// NOTE(Jesse): This path is currently never compiled.
+
+#include "mycpp/mylib_old.h"
 using gc_heap::gHeap;
+
 
 #else
 
@@ -14,9 +15,7 @@ using gc_heap::gHeap;
 
 using gc_heap::gHeap;
 using gc_heap::kEmptyString;
-using gc_heap::Str;
 using gc_heap::StrFromC;
-/* using gc_heap::StrFromC; */
 
 #endif
 
@@ -654,6 +653,25 @@ TEST test_str_to_int() {
   PASS();
 }
 
+TEST test_str_size() {
+  printf("---------- str_size ----------\n");
+
+  PRINT_INT(kStrHeaderSize);
+  PRINT_INT((int)sizeof(Str));
+
+#ifdef LEAKY_BINDINGS
+  PRINT_INT(1);
+#else
+  PRINT_INT(0);
+#endif
+
+  ASSERT(kStrHeaderSize == 12);
+  ASSERT(sizeof(Str) == 16);
+
+  printf("---------- Done ----------\n");
+  PASS();
+}
+
 GREATEST_MAIN_DEFS();
 
 int main(int argc, char** argv) {
@@ -667,6 +685,7 @@ int main(int argc, char** argv) {
   RUN_TEST(test_str_just);
   RUN_TEST(test_str_concat);
   RUN_TEST(test_str_to_int);
+  RUN_TEST(test_str_size);
 
   GREATEST_MAIN_END();
   return 0;

--- a/mycpp/mylib_old.cc
+++ b/mycpp/mylib_old.cc
@@ -12,6 +12,20 @@ using mylib::CopyBufferIntoNewStr;
 
 Str* kEmptyString = StrFromC("", 0);
 
+// For cStringIO API
+Str* mylib::BufWriter::getvalue() {
+  if (data_) {
+    Str* ret = CopyBufferIntoNewStr(data_, len_);
+    reset();  // Invalidate this instance
+    return ret;
+  } else {
+    // log('') translates to this
+    // Strings are immutable so we can do this.
+    return kEmptyString;
+  }
+}
+
+
 List<Str*>* Str::split(Str* sep) {
   assert(len(sep) == 1);  // we can only split one char
   char sep_char = sep->data_[0];

--- a/mycpp/mylib_old.h
+++ b/mycpp/mylib_old.h
@@ -18,22 +18,22 @@
 
 #include "common.h"
 
-// if this file is even included, we're using the old mylib
-#define MYLIB_LEAKY 1
-#include "mycpp/gc_types.h"  // for Obj
-#include "mycpp/tuple_types.h"
-#include "mycpp/error_types.h"
-
 #ifdef DUMB_ALLOC
   #include "cpp/dumb_alloc.h"
   #define malloc dumb_malloc
   #define free dumb_free
 #endif
 
-class Str;
+// if this file is even included, we're using the old mylib
+#define MYLIB_LEAKY 1
+#include "mycpp/gc_types.h"  // for Obj
+#include "mycpp/tuple_types.h"
+#include "mycpp/error_types.h"
 
 template <class T>
 class List;
+
+#include "mycpp/str_types.h"
 
 template <class K, class V>
 class Dict;
@@ -43,9 +43,7 @@ class DictIter;
 
 namespace mylib {
 
-  inline Str* CopyBufferIntoNewStr(char* buf, unsigned int buf_len);
-  inline Str* StrFromC(const char* s, int len);
-  inline Str* StrFromC(const char* s);
+#include "mycpp/str_allocators.h"
 
   template <typename V>
   void dict_remove(Dict<Str*, V>* haystack, Str* needle);
@@ -66,8 +64,6 @@ void println_stderr(Str* s);
 //
 // Data Types
 //
-
-#include "mycpp/str_types.h"
 
 inline int len(const Str* s) {
   return s->obj_len_ - kStrHeaderSize - 1;
@@ -761,7 +757,6 @@ inline void dict_remove(Dict<int, V>* haystack, int needle) {
 
 Tuple2<Str*, Str*> split_once(Str* s, Str* delim);
 
-#include "mycpp/str_allocators.h"
 
 // emulate gc_heap API for ASDL
 

--- a/mycpp/mylib_old.h
+++ b/mycpp/mylib_old.h
@@ -73,11 +73,6 @@ class List;
 
 #include "mycpp/str_types.h"
 
-inline int len(const Str* s) {
-  return s->obj_len_ - kStrHeaderSize - 1;
-}
-
-
 template <class K, class V>
 class Dict;
 

--- a/mycpp/mylib_old.h
+++ b/mycpp/mylib_old.h
@@ -26,7 +26,45 @@
 
 // if this file is even included, we're using the old mylib
 #define MYLIB_LEAKY 1
-#include "mycpp/gc_types.h"  // for Obj
+/* #include "mycpp/gc_types.h"  // for Obj */
+
+#define GLOBAL_STR(name, val) Str* name = StrFromC(val, sizeof(val)-1)
+#define GLOBAL_LIST(T, N, name, array) List<T>* name = new List<T>(array);
+
+#include "mycpp/gc_tag.h"
+
+namespace gc_heap {
+  #include "mycpp/gc_obj.h"
+  #include "mycpp/gc_alloc.h"
+
+  struct Heap
+  {
+    void Init(int byte_count)
+    {
+    }
+
+    void Bump()
+    {
+    }
+
+    void Collect()
+    {
+    }
+
+    void* Allocate(int num_bytes)
+    {
+      return calloc(num_bytes, 1);
+    }
+  };
+
+  extern Heap gHeap;
+
+  struct StackRoots {
+    StackRoots(std::initializer_list<void*> roots) {}
+  };
+
+}
+
 #include "mycpp/tuple_types.h"
 #include "mycpp/error_types.h"
 
@@ -34,6 +72,11 @@ template <class T>
 class List;
 
 #include "mycpp/str_types.h"
+
+inline int len(const Str* s) {
+  return s->obj_len_ - kStrHeaderSize - 1;
+}
+
 
 template <class K, class V>
 class Dict;
@@ -64,10 +107,6 @@ void println_stderr(Str* s);
 //
 // Data Types
 //
-
-inline int len(const Str* s) {
-  return s->obj_len_ - kStrHeaderSize - 1;
-}
 
 // NOTE: This iterates over bytes.
 class StrIter {
@@ -523,7 +562,6 @@ Dict<K, V>* NewDict(std::initializer_list<K> keys,
 
 template <typename T>
 inline int len(const List<T>* L) {
-  // inline int len(List<T>* L) {
   return L->v_.size();
 }
 

--- a/mycpp/str_types.h
+++ b/mycpp/str_types.h
@@ -80,4 +80,3 @@ inline void Str::SetObjLenFromStrLen(int str_len) {
 }
 
 #endif // STR_TYPES_H
-

--- a/mycpp/str_types.h
+++ b/mycpp/str_types.h
@@ -84,7 +84,15 @@ class Str : public gc_heap::Obj {
   DISALLOW_COPY_AND_ASSIGN(Str)
 };
 
-static const int kStrHeaderSize = offsetof(Str, data_);
+constexpr int kStrHeaderSize = offsetof(Str, data_);
+
+inline int len(const Str* s) {
+  // NOTE(Jesse): Not sure if 0-length strings should be allowed, but we
+  // currently don't hit this assertion, so I would think not?
+  assert(s->obj_len_ >= kStrHeaderSize - 1);
+
+  return s->obj_len_ - kStrHeaderSize - 1;
+}
 
 inline void Str::SetObjLenFromStrLen(int str_len) {
   obj_len_ = kStrHeaderSize + str_len + 1;

--- a/mycpp/str_types.h
+++ b/mycpp/str_types.h
@@ -1,6 +1,17 @@
 #ifndef STR_TYPES_H
 #define STR_TYPES_H
 
+#ifdef LEAKY_BINDINGS
+
+template <typename T>
+class List;
+
+#else
+
+using gc_heap::List;
+
+#endif
+
 using gc_heap::kZeroMask;
 
 class Str : public gc_heap::Obj {
@@ -73,10 +84,11 @@ class Str : public gc_heap::Obj {
   DISALLOW_COPY_AND_ASSIGN(Str)
 };
 
-constexpr int kStrHeaderSize = offsetof(Str, data_);
+static const int kStrHeaderSize = offsetof(Str, data_);
 
 inline void Str::SetObjLenFromStrLen(int str_len) {
-  obj_len_ = kStrHeaderSize + str_len + 1;  // NUL terminator
+  obj_len_ = kStrHeaderSize + str_len + 1;
+  /* assert(len(this) == str_len); */
 }
 
 #endif // STR_TYPES_H

--- a/test/baseline.spec-cpp.assertion_fails
+++ b/test/baseline.spec-cpp.assertion_fails
@@ -9,4 +9,4 @@
 (/home/scallywag/work/oil/cpp/leaky_osh_eval_stubs.h:45: int signal_def::GetNumber(Str*): Assertion `!"Not Implemented"' failed.) _tmp/spec/cpp/builtin-trap.html
 (/home/scallywag/work/oil/cpp/leaky_osh_eval_stubs.h:45: int signal_def::GetNumber(Str*): Assertion `!"Not Implemented"' failed.) _tmp/spec/cpp/builtin-trap.html
 (/home/scallywag/work/oil/cpp/leaky_osh_eval_stubs.h:45: int signal_def::GetNumber(Str*): Assertion `!"Not Implemented"' failed.) _tmp/spec/cpp/builtin-trap.html
-(mycpp/mylib_old.cc:232: void mylib::BufWriter::format_o(int): Assertion `!"Not Implemented"' failed.) _tmp/spec/cpp/builtins.html
+(mycpp/mylib_old.cc:246: void mylib::BufWriter::format_o(int): Assertion `!"Not Implemented"' failed.) _tmp/spec/cpp/builtins.html


### PR DESCRIPTION
I guess the only thing I really have to say about this is, it's going to get worse before it gets better.  Tests still pass, and I've got a plan for getting closer towards removing the `gc_heap` namespace.  Once that namespace is gone we should be able to collapse a lot of the little files I'm creating back down to bigger ones, but this intermediate step is the only method I've been able to make any progress with.