### PR TITLE
[cpp] some umask fixes

### DIFF
--- a/cpp/leaky_stdlib.cc
+++ b/cpp/leaky_stdlib.cc
@@ -41,8 +41,7 @@ int fcntl(int fd, int cmd, int arg) {
 
 namespace posix {
 
-int umask(int mask) {
-  // note: assuming mode_t fits in an int
+mode_t umask(mode_t mask) {
   return ::umask(mask);
 }
 

--- a/cpp/leaky_stdlib.h
+++ b/cpp/leaky_stdlib.h
@@ -4,6 +4,7 @@
 #define LEAKY_STDLIB_H
 
 #include <errno.h>
+#include <sys/types.h>  // mode_t
 #include <unistd.h>
 
 #include "mycpp/runtime.h"
@@ -18,7 +19,7 @@ int fcntl(int fd, int cmd, int arg);
 
 namespace posix {
 
-int umask(int mask);
+mode_t umask(mode_t mask);
 
 inline int access(Str* pathname, int mode) {
   return ::access(pathname->data_, mode) == 0;

--- a/mycpp/leaky_mylib.cc
+++ b/mycpp/leaky_mylib.cc
@@ -242,7 +242,9 @@ void FormatStringer::format_s(Str* s) {
 }
 
 void FormatStringer::format_o(int i) {
-  NotImplemented();
+  data_ = static_cast<char*>(realloc(data_, len_ + kIntBufSize));
+  int len = snprintf(data_ + len_, kIntBufSize, "%o", i);
+  len_ += len;
 }
 
 void FormatStringer::format_d(int i) {

--- a/osh/builtin_process2.py
+++ b/osh/builtin_process2.py
@@ -215,8 +215,11 @@ class Umask(vm._Builtin):
         # NOTE: This happens if we have '8' or '9' in the input too.
         stderr_line("osh warning: umask with symbolic input isn't implemented")
         return 1
-      else:
-        posix.umask(new_mask)
-        return 0
+      except TypeError:
+        # Should be unreachable
+        raise AssertionError()
+
+      posix.umask(new_mask)
+      return 0
 
     e_usage('umask: unexpected arguments')


### PR DESCRIPTION
These should fix two failures found by `./test/spec-cpp.sh run-with-osh-eval builtins` (`get umask` and `set umask in octal`)

@andychu any reason we had `int umask(int)` instead of `mode_t umask(mode_t)`? The commit that tweaks that isn't essential, but I figured it was worth updating while I was in that region