### PR TITLE
[core] make post-fork signal setup translatable

### DIFF
--- a/core/pyos.py
+++ b/core/pyos.py
@@ -286,31 +286,10 @@ class SigwinchHandler(object):
       self.user_handler(sig_num, unused_frame)
 
 
-def SignalState_AfterForkingChild():
-  # type: () -> None
-  """Not a member of SignalState since we didn't do dependency injection."""
-
-  # Note: this happens in BOTH interactive and non-interactive shells.
-  # We technically don't need to do most of it in non-interactive, since we
-  # did not change state in InitInteractiveShell().
-
-  # Python sets SIGPIPE handler to SIG_IGN by default.  Child processes
-  # shouldn't have this.
-  # https://docs.python.org/2/library/signal.html
-  # See Python/pythonrun.c.
-  signal.signal(signal.SIGPIPE, signal.SIG_DFL)
-
-  # Respond to Ctrl-\ (core dump)
-  signal.signal(signal.SIGQUIT, signal.SIG_DFL)
-
-  # Child processes should get Ctrl-Z.
-  signal.signal(signal.SIGTSTP, signal.SIG_DFL)
-
-  # More signals from
-  # https://www.gnu.org/software/libc/manual/html_node/Launching-Jobs.html
-  # (but not SIGCHLD)
-  signal.signal(signal.SIGTTOU, signal.SIG_DFL)
-  signal.signal(signal.SIGTTIN, signal.SIG_DFL)
+def Sigaction(sig_num, handler):
+  # type: (int, Any) -> None
+  """Register a signal handler"""
+  signal.signal(sig_num, handler)
 
 
 class SignalState(object):

--- a/cpp/leaky_core.cc
+++ b/cpp/leaky_core.cc
@@ -181,10 +181,10 @@ bool InputAvailable(int fd) {
   NotImplemented();
 }
 
-void SignalState_AfterForkingChild() {
-  signal(SIGQUIT, SIG_DFL);
-  signal(SIGPIPE, SIG_DFL);
-  signal(SIGTSTP, SIG_DFL);
+void Sigaction(int sig_num, sighandler_t handler) {
+  struct sigaction act = {};
+  act.sa_handler = handler;
+  assert(sigaction(sig_num, &act, nullptr) == 0);
 }
 
 }  // namespace pyos

--- a/cpp/leaky_core.h
+++ b/cpp/leaky_core.h
@@ -3,6 +3,7 @@
 #ifndef LEAKY_CORE_H
 #define LEAKY_CORE_H
 
+#include <signal.h>  // sighandler_t
 #include <termios.h>
 
 #include "mycpp/runtime.h"
@@ -51,8 +52,6 @@ class TermState {
   }
 };
 
-void SignalState_AfterForkingChild();
-
 class SignalState {
  public:
   SignalState() {
@@ -69,6 +68,8 @@ class SignalState {
 
   DISALLOW_COPY_AND_ASSIGN(SignalState)
 };
+
+void Sigaction(int sig_num, sighandler_t handler);
 
 }  // namespace pyos
 


### PR DESCRIPTION
This commit adds a wrapper around `signal.signal()` called `Sigaction()` and adds a C++ implementation for basic signal dispositions like SIG_DFL and SIG_IGN. We can use this to share some post-fork signal setup between python and C++.

A future commit will also use this to make some other signal-related code translatable.