### PR TITLE
Jesse/feature/use mmap always

### DIFF
--- a/cpp/NINJA-steps.sh
+++ b/cpp/NINJA-steps.sh
@@ -90,11 +90,11 @@ setglobal_compile_flags() {
 
     (gcstats)
       # unit tests use for gHeap.Report()
-      flags="$flags -g -D GC_PROTECT -D GC_STATS"
+      flags="$flags -g -D GC_STATS"
       ;;
 
     (gcevery)
-      flags="$flags -g -D GC_PROTECT -D GC_STATS -D GC_EVERY_ALLOC"
+      flags="$flags -g -D GC_STATS -D GC_EVERY_ALLOC"
       ;;
 
     (oldstl)

--- a/cpp/NINJA_subgraph.py
+++ b/cpp/NINJA_subgraph.py
@@ -131,8 +131,6 @@ for cc in CPP_BINDINGS + GENERATED_CC:
   HEADER_DEPS[cc].extend(ASDL_H)
   HEADER_DEPS[cc].extend(GENERATED_H)
 
-# -D NO_GC_HACK: Avoid memset().  -- rename GC_NO_MEMSET?
-#  - only applies to gc_heap.h in Space::Clear()
 # -D LEAKY_ALLOCATOR: for QSN, which is used by the ASDL runtime
 #  TODO: use .leaky variant
 #  - _bin/cxx-leaky/osh_eval -- this means it's optimized then?
@@ -142,7 +140,7 @@ for cc in CPP_BINDINGS + GENERATED_CC:
 # leakyopt, leakyasan -- I guess this is good for tests
 
 # single quoted in Ninja/shell syntax
-OSH_EVAL_FLAGS_STR = "'-D NO_GC_HACK -D LEAKY_ALLOCATOR'"
+OSH_EVAL_FLAGS_STR = "'-D LEAKY_ALLOCATOR'"
 
 
 def NinjaGraph(n):

--- a/mycpp/gc_heap.cc
+++ b/mycpp/gc_heap.cc
@@ -124,10 +124,12 @@ void Heap::Collect() {
   num_collections_++;
 #endif
 
-  // If we grew one space, the other one has to catch up.
   if (to_space_.size_ < from_space_.size_) {
-    to_space_.Free();
-    to_space_.Init(from_space_.size_);
+    // We just initialized the to_space to the size of the from space.  If it's
+    // smaller here, thats now a bug.
+    InvalidCodePath(); 
+    /* to_space_.Free(); */
+    /* to_space_.Init(from_space_.size_); */
   }
 
   char* scan = to_space_.begin_;  // boundary between black and gray

--- a/mycpp/gc_heap.h
+++ b/mycpp/gc_heap.h
@@ -94,7 +94,6 @@
 // #defines for degbugging:
 //
 // GC_EVERY_ALLOC: Collect() on every Allocate().  Exposes many bugs!
-// GC_PROTECT: Use mprotect()
 // GC_VERBOSE: Log when we collect
 // GC_STATS: Collect more stats.  TODO: Rename this?
 

--- a/mycpp/gc_heap.h
+++ b/mycpp/gc_heap.h
@@ -114,28 +114,12 @@ const int kMaxRoots = 4 * 1024;  // related to C stack size
 
 class Space {
  public:
-  Space() {
-  }
+  Space() {}
+
   void Init(int space_size);
 
   void Free();
 
-  void Clear() {
-    // Slab scanning relies on 0 bytes (nullptr).  e.g. for a List<Token*>*.
-    // Note: I noticed that memset() of say 400 MiB is pretty expensive.  Does
-    // it makes sense to zero the slabs instead?
-#ifndef NO_GC_HACK
-    // When not collecting, we need a huge 400 MiB heap.  Try to save startup
-    // time by not doing this.
-    memset(begin_, 0, size_);
-#endif
-  }
-
-#if GC_PROTECT
-  // To maintain invariants
-  void Protect();
-  void Unprotect();
-#endif
 #if GC_STATS
   void AssertValid(void* p) {
     if (begin_ <= p && p < begin_ + size_) {
@@ -152,8 +136,7 @@ class Space {
 
 class Heap {
  public:
-  Heap() {  // default constructor does nothing -- relies on zero initialization
-  }
+  Heap() {}  // default constructor does nothing -- relies on zero initialization
 
   // Real initialization with the initial heap size.  The heap grows with
   // allocations.

--- a/mycpp/gc_heap.h
+++ b/mycpp/gc_heap.h
@@ -143,8 +143,6 @@ class Heap {
   void Init(int space_size) {
     // malloc() and memset()
     from_space_.Init(space_size);
-    to_space_.Init(space_size);
-
     free_ = from_space_.begin_;  // where we allocate from
     limit_ = free_ + space_size;
 

--- a/mycpp/gc_heap_test.cc
+++ b/mycpp/gc_heap_test.cc
@@ -934,7 +934,8 @@ TEST protect_test() {
   Space from;
   from.Init(512);
 
-#ifdef GC_PROTECT
+  // TODO(Jesse): What does this test do?
+#if 0
   from.Protect();
   // This crashes
   // log("begin = %x", *from.begin_);

--- a/mycpp/gc_heap_test.cc
+++ b/mycpp/gc_heap_test.cc
@@ -934,7 +934,11 @@ TEST protect_test() {
   Space from;
   from.Init(512);
 
-  // TODO(Jesse): What does this test do?
+  // TODO(Jesse): This test is no longer necessary .. whatever it was doing.
+  //
+  // Seems to me like it was manually toggled on at one point to verify that
+  // the 'Protect()' call indeed produced a crash as intended ..?
+  //
 #if 0
   from.Protect();
   // This crashes

--- a/test/baseline.spec-cpp.assertion_fails
+++ b/test/baseline.spec-cpp.assertion_fails
@@ -9,4 +9,4 @@
 (/home/scallywag/work/oil/cpp/leaky_osh_eval_stubs.h:45: int signal_def::GetNumber(Str*): Assertion `!"Not Implemented"' failed.) _tmp/spec/cpp/builtin-trap.html
 (/home/scallywag/work/oil/cpp/leaky_osh_eval_stubs.h:45: int signal_def::GetNumber(Str*): Assertion `!"Not Implemented"' failed.) _tmp/spec/cpp/builtin-trap.html
 (/home/scallywag/work/oil/cpp/leaky_osh_eval_stubs.h:45: int signal_def::GetNumber(Str*): Assertion `!"Not Implemented"' failed.) _tmp/spec/cpp/builtin-trap.html
-(mycpp/leaky_mylib.cc:120: void mylib::BufWriter::format_o(int): Assertion `!"Not Implemented"' failed.) _tmp/spec/cpp/builtins.html
+(mycpp/leaky_mylib.cc:119: void mylib::BufWriter::format_o(int): Assertion `!"Not Implemented"' failed.) _tmp/spec/cpp/builtins.html


### PR DESCRIPTION
Pretty straight-forward change which simplified the Heap struct quite a bit.

I was able to remove `GC_NO_HACK` and `GC_PROTECT` by virtue of using `mmap()`.

First, we never need to clear pages because the OS does that when they're faulted in.

Second, we never need to call memprotect() because we jettison the entire mapping every time the collector hits.  We maintain the invariant that the program crashes if anyone tries to access the old zone; munmap makes sure of that.