### PR TITLE
Jesse/refactor/remove placement new for str

### DIFF
--- a/mycpp/gc_builtins.cc
+++ b/mycpp/gc_builtins.cc
@@ -386,10 +386,10 @@ List<Str*>* Str::split(Str* sep) {
     int prev_pos = breaks[i - 1];
     int part_len = breaks[i] - prev_pos - 1;
     if (part_len > 0) {
+
       // like AllocStr(), but IN PLACE
-      int obj_len = kStrHeaderSize + part_len + 1;  // NUL terminator
-      Str* part = new (place) Str();                // placement new
-      part->SetObjLen(obj_len);                     // So the GC can copy it
+      int obj_len = ObjLenFromStrLen(part_len);
+      Str* part = InitStr(place, part_len, obj_len);
       memcpy(part->data_, self->data_ + prev_pos + 1, part_len);
       result->set(i - 1, part);
       place += aligned(obj_len);

--- a/mycpp/gc_builtins.cc
+++ b/mycpp/gc_builtins.cc
@@ -389,7 +389,7 @@ List<Str*>* Str::split(Str* sep) {
 
       // like AllocStr(), but IN PLACE
       int obj_len = ObjLenFromStrLen(part_len);
-      Str* part = InitStr(place, part_len, obj_len);
+      Str* part = InitStr(place, obj_len);
       memcpy(part->data_, self->data_ + prev_pos + 1, part_len);
       result->set(i - 1, part);
       place += aligned(obj_len);

--- a/mycpp/gc_str.h
+++ b/mycpp/gc_str.h
@@ -17,13 +17,6 @@ class List;
 class Str : public Obj {
  public:
 
-#if 0
-  // Don't call this directly.  Call AllocStr() instead, which calls this.
-  explicit Str() : Obj(Tag::Opaque, kZeroMask, 0) {
-    // log("GC Str()");
-  }
-#endif
-
   char* data() {
     return data_;
   };
@@ -123,10 +116,11 @@ inline void Str::SetObjLenFromStrLen(int str_len) {
 
 inline void InitObj(void* buf, uint8_t heap_tag, uint8_t type_tag, uint16_t field_mask, uint32_t obj_len)
 {
-  ((Obj*)buf)->heap_tag_ = heap_tag;
-  ((Obj*)buf)->type_tag_ = type_tag;
-  ((Obj*)buf)->field_mask_ = field_mask;
-  ((Obj*)buf)->obj_len_ = obj_len;
+  Obj *obj = static_cast<Obj*>(buf);
+  obj->heap_tag_ = heap_tag;
+  obj->type_tag_ = type_tag;
+  obj->field_mask_ = field_mask;
+  obj->obj_len_ = obj_len;
 }
 
 inline int ObjLenFromStrLen(int len)
@@ -136,9 +130,7 @@ inline int ObjLenFromStrLen(int len)
 
 inline Str* InitStr(void* buf, int str_len, int obj_len) {
   InitObj(buf, Tag::Opaque, 0, kZeroMask, obj_len);
-  Str* s = (Str*)buf;
-  s->SetObjLen(obj_len);
-  return s;
+  return static_cast<Str*>(buf);
 }
 
 inline Str* AllocStr(int str_len) {

--- a/mycpp/gc_str.h
+++ b/mycpp/gc_str.h
@@ -116,6 +116,9 @@ inline void Str::SetObjLenFromStrLen(int str_len) {
 
 inline void InitObj(void* buf, uint8_t heap_tag, uint8_t type_tag, uint16_t field_mask, uint32_t obj_len)
 {
+  assert(obj_len >= sizeof(Obj));
+  assert(heap_tag & 1); // By definition, heap tags are odd numbers
+
   Obj *obj = static_cast<Obj*>(buf);
   obj->heap_tag_ = heap_tag;
   obj->type_tag_ = type_tag;
@@ -128,7 +131,7 @@ inline int ObjLenFromStrLen(int len)
   return kStrHeaderSize + len + 1;
 }
 
-inline Str* InitStr(void* buf, int str_len, int obj_len) {
+inline Str* InitStr(void* buf, int obj_len) {
   InitObj(buf, Tag::Opaque, 0, kZeroMask, obj_len);
   return static_cast<Str*>(buf);
 }
@@ -136,7 +139,7 @@ inline Str* InitStr(void* buf, int str_len, int obj_len) {
 inline Str* AllocStr(int str_len) {
   int obj_len = ObjLenFromStrLen(str_len);
   void* place = ALLOCATE(obj_len);
-  Str* result = InitStr(place, str_len, obj_len);
+  Str* result = InitStr(place, obj_len);
   return result;
 }
 


### PR DESCRIPTION
Not sure if we want to merge this @andychu, but this is one way of statically denying the use of the `new` operator.

Worth noting that we can't disallow the `Obj` constructor at the present time because that code still gets called in the oldstl paths .. ie during `new List` and friends.

WDYT?