### PR TITLE
[cpp] remove some calls to malloc()

### DIFF
--- a/cpp/leaky_core.cc
+++ b/cpp/leaky_core.cc
@@ -235,8 +235,8 @@ Str* ShowAppVersion(Str* app_name, _ResourceLoader* loader) {
 
 Str* BackslashEscape(Str* s, Str* meta_chars) {
   int upper_bound = len(s) * 2;
-  char* buf = static_cast<char*>(malloc(upper_bound));
-  char* p = buf;
+  Str* buf = AllocStr(upper_bound);
+  char* p = buf->data_;
 
   for (int i = 0; i < len(s); ++i) {
     char c = s->data_[i];
@@ -245,8 +245,8 @@ Str* BackslashEscape(Str* s, Str* meta_chars) {
     }
     *p++ = c;
   }
-  int len = p - buf;
-  return StrFromC(buf, len);
+  int len = p - buf->data_;
+  return StrFromC(buf->data_, len);
 }
 
 // Hack so e->errno will work below

--- a/cpp/leaky_core.cc
+++ b/cpp/leaky_core.cc
@@ -71,20 +71,13 @@ Dict<Str*, Str*>* Environ() {
     char* eq = strchr(pair, '=');
     assert(eq != nullptr);  // must look like KEY=value
 
-    int key_len = eq - pair;
-    char* buf = static_cast<char*>(malloc(key_len + 1));
-    memcpy(buf, pair, key_len);  // includes NUL terminator
-    buf[key_len] = '\0';
-
-    Str* key = StrFromC(buf, key_len);
-
     int len = strlen(pair);
-    int val_len = len - key_len - 1;
-    char* buf2 = static_cast<char*>(malloc(val_len + 1));
-    memcpy(buf2, eq + 1, val_len);  // copy starting after =
-    buf2[val_len] = '\0';
 
-    Str* val = StrFromC(buf2, val_len);
+    int key_len = eq - pair;
+    Str* key = StrFromC(pair, key_len);
+
+    int val_len = len - key_len - 1;
+    Str* val = StrFromC(eq + 1, val_len);
 
     d->set(key, val);
   }

--- a/cpp/leaky_libc.cc
+++ b/cpp/leaky_libc.cc
@@ -86,19 +86,17 @@ List<Str*>* regex_match(Str* pattern, Str* str) {
   int outlen = pat.re_nsub + 1;  // number of captures
 
   const char* s0 = str->data_;
-  regmatch_t* pmatch =
-      static_cast<regmatch_t*>(malloc(sizeof(regmatch_t) * outlen));
-  int match = regexec(&pat, s0, outlen, pmatch, 0) == 0;
+  Slab<regmatch_t>* pmatch = NewSlab<regmatch_t>(outlen);
+  int match = regexec(&pat, s0, outlen, pmatch->items_, 0) == 0;
   if (match) {
     int i;
     for (i = 0; i < outlen; i++) {
-      int len = pmatch[i].rm_eo - pmatch[i].rm_so;
-      Str* m = StrFromC(s0 + pmatch[i].rm_so, len);
+      int len = pmatch->items_[i].rm_eo - pmatch->items_[i].rm_so;
+      Str* m = StrFromC(s0 + pmatch->items_[i].rm_so, len);
       results->append(m);
     }
   }
 
-  free(pmatch);
   regfree(&pat);
 
   if (!match) {


### PR DESCRIPTION
Passes the following relevant-sounding tests according to grep:
- `spec/builtin-printf`
- `spec/regex`
- `cpp/leaky-core-test`