### PR TITLE
[core] move trap-related state into SignalState

### DIFF
--- a/core/shell.py
+++ b/core/shell.py
@@ -314,12 +314,6 @@ def Main(lang, arg_r, environ, login_shell, loader, line_input):
   cmd_deps = cmd_eval.Deps()
   cmd_deps.mutable_opts = mutable_opts
 
-  # TODO: In general, cmd_deps are shared between the mutually recursive
-  # evaluators.  Some of the four below are only shared between a builtin and
-  # the CommandEvaluator, so we could put them somewhere else.
-  cmd_deps.traps = {}
-  cmd_deps.trap_nodes = []  # TODO: Clear on fork() to avoid duplicates
-
   job_state = process.JobState()
   fd_state = process.FdState(errfmt, job_state, mem, None, None)
 
@@ -429,7 +423,7 @@ def Main(lang, arg_r, environ, login_shell, loader, line_input):
 
   assign_b = shell_native.InitAssignmentBuiltins(mem, procs, errfmt)
   cmd_ev = cmd_eval.CommandEvaluator(mem, exec_opts, errfmt, procs,
-                                     assign_b, arena, cmd_deps)
+                                     assign_b, arena, cmd_deps, sig_state)
 
   AddOil(builtins, mem, search_path, cmd_ev, errfmt, procs, arena)
 
@@ -486,9 +480,7 @@ def Main(lang, arg_r, environ, login_shell, loader, line_input):
   builtins[builtin_i.compopt] = builtin_comp.CompOpt(compopt_state, errfmt)
   builtins[builtin_i.compadjust] = builtin_comp.CompAdjust(mem)
 
-  builtins[builtin_i.trap] = builtin_trap.Trap(sig_state, cmd_deps.traps,
-                                               cmd_deps.trap_nodes,
-                                               parse_ctx, tracer, errfmt)
+  builtins[builtin_i.trap] = builtin_trap.Trap(sig_state, parse_ctx, tracer, errfmt)
 
   # History evaluation is a no-op if line_input is None.
   hist_ev = history.Evaluator(line_input, hist_ctx, debug_f)

--- a/core/shell_native.py
+++ b/core/shell_native.py
@@ -322,12 +322,6 @@ def Main(lang, arg_r, environ, login_shell, loader, line_input):
   cmd_deps = cmd_eval.Deps()
   cmd_deps.mutable_opts = mutable_opts
 
-  # TODO: In general, cmd_deps are shared between the mutually recursive
-  # evaluators.  Some of the four below are only shared between a builtin and
-  # the CommandEvaluator, so we could put them somewhere else.
-  cmd_deps.traps = {}
-  cmd_deps.trap_nodes = []  # TODO: Clear on fork() to avoid duplicates
-
   my_pid = posix.getpid()
 
   debug_path = ''
@@ -422,7 +416,7 @@ def Main(lang, arg_r, environ, login_shell, loader, line_input):
 
   assign_b = InitAssignmentBuiltins(mem, procs, errfmt)
   cmd_ev = cmd_eval.CommandEvaluator(mem, exec_opts, errfmt, procs,
-                                     assign_b, arena, cmd_deps)
+                                     assign_b, arena, cmd_deps, sig_state)
 
 
   # PromptEvaluator rendering is needed in non-interactive shells for @P.
@@ -461,9 +455,7 @@ def Main(lang, arg_r, environ, login_shell, loader, line_input):
           errfmt)
   AddBlock(builtins, mem, mutable_opts, dir_stack, cmd_ev, shell_ex, hay_tree, errfmt)
 
-  builtins[builtin_i.trap] = builtin_trap.Trap(
-      sig_state, cmd_deps.traps, cmd_deps.trap_nodes, parse_ctx, tracer,
-      errfmt)
+  builtins[builtin_i.trap] = builtin_trap.Trap(sig_state, parse_ctx, tracer, errfmt)
 
   if flag.c is not None:
     arena.PushSource(source.CFlag())

--- a/core/test_lib.py
+++ b/core/test_lib.py
@@ -207,7 +207,6 @@ def InitCommandEvaluator(parse_ctx=None, comp_lookup=None, arena=None, mem=None,
   debug_f = util.DebugFile(sys.stderr)
   cmd_deps = cmd_eval.Deps()
   cmd_deps.mutable_opts = mutable_opts
-  cmd_deps.trap_nodes = []
 
   search_path = state.SearchPath(mem)
 
@@ -224,10 +223,10 @@ def InitCommandEvaluator(parse_ctx=None, comp_lookup=None, arena=None, mem=None,
   expr_ev = expr_eval.OilEvaluator(mem, mutable_opts, procs, splitter, errfmt)
   word_ev = word_eval.NormalWordEvaluator(mem, exec_opts, mutable_opts,
                                           splitter, errfmt)
-  cmd_ev = cmd_eval.CommandEvaluator(mem, exec_opts, errfmt, procs,
-                                     assign_builtins, arena, cmd_deps)
-
   sig_state = pyos.SignalState()
+  cmd_ev = cmd_eval.CommandEvaluator(mem, exec_opts, errfmt, procs,
+                                     assign_builtins, arena, cmd_deps, sig_state)
+
   tracer = dev.Tracer(parse_ctx, exec_opts, mutable_opts, mem, debug_f)
   waiter = process.Waiter(job_state, exec_opts, sig_state, tracer)
 

--- a/cpp/leaky_core.h
+++ b/cpp/leaky_core.h
@@ -7,6 +7,7 @@
 #include <termios.h>
 
 #include "mycpp/myerror.h"
+#include "_gen/frontend/syntax.asdl.h"
 #include "mycpp/runtime.h"
 
 // Hacky forward declaration
@@ -55,7 +56,9 @@ class TermState {
 
 class SignalState {
  public:
-  SignalState() {
+  SignalState()
+      : traps(NewDict<Str*, builtin_trap::_TrapHandler*>()),
+        nodes_to_run(NewList<syntax_asdl::command_t*>()) {
   }
   void InitShell() {
   }
@@ -65,7 +68,12 @@ class SignalState {
   void RemoveUserTrap(int sig_num) {
     NotImplemented();
   }
+  List<syntax_asdl::command_t*>* TakeRunList() {
+    return NewList<syntax_asdl::command_t*>();
+  }
   int last_sig_num = 0;
+  Dict<Str*, builtin_trap::_TrapHandler*>* traps;
+  List<syntax_asdl::command_t*>* nodes_to_run;
 
   DISALLOW_COPY_AND_ASSIGN(SignalState)
 };


### PR DESCRIPTION
This is the first commit in a series that will refactor the signal and trap handling code to make it safely shareable between ptyhon and C++.

The first step in this process is to remove the illusion that the various users of the trap-related state each own it. We can make it more obvious that they're really borrowing global state by renaming the member(s) they all use to access it.