### PR TITLE
[mycpp/runtime] Make roots arbitrarily sized with std::vector.

### DIFF
--- a/mycpp/gc_stress_test.cc
+++ b/mycpp/gc_stress_test.cc
@@ -10,6 +10,35 @@
 // - Assert the number of heap growths
 // - maybe number of allocations?
 
+int count(int n) {
+  int dummy = 42;
+  StackRoots _roots({&dummy});
+  // log("d %p", &dummy);
+
+  if (n == 0) {
+    return 0;
+  } else {
+    return 1 + count(n - 1);
+  }
+}
+
+TEST overflowing_roots_test() {
+  gHeap.Init(KiB(1));
+
+  log("count 4000 = %d", count(4000));
+
+  // When our stack roots were limited, this would crash
+  log("count 5000 = %d", count(5000));
+  log("count 20000 = %d", count(20000));
+  log("count 25000 = %d", count(25000));
+  // Stack overflow in ASAN
+  // log("count 29000 = %d", count(29000));
+  // Stack overflow in dbg
+  // log("count 200000 = %d", count(200000));
+
+  PASS();
+}
+
 TEST str_simple_test() {
   gHeap.Init(KiB(1));
 
@@ -37,7 +66,7 @@ GLOBAL_STR(b, "b");
 GLOBAL_STR(bx, "bx");
 
 TEST str_growth_test() {
-  gHeap.Init(1 << 8);  // 1 KiB
+  gHeap.Init(KiB(1));
 
   Str* s = nullptr;
   StackRoots _roots({&s});
@@ -71,7 +100,7 @@ TEST str_growth_test() {
 
 // Simple test with just List on the heap.
 TEST list_append_test() {
-  gHeap.Init(1 << 8);  // 1 KiB
+  gHeap.Init(KiB(1));
 
   List<int>* L = nullptr;
   StackRoots _roots({&L});
@@ -94,7 +123,7 @@ TEST list_append_test() {
 }
 
 TEST list_slice_append_test() {
-  gHeap.Init(1 << 8);  // 1 KiB
+  gHeap.Init(KiB(1));
 
   List<int>* L = nullptr;
   StackRoots _roots({&L});
@@ -123,7 +152,7 @@ TEST list_slice_append_test() {
 }
 
 TEST list_str_growth_test() {
-  gHeap.Init(1 << 8);  // 1 KiB
+  gHeap.Init(KiB(1));
 
   Str* s = nullptr;
   List<Str*>* L = nullptr;
@@ -155,7 +184,7 @@ TEST list_str_growth_test() {
 }
 
 TEST dict_growth_test() {
-  gHeap.Init(1 << 20);  // 1 KiB
+  gHeap.Init(KiB(1));
 
   Str* s = nullptr;
   Dict<Str*, int>* D = nullptr;
@@ -180,10 +209,11 @@ TEST dict_growth_test() {
 GREATEST_MAIN_DEFS();
 
 int main(int argc, char** argv) {
-  gHeap.Init(1 << 20);
+  gHeap.Init(KiB(1));
 
   GREATEST_MAIN_BEGIN();
 
+  RUN_TEST(overflowing_roots_test);
   RUN_TEST(str_simple_test);
   RUN_TEST(str_growth_test);
   RUN_TEST(list_append_test);

--- a/mycpp/marksweep_heap.cc
+++ b/mycpp/marksweep_heap.cc
@@ -2,6 +2,7 @@
 
 void MarkSweepHeap::Init(int collection_thresh) {
   this->collection_thresh_ = collection_thresh;
+  roots_.reserve(1024);  // prevent resizing in common case
 }
 
 void* MarkSweepHeap::Allocate(int byte_count) {

--- a/mycpp/marksweep_heap.h
+++ b/mycpp/marksweep_heap.h
@@ -3,6 +3,7 @@
 
 #include <new>
 #include <unordered_set>
+#include <vector>
 
 class MarkSweepHeap {
   void MarkAllReferences(Obj* obj);
@@ -15,12 +16,11 @@ class MarkSweepHeap {
   void* Allocate(int);
 
   void PushRoot(Obj** p) {
-    assert(roots_top_ < kMaxRoots);
-    roots_[roots_top_++] = p;
+    roots_.push_back(p);
   }
 
   void PopRoot() {
-    roots_top_--;
+    roots_.pop_back();
   }
 
   void Collect();
@@ -28,7 +28,7 @@ class MarkSweepHeap {
   void Report(){};
 
   int roots_top_;
-  Obj** roots_[kMaxRoots];  // These are pointers to Obj* pointers
+  std::vector<Obj**> roots_;
 
   uint64_t current_heap_bytes_;
   uint64_t collection_thresh_;


### PR DESCRIPTION
Also make heap initialization consistent to KiB(1).