### PR TITLE
[mycpp/runtime] Separate BufWriter and FormatStringer

### DIFF
--- a/mycpp/gc_mylib.h
+++ b/mycpp/gc_mylib.h
@@ -13,7 +13,4 @@ void dict_remove(Dict<K, V>* haystack, K needle);
 
 }  // namespace mylib
 
-// Global formatter
-extern mylib::BufWriter gBuf;
-
 #endif  // GC_MYLIB_H

--- a/mycpp/leaky_builtins.cc
+++ b/mycpp/leaky_builtins.cc
@@ -2,8 +2,6 @@
 
 #include "mycpp/runtime.h"
 
-mylib::BufWriter gBuf;
-
 // Translation of Python's print().
 void print(Str* s) {
   fputs(s->data(), stdout);
@@ -24,7 +22,7 @@ Str* str(int i) {
 }
 
 Str* repr(Str* s) {
-  mylib::BufWriter f;
+  mylib::FormatStringer f;
   f.format_r(s);
   return f.getvalue();
 }

--- a/mycpp/leaky_mylib.cc
+++ b/mycpp/leaky_mylib.cc
@@ -160,16 +160,18 @@ void BufWriter::write(Str* s) {
 }
 
 Str* BufWriter::getvalue() {
-  if (len_ == 0) {  // result is "" if no methods are called
+  if (len_ == 0) {  // if no write() methods are called, the result is ""
     assert(data_ == nullptr);
     return kEmptyString;
   } else {
-    assert(len_ != -1);
+    assert(len_ != -1);  // Check for two INVALID getvalue() in a row
+
     Str* ret = ::StrFromC(data_, len_);
 
-    // Put this instance in an INVALID STATE so you can't call getvalue() twice
-    // in a row.
+    // Put this instance in an INVALID state
     len_ = -1;
+    free(data_);
+    data_ = nullptr;
 
     return ret;
   }

--- a/mycpp/leaky_mylib.cc
+++ b/mycpp/leaky_mylib.cc
@@ -160,10 +160,19 @@ void BufWriter::write(Str* s) {
 }
 
 Str* BufWriter::getvalue() {
-  assert(data_);
-  Str* ret = ::StrFromC(data_, len_);
-  data_ = nullptr;  // can't call it twice in a row
-  return ret;
+  if (len_ == 0) {  // result is "" if no methods are called
+    assert(data_ == nullptr);
+    return kEmptyString;
+  } else {
+    assert(len_ != -1);
+    Str* ret = ::StrFromC(data_, len_);
+
+    // Put this instance in an INVALID STATE so you can't call getvalue() twice
+    // in a row.
+    len_ = -1;
+
+    return ret;
+  }
 }
 
 //

--- a/mycpp/leaky_mylib.h
+++ b/mycpp/leaky_mylib.h
@@ -141,7 +141,17 @@ class BufWriter : public Writer {
   // For cStringIO API
   Str* getvalue();
 
-  // Methods to compile printf format strings to
+ private:
+  // Just like a string, except it's mutable
+  char* data_;
+  int len_;
+};
+
+class FormatStringer {
+ public:
+  FormatStringer() : data_(nullptr), len_(0) {
+  }
+  Str* getvalue();
 
   // Called before reusing the global gBuf instance for fmtX() functions
   //
@@ -210,6 +220,6 @@ inline Writer* Stderr() {
 
 }  // namespace mylib
 
-extern mylib::BufWriter gBuf;
+extern mylib::FormatStringer gBuf;
 
 #endif  // LEAKY_MYLIB_H


### PR DESCRIPTION
The former will be a GC-managed object used by generated code.

The latter is a global, and can be a local in fmt123() functions.

This was a smell -- the APIs were almost totally disjoint!

    class BufWriter : public Writer
      getvalue()
      write()
      ...

    class FormatStringer
      getvalue()
      reset()        // could go away
      write_const()
      format_r()
      format_s()
      format_d()
      ...