### PR TITLE
[core,osh] make SignalState translatable

### DIFF
--- a/core/process.py
+++ b/core/process.py
@@ -1428,11 +1428,11 @@ class Waiter(object):
   Now when you do wait() after starting the pipeline, you might get a pipeline
   process OR a background process!  So you have to distinguish between them.
   """
-  def __init__(self, job_state, exec_opts, sig_state, tracer):
-    # type: (JobState, optview.Exec, builtin_trap.SignalState, dev.Tracer) -> None
+  def __init__(self, job_state, exec_opts, trap_state, tracer):
+    # type: (JobState, optview.Exec, builtin_trap.TrapState, dev.Tracer) -> None
     self.job_state = job_state
     self.exec_opts = exec_opts
-    self.sig_state = sig_state
+    self.trap_state = trap_state
     self.tracer = tracer
     self.last_status = 127  # wait -n error code
 
@@ -1476,8 +1476,8 @@ class Waiter(object):
       if err_num == ECHILD:
         return W1_ECHILD  # nothing to wait for caller should stop
       elif err_num == EINTR:  # Bug #858 fix
-        #log('WaitForOne() => %d', self.sig_state.GetLastSignal())
-        return self.sig_state.GetLastSignal()  # e.g. 1 for SIGHUP
+        #log('WaitForOne() => %d', self.trap_state.GetLastSignal())
+        return self.trap_state.GetLastSignal()  # e.g. 1 for SIGHUP
       else:
         # The signature of waitpid() means this shouldn't happen
         raise AssertionError()

--- a/core/process.py
+++ b/core/process.py
@@ -57,6 +57,7 @@ if TYPE_CHECKING:
   from core.ui import ErrorFormatter
   from core.util import _DebugFile
   from osh.cmd_eval import CommandEvaluator
+  from osh import builtin_trap
 
 
 NO_FD = -1
@@ -1428,7 +1429,7 @@ class Waiter(object):
   process OR a background process!  So you have to distinguish between them.
   """
   def __init__(self, job_state, exec_opts, sig_state, tracer):
-    # type: (JobState, optview.Exec, pyos.SignalState, dev.Tracer) -> None
+    # type: (JobState, optview.Exec, builtin_trap.SignalState, dev.Tracer) -> None
     self.job_state = job_state
     self.exec_opts = exec_opts
     self.sig_state = sig_state

--- a/core/process_test.py
+++ b/core/process_test.py
@@ -49,9 +49,9 @@ class ProcessTest(unittest.TestCase):
     state.InitMem(mem, {}, '0.1')
 
     self.job_state = process.JobState()
-    sig_state = builtin_trap.SignalState()
+    trap_state = builtin_trap.TrapState()
     self.tracer = dev.Tracer(None, exec_opts, mutable_opts, mem, mylib.Stderr())
-    self.waiter = process.Waiter(self.job_state, exec_opts, sig_state, self.tracer)
+    self.waiter = process.Waiter(self.job_state, exec_opts, trap_state, self.tracer)
     errfmt = ui.ErrorFormatter(self.arena)
     self.fd_state = process.FdState(errfmt, self.job_state, None, self.tracer, None)
     self.ext_prog = process.ExternalProgram('', self.fd_state, errfmt,

--- a/core/process_test.py
+++ b/core/process_test.py
@@ -20,7 +20,7 @@ from core import ui
 from core import util
 from core.pyerror import log
 from core import state
-from osh import builtin_misc
+from osh import builtin_misc, builtin_trap
 from mycpp import mylib
 
 Process = process.Process
@@ -49,7 +49,7 @@ class ProcessTest(unittest.TestCase):
     state.InitMem(mem, {}, '0.1')
 
     self.job_state = process.JobState()
-    sig_state = pyos.SignalState()
+    sig_state = builtin_trap.SignalState()
     self.tracer = dev.Tracer(None, exec_opts, mutable_opts, mem, mylib.Stderr())
     self.waiter = process.Waiter(self.job_state, exec_opts, sig_state, self.tracer)
     errfmt = ui.ErrorFormatter(self.arena)

--- a/core/pyos.py
+++ b/core/pyos.py
@@ -266,26 +266,56 @@ def InputAvailable(fd):
 
 UNTRAPPED_SIGWINCH = -1
 
-class SigwinchHandler(object):
-  """Wrapper to call user handler."""
 
-  def __init__(self, display, sig_state):
-    # type: (_IDisplay, SignalState) -> None
-    self.display = display
-    self.sig_state = sig_state
-    self.user_handler = None  # type: _TrapHandler
+class _SignalHandler(object):
+  """
+  A singleton that implements a basic generic signal handler that enqueues
+  signals for asynchrnous processing as they are fired.
+  """
+  _instance = None
+
+  signal_queue = []  # type: List[int]
+  last_sig_num = 0  # type: int
+  sigwinch_num = UNTRAPPED_SIGWINCH
+
+  def __new__(cls):
+    # type: () -> None
+    if cls._instance is None:
+        cls._instance = super(_SignalHandler, cls).__new__(cls)
+
+    return cls._instance
 
   def __call__(self, sig_num, unused_frame):
     # type: (int, Any) -> None
-    """For Python's signal module."""
+    if sig_num == signal.SIGWINCH:
+      self.last_sig_num = self.sigwinch_num
+    else:
+      self.last_sig_num = sig_num
 
-    # SENTINEL for UNTRAPPED SIGWINCH.  If it's trapped, self.user_handler
-    # will overwrite it with signal.SIGWINCH.
-    self.sig_state.last_sig_num = UNTRAPPED_SIGWINCH
+    self.signal_queue.append(sig_num)
 
-    self.display.OnWindowChange()
-    if self.user_handler:
-      self.user_handler(sig_num, unused_frame)
+  def TakeSignalQueue(self):
+    # type: () -> List[int]
+    # A note on signal-safety here. The main loop might be calling this function
+    # at the same time a signal is firing and appending to
+    # `self.signal_queue`. We can forgoe using a lock here
+    # (which would be problematic for the signal handler) because mutual
+    # exclusivity should be maintained by the atomic nature of pointer
+    # assignment (i.e. word-sized writes) on most modern platforms.
+    # The replacement run list is allocated before the swap, so it can be
+    # interuppted at any point without consequence.
+    # This means the signal handler always has exclusive access to
+    # `self.signal_queue`. In the worst case the signal handler might write to
+    # `new_queue` and the corresponding trap handler won't get executed
+    # until the main loop calls this function again.
+    # NOTE: It's important to distinguish between signal-saftey an
+    # thread-saftey here. Signals run in the same process context as the main
+    # loop, while concurrent threads do not and would have to worry about
+    # cache-coherence and instruction reordering.
+    new_queue = []  #  type: List[int]
+    ret = self.signal_queue
+    self.signal_queue = new_queue
+    return ret
 
 
 def Sigaction(sig_num, handler):
@@ -299,10 +329,9 @@ class SignalState(object):
 
   def __init__(self):
     # type: () -> None
-    self.sigwinch_handler = None  # type: SigwinchHandler
-    self.last_sig_num = 0  # MUTABLE GLOBAL, for interrupted 'wait'
+    self.display = None  # type: _IDisplay
     # signal/hook name -> handler
-    self.traps = {}  # type: Dict[int, _TrapHandler]
+    self.traps = {}  # type: Dict[int, command_t]
     # appended to by signal handlers
     self.nodes_to_run = []  # type: List[command_t]
 
@@ -331,8 +360,9 @@ class SignalState(object):
 
     # This is ALWAYS on, which means that it can cause EINTR, and wait() and
     # read() have to handle it
-    self.sigwinch_handler = SigwinchHandler(display, self)
-    signal.signal(signal.SIGWINCH, self.sigwinch_handler)
+    self.display = display
+    signal.signal(signal.SIGWINCH, _SignalHandler())
+    _SignalHandler().sigwinch_num = UNTRAPPED_SIGWINCH
 
     # This doesn't make any tests pass, and we might punt on job control
     if 0:
@@ -349,17 +379,17 @@ class SignalState(object):
   def GetLastSignal(self):
     # type: () -> int
     """Return the last signal that fired"""
-    return self.last_sig_num
+    return _SignalHandler().last_sig_num
 
   def AddUserTrap(self, sig_num, handler):
-    # type: (int, Any) -> None
+    # type: (int, command_t) -> None
     """For user-defined handlers registered with the 'trap' builtin."""
 
     if sig_num == signal.SIGWINCH:
-      assert self.sigwinch_handler is not None
-      self.sigwinch_handler.user_handler = handler
+      assert self.display is not None
+      _SignalHandler().sigwinch_num = signal.SIGWINCH
     else:
-      signal.signal(sig_num, handler)
+      signal.signal(sig_num, _SignalHandler())
     self.traps[sig_num] = handler
     # TODO: SIGINT is similar: set a flag, then optionally call user _TrapHandler
 
@@ -370,8 +400,7 @@ class SignalState(object):
     mylib.dict_remove(self.traps, sig_num)
 
     if sig_num == signal.SIGWINCH:
-      assert self.sigwinch_handler is not None
-      self.sigwinch_handler.user_handler = None
+      _SignalHandler().sigwinch_num = UNTRAPPED_SIGWINCH
     else:
       signal.signal(sig_num, signal.SIG_DFL)
     # TODO: SIGINT is similar: set a flag, then optionally call user _TrapHandler
@@ -379,23 +408,18 @@ class SignalState(object):
   def TakeRunList(self):
       # type: () -> List[command_t]
       """Transfer ownership of the current queue of pending trap handlers to the caller."""
-      # A note on signal-safety here. The main loop might be calling this function
-      # at the same time a signal is firing and appending to
-      # `self.nodes_to_run`. We can forgoe using a lock here
-      # (which would be problematic for the signal handler) because mutual
-      # exclusivity should be maintained by the atomic nature of pointer
-      # assignment (i.e. word-sized writes) on most modern platforms.
-      # The replacement run list is allocated before the swap, so it can be
-      # interuppted at any point without consequence.
-      # This means the signal handler always has exclusive access to
-      # `self.nodes_to_run`. In the worst case the signal handler might write to
-      # `new_run_list` and the corresponding trap handler won't get executed
-      # until the main loop calls this function again.
-      # NOTE: It's important to distinguish between signal-saftey an
-      # thread-saftey here. Signals run in the same process context as the main
-      # loop, while concurrent threads do not and would have to worry about
-      # cache-coherence and instruction reordering.
-      new_run_list = []  # type: List[command_t]
-      ret = self.nodes_to_run
-      self.nodes_to_run = new_run_list
-      return ret
+      sig_queue = _SignalHandler().TakeSignalQueue()
+
+      run_list = []  # type: List[command_t]
+      for sig_num in sig_queue:
+        node = self.traps.get(sig_num, None)
+
+        if sig_num == signal.SIGWINCH:
+          self.display.OnWindowChange()
+          if node is None:
+            continue
+
+        assert node is not None
+        run_list.append(node)
+
+      return run_list

--- a/core/pyos.py
+++ b/core/pyos.py
@@ -302,7 +302,6 @@ class SignalState(object):
     self.sigwinch_handler = None  # type: SigwinchHandler
     self.last_sig_num = 0  # MUTABLE GLOBAL, for interrupted 'wait'
     # signal/hook name -> handler
-    self.hooks = {}  # type: Dict[str, _TrapHandler]
     self.traps = {}  # type: Dict[int, _TrapHandler]
     # appended to by signal handlers
     self.nodes_to_run = []  # type: List[command_t]

--- a/core/pyos.py
+++ b/core/pyos.py
@@ -318,12 +318,11 @@ def Sigaction(sig_num, handler):
 def RegisterSignalInterest(sig_num):
   # type: (int) -> None
   """Have the kernel notify the main loop about the given signal"""
-  global gSignalHandler
   assert gSignalHandler is not None
   signal.signal(sig_num, gSignalHandler)
 
 
-def GetPendingSignals():
+def TakeSignalQueue():
   # type: () -> List[int]
   """Transfer ownership of the current queue of pending signals to the caller."""
   global gSignalHandler
@@ -334,7 +333,6 @@ def GetPendingSignals():
 def LastSignal():
   # type: () -> int
   """Returns the number of the last signal that fired"""
-  global gSignalHandler
   assert gSignalHandler is not None
   return gSignalHandler.last_sig_num
 

--- a/core/pyos.py
+++ b/core/pyos.py
@@ -15,16 +15,12 @@ import time
 
 from core import pyutil
 from core.pyerror import log
-from mycpp import mylib
 
 import posix_ as posix
 from posix_ import WUNTRACED
 
-from typing import Optional, Tuple, List, Dict, cast, Any, TYPE_CHECKING
+from typing import Optional, Tuple, List, Dict, cast, Any
 
-if TYPE_CHECKING:
-  from _devbuild.gen.syntax_asdl import command_t
-  from core.comp_ui import _IDisplay
 
 _ = log
 
@@ -271,14 +267,14 @@ class _SignalHandler(object):
   A singleton that implements a basic generic signal handler that enqueues
   signals for asynchrnous processing as they are fired.
   """
-  _instance = None
+  _instance = None  # type: _SignalHandler
 
   signal_queue = []  # type: List[int]
   last_sig_num = 0  # type: int
   sigwinch_num = UNTRAPPED_SIGWINCH
 
   def __new__(cls):
-    # type: () -> None
+    # type: () -> _SignalHandler
     if cls._instance is None:
         cls._instance = super(_SignalHandler, cls).__new__(cls)
 
@@ -323,102 +319,33 @@ def Sigaction(sig_num, handler):
   signal.signal(sig_num, handler)
 
 
-class SignalState(object):
-  """All changes to global signal state go through this object."""
+def RegisterSignalInterest(sig_num):
+  # type: (int) -> None
+  """Have the kernel notify the main loop about the given signal"""
+  signal.signal(sig_num, _SignalHandler())
 
-  def __init__(self):
-    # type: () -> None
-    self.display = None  # type: _IDisplay
-    # signal/hook name -> handler
-    self.traps = {}  # type: Dict[int, command_t]
-    # appended to by signal handlers
-    self.nodes_to_run = []  # type: List[command_t]
 
-  def InitShell(self):
-    # type: () -> None
-    """Always called when initializing the shell process."""
-    pass
+def GetPendingSignals():
+  # type: () -> List[int]
+  """Transfer ownership of the current queue of pending signals to the caller."""
+  return _SignalHandler().TakeSignalQueue()
 
-  def InitInteractiveShell(self, display, my_pid):
-    # type: (_IDisplay, int) -> None
-    """Called when initializing an interactive shell."""
-    # The shell itself should ignore Ctrl-\.
-    signal.signal(signal.SIGQUIT, signal.SIG_IGN)
 
-    # This prevents Ctrl-Z from suspending OSH in interactive mode.
-    signal.signal(signal.SIGTSTP, signal.SIG_IGN)
+def LastSignal():
+  # type: () -> int
+  """Returns the number of the last signal that fired"""
+  return _SignalHandler().last_sig_num
 
-    # More signals from
-    # https://www.gnu.org/software/libc/manual/html_node/Initializing-the-Shell.html
-    # (but not SIGCHLD)
-    signal.signal(signal.SIGTTOU, signal.SIG_IGN)
-    signal.signal(signal.SIGTTIN, signal.SIG_IGN)
 
-    # Register a callback to receive terminal width changes.
-    # NOTE: In line_input.c, we turned off rl_catch_sigwinch.
+def SetSigwinchCode(code):
+  # type: (int) -> None
+  """
+  Depending on whether or not SIGWINCH is trapped by a user, it is expected to
+  report a different code to `wait`. SetSigwinchCode() lets us set which code is
+  reported.
+  """
+  _SignalHandler().sigwinch_num = code
 
-    # This is ALWAYS on, which means that it can cause EINTR, and wait() and
-    # read() have to handle it
-    self.display = display
-    signal.signal(signal.SIGWINCH, _SignalHandler())
-    _SignalHandler().sigwinch_num = UNTRAPPED_SIGWINCH
-
-    # This doesn't make any tests pass, and we might punt on job control
-    if 0:
-      try:
-        # Put the interactive shell in its own process group, named by its PID
-        posix.setpgid(my_pid, my_pid)
-        # Attach the terminal (stdin) to the progress group
-        posix.tcsetpgrp(0, my_pid)
-
-      except (IOError, OSError) as e:
-        # For some reason setpgid() fails with Operation Not Permitted (EPERM) under pexpect?
-        pass
-
-  def GetLastSignal(self):
-    # type: () -> int
-    """Return the last signal that fired"""
-    return _SignalHandler().last_sig_num
-
-  def AddUserTrap(self, sig_num, handler):
-    # type: (int, command_t) -> None
-    """For user-defined handlers registered with the 'trap' builtin."""
-
-    if sig_num == signal.SIGWINCH:
-      assert self.display is not None
-      _SignalHandler().sigwinch_num = signal.SIGWINCH
-    else:
-      signal.signal(sig_num, _SignalHandler())
-    self.traps[sig_num] = handler
-    # TODO: SIGINT is similar: set a flag, then optionally call user _TrapHandler
-
-  def RemoveUserTrap(self, sig_num):
-    # type: (int) -> None
-    """For user-defined handlers registered with the 'trap' builtin."""
-    # Restore default
-    mylib.dict_remove(self.traps, sig_num)
-
-    if sig_num == signal.SIGWINCH:
-      _SignalHandler().sigwinch_num = UNTRAPPED_SIGWINCH
-    else:
-      signal.signal(sig_num, signal.SIG_DFL)
-    # TODO: SIGINT is similar: set a flag, then optionally call user _TrapHandler
-
-  def TakeRunList(self):
-      # type: () -> List[command_t]
-      """Transfer ownership of the current queue of pending trap handlers to the caller."""
-      sig_queue = _SignalHandler().TakeSignalQueue()
-
-      run_list = []  # type: List[command_t]
-      for sig_num in sig_queue:
-        node = self.traps.get(sig_num, None)
-
-        if sig_num == signal.SIGWINCH:
-          self.display.OnWindowChange()
-          if node is None:
-            continue
-
-        assert node is not None
-        run_list.append(node)
-
-      return run_list
+def InitShell():
+  # type: () -> None
+  pass

--- a/core/pyos.py
+++ b/core/pyos.py
@@ -25,7 +25,6 @@ from typing import Optional, Tuple, List, Dict, cast, Any, TYPE_CHECKING
 if TYPE_CHECKING:
   from _devbuild.gen.syntax_asdl import command_t
   from core.comp_ui import _IDisplay
-  from osh.builtin_trap import _TrapHandler
 
 _ = log
 

--- a/core/shell.py
+++ b/core/shell.py
@@ -347,7 +347,7 @@ def Main(lang, arg_r, environ, login_shell, loader, line_input):
   fd_state.tracer = tracer  # circular dep
 
   hook_state = builtin_trap.HookState()
-  sig_state = pyos.SignalState()
+  sig_state = builtin_trap.SignalState()
   sig_state.InitShell()
   waiter = process.Waiter(job_state, exec_opts, sig_state, tracer)
   fd_state.waiter = waiter

--- a/core/shell.py
+++ b/core/shell.py
@@ -346,10 +346,9 @@ def Main(lang, arg_r, environ, login_shell, loader, line_input):
   tracer = dev.Tracer(parse_ctx, exec_opts, mutable_opts, mem, trace_f)
   fd_state.tracer = tracer  # circular dep
 
-  hook_state = builtin_trap.HookState()
-  sig_state = builtin_trap.SignalState()
-  sig_state.InitShell()
-  waiter = process.Waiter(job_state, exec_opts, sig_state, tracer)
+  trap_state = builtin_trap.TrapState()
+  trap_state.InitShell()
+  waiter = process.Waiter(job_state, exec_opts, trap_state, tracer)
   fd_state.waiter = waiter
 
   cmd_deps.debug_f = debug_f
@@ -424,7 +423,7 @@ def Main(lang, arg_r, environ, login_shell, loader, line_input):
 
   assign_b = shell_native.InitAssignmentBuiltins(mem, procs, errfmt)
   cmd_ev = cmd_eval.CommandEvaluator(mem, exec_opts, errfmt, procs,
-                                     assign_b, arena, cmd_deps, sig_state, hook_state)
+                                     assign_b, arena, cmd_deps, trap_state)
 
   AddOil(builtins, mem, search_path, cmd_ev, errfmt, procs, arena)
 
@@ -481,7 +480,7 @@ def Main(lang, arg_r, environ, login_shell, loader, line_input):
   builtins[builtin_i.compopt] = builtin_comp.CompOpt(compopt_state, errfmt)
   builtins[builtin_i.compadjust] = builtin_comp.CompAdjust(mem)
 
-  builtins[builtin_i.trap] = builtin_trap.Trap(sig_state, hook_state, parse_ctx, tracer, errfmt)
+  builtins[builtin_i.trap] = builtin_trap.Trap(trap_state, parse_ctx, tracer, errfmt)
 
   # History evaluation is a no-op if line_input is None.
   hist_ev = history.Evaluator(line_input, hist_ctx, debug_f)
@@ -617,7 +616,7 @@ def Main(lang, arg_r, environ, login_shell, loader, line_input):
     else:  # Without readline module
       display = comp_ui.MinimalDisplay(comp_ui_state, prompt_state, debug_f)
 
-    sig_state.InitInteractiveShell(display, my_pid)
+    trap_state.InitInteractiveShell(display, my_pid)
 
     # NOTE: called AFTER _InitDefaultCompletions.
     with state.ctx_ThisDir(mem, rc_path):

--- a/core/shell_native.py
+++ b/core/shell_native.py
@@ -354,14 +354,12 @@ def Main(lang, arg_r, environ, login_shell, loader, line_input):
     trace_f = util.DebugFile(mylib.Stderr())
   tracer = dev.Tracer(parse_ctx, exec_opts, mutable_opts, mem, trace_f)
 
-  hook_state = builtin_trap.HookState()
-  # TODO: We shouldn't have SignalState?
-  sig_state = builtin_trap.SignalState()
-  sig_state.InitShell()
+  trap_state = builtin_trap.TrapState()
+  trap_state.InitShell()
 
   job_state = process.JobState()
   fd_state = process.FdState(errfmt, job_state, mem, tracer, None)
-  waiter = process.Waiter(job_state, exec_opts, sig_state, tracer)
+  waiter = process.Waiter(job_state, exec_opts, trap_state, tracer)
   fd_state.waiter = waiter  # circular dep
 
   interp = environ.get('OSH_HIJACK_SHEBANG', '')
@@ -416,7 +414,7 @@ def Main(lang, arg_r, environ, login_shell, loader, line_input):
 
   assign_b = InitAssignmentBuiltins(mem, procs, errfmt)
   cmd_ev = cmd_eval.CommandEvaluator(mem, exec_opts, errfmt, procs,
-                                     assign_b, arena, cmd_deps, sig_state, hook_state)
+                                     assign_b, arena, cmd_deps, trap_state)
 
 
   # PromptEvaluator rendering is needed in non-interactive shells for @P.
@@ -455,7 +453,7 @@ def Main(lang, arg_r, environ, login_shell, loader, line_input):
           errfmt)
   AddBlock(builtins, mem, mutable_opts, dir_stack, cmd_ev, shell_ex, hay_tree, errfmt)
 
-  builtins[builtin_i.trap] = builtin_trap.Trap(sig_state, hook_state, parse_ctx, tracer, errfmt)
+  builtins[builtin_i.trap] = builtin_trap.Trap(trap_state, parse_ctx, tracer, errfmt)
 
   if flag.c is not None:
     arena.PushSource(source.CFlag())

--- a/core/shell_native.py
+++ b/core/shell_native.py
@@ -22,7 +22,6 @@ from core import main_loop
 from core import process
 from core.pyerror import e_usage, log
 unused1 = log
-from core import pyos
 from core import pyutil
 from core.pyutil import stderr_line
 from core import state
@@ -357,7 +356,7 @@ def Main(lang, arg_r, environ, login_shell, loader, line_input):
 
   hook_state = builtin_trap.HookState()
   # TODO: We shouldn't have SignalState?
-  sig_state = pyos.SignalState()
+  sig_state = builtin_trap.SignalState()
   sig_state.InitShell()
 
   job_state = process.JobState()

--- a/core/test_lib.py
+++ b/core/test_lib.py
@@ -224,6 +224,7 @@ def InitCommandEvaluator(parse_ctx=None, comp_lookup=None, arena=None, mem=None,
   word_ev = word_eval.NormalWordEvaluator(mem, exec_opts, mutable_opts,
                                           splitter, errfmt)
   sig_state = builtin_trap.SignalState()
+  sig_state.InitShell()
   hook_state = builtin_trap.HookState()
   cmd_ev = cmd_eval.CommandEvaluator(mem, exec_opts, errfmt, procs,
                                      assign_builtins, arena, cmd_deps, sig_state, hook_state)

--- a/core/test_lib.py
+++ b/core/test_lib.py
@@ -24,7 +24,6 @@ from core import executor
 from core import main_loop
 from core import optview
 from core import process
-from core import pyos
 from core import pyutil
 from core import ui
 from core import util
@@ -224,7 +223,7 @@ def InitCommandEvaluator(parse_ctx=None, comp_lookup=None, arena=None, mem=None,
   expr_ev = expr_eval.OilEvaluator(mem, mutable_opts, procs, splitter, errfmt)
   word_ev = word_eval.NormalWordEvaluator(mem, exec_opts, mutable_opts,
                                           splitter, errfmt)
-  sig_state = pyos.SignalState()
+  sig_state = builtin_trap.SignalState()
   hook_state = builtin_trap.HookState()
   cmd_ev = cmd_eval.CommandEvaluator(mem, exec_opts, errfmt, procs,
                                      assign_builtins, arena, cmd_deps, sig_state, hook_state)

--- a/core/test_lib.py
+++ b/core/test_lib.py
@@ -223,14 +223,14 @@ def InitCommandEvaluator(parse_ctx=None, comp_lookup=None, arena=None, mem=None,
   expr_ev = expr_eval.OilEvaluator(mem, mutable_opts, procs, splitter, errfmt)
   word_ev = word_eval.NormalWordEvaluator(mem, exec_opts, mutable_opts,
                                           splitter, errfmt)
-  sig_state = builtin_trap.SignalState()
-  sig_state.InitShell()
-  hook_state = builtin_trap.HookState()
+  trap_state = builtin_trap.TrapState()
+  trap_state.InitShell()
   cmd_ev = cmd_eval.CommandEvaluator(mem, exec_opts, errfmt, procs,
-                                     assign_builtins, arena, cmd_deps, sig_state, hook_state)
+                                     assign_builtins, arena, cmd_deps,
+                                     trap_state)
 
   tracer = dev.Tracer(parse_ctx, exec_opts, mutable_opts, mem, debug_f)
-  waiter = process.Waiter(job_state, exec_opts, sig_state, tracer)
+  waiter = process.Waiter(job_state, exec_opts, trap_state, tracer)
 
   hay_state = state.Hay()
   shell_ex = executor.ShellExecutor(

--- a/cpp/leaky_core.h
+++ b/cpp/leaky_core.h
@@ -56,6 +56,17 @@ class TermState {
   }
 };
 
+class SignalHandler {
+ public:
+  SignalHandler();
+  void EnqueueSignal(int sig_num);
+  List<int>* TakeSignalQueue();
+
+  List<int>* signal_queue;
+  int last_sig_num;
+  int sigwinch_num;
+};
+
 void Sigaction(int sig_num, sighandler_t handler);
 
 void RegisterSignalInterest(int sig_num);

--- a/cpp/leaky_core.h
+++ b/cpp/leaky_core.h
@@ -10,12 +10,19 @@
 #include "mycpp/myerror.h"
 #include "mycpp/runtime.h"
 
+// Hacky forward declaration
+namespace comp_ui {
+class _IDisplay;
+};
+
 namespace pyos {
 
 const int TERM_ICANON = ICANON;
 const int TERM_ECHO = ECHO;
 const int EOF_SENTINEL = 256;
 const int NEWLINE_CH = 10;
+const int UNTRAPPED_SIGWINCH = -1;
+const int kMaxSignalsInFlight = 1024;
 
 Tuple2<int, int> WaitPid();
 Tuple2<int, int> Read(int fd, int n, List<Str*>* chunks);
@@ -49,33 +56,17 @@ class TermState {
   }
 };
 
-class SignalState {
- public:
-  SignalState()
-      : traps(NewDict<int, syntax_asdl::command_t*>()),
-        nodes_to_run(NewList<syntax_asdl::command_t*>()) {
-  }
-  void InitShell() {
-  }
-  int GetLastSignal() {
-    return -1;
-  }
-  void AddUserTrap(int sig_num, syntax_asdl::command_t* handler) {
-    NotImplemented();
-  }
-  void RemoveUserTrap(int sig_num) {
-    NotImplemented();
-  }
-  List<syntax_asdl::command_t*>* TakeRunList() {
-    return NewList<syntax_asdl::command_t*>();
-  }
-  Dict<int, syntax_asdl::command_t*>* traps;
-  List<syntax_asdl::command_t*>* nodes_to_run;
-
-  DISALLOW_COPY_AND_ASSIGN(SignalState)
-};
-
 void Sigaction(int sig_num, sighandler_t handler);
+
+void RegisterSignalInterest(int sig_num);
+
+List<int>* GetPendingSignals();
+
+int LastSignal();
+
+void SetSigwinchCode(int code);
+
+void InitShell();
 
 }  // namespace pyos
 

--- a/cpp/leaky_core.h
+++ b/cpp/leaky_core.h
@@ -10,11 +10,6 @@
 #include "mycpp/myerror.h"
 #include "mycpp/runtime.h"
 
-// Hacky forward declaration
-namespace builtin_trap {
-class _TrapHandler;
-};
-
 namespace pyos {
 
 const int TERM_ICANON = ICANON;

--- a/cpp/leaky_core.h
+++ b/cpp/leaky_core.h
@@ -57,15 +57,15 @@ class TermState {
 class SignalState {
  public:
   SignalState()
-      : traps(NewDict<int, builtin_trap::_TrapHandler*>()),
+      : traps(NewDict<int, syntax_asdl::command_t*>()),
         nodes_to_run(NewList<syntax_asdl::command_t*>()) {
   }
   void InitShell() {
   }
   int GetLastSignal() {
-    return last_sig_num;
+    return -1;
   }
-  void AddUserTrap(int sig_num, builtin_trap::_TrapHandler* handler) {
+  void AddUserTrap(int sig_num, syntax_asdl::command_t* handler) {
     NotImplemented();
   }
   void RemoveUserTrap(int sig_num) {
@@ -74,8 +74,7 @@ class SignalState {
   List<syntax_asdl::command_t*>* TakeRunList() {
     return NewList<syntax_asdl::command_t*>();
   }
-  int last_sig_num = 0;
-  Dict<int, builtin_trap::_TrapHandler*>* traps;
+  Dict<int, syntax_asdl::command_t*>* traps;
   List<syntax_asdl::command_t*>* nodes_to_run;
 
   DISALLOW_COPY_AND_ASSIGN(SignalState)

--- a/cpp/leaky_core.h
+++ b/cpp/leaky_core.h
@@ -59,19 +59,19 @@ class TermState {
 class SignalHandler {
  public:
   SignalHandler();
-  void EnqueueSignal(int sig_num);
+  void Update(int sig_num);
   List<int>* TakeSignalQueue();
 
-  List<int>* signal_queue;
-  int last_sig_num;
-  int sigwinch_num;
+  List<int>* signal_queue_;
+  int last_sig_num_;
+  int sigwinch_num_;
 };
 
 void Sigaction(int sig_num, sighandler_t handler);
 
 void RegisterSignalInterest(int sig_num);
 
-List<int>* GetPendingSignals();
+List<int>* TakeSignalQueue();
 
 int LastSignal();
 

--- a/osh/builtin_trap.py
+++ b/osh/builtin_trap.py
@@ -127,7 +127,7 @@ class SignalState(object):
   def TakeRunList(self):
       # type: () -> List[command_t]
       """Transfer ownership of the current queue of pending trap handlers to the caller."""
-      sig_queue = pyos.GetPendingSignals()
+      sig_queue = pyos.TakeSignalQueue()
 
       run_list = []  # type: List[command_t]
       for sig_num in sig_queue:

--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -87,7 +87,7 @@ if TYPE_CHECKING:
   from core.vm import _Executor, _AssignBuiltin
   from oil_lang import expr_eval
   from osh import word_eval
-  from osh.builtin_trap import _TrapHandler, HookState
+  from osh.builtin_trap import HookState
 
 # flags for main_loop.Batch, ExecuteAndCatch.  TODO: Should probably in
 # ExecuteAndCatch, along with SetValue() flags.
@@ -1430,7 +1430,7 @@ class CommandEvaluator(object):
   def RunPendingTraps(self):
     # type: () -> None
 
-    # See osh/builtin_trap.py _TrapHandler for the code that populates this
+    # See osh/builtin_trap.py SignalState for the code that populates this
     # list.
     trap_nodes = self.sig_state.TakeRunList()
 
@@ -1708,11 +1708,11 @@ class CommandEvaluator(object):
     Could use i & (n-1) == i & 255  because we have a power of 2.
     https://stackoverflow.com/questions/14997165/fastest-way-to-get-a-positive-modulo-in-c-c
     """
-    handler = self.hook_state.GetHook('EXIT')  # type: _TrapHandler
-    if handler:
+    node = self.hook_state.GetHook('EXIT')  # type: command_t
+    if node:
       with dev.ctx_Tracer(self.tracer, 'trap EXIT', None):
         try:
-          is_return, is_fatal = self.ExecuteAndCatch(handler.node)
+          is_return, is_fatal = self.ExecuteAndCatch(node)
         except util.UserExit as e:  # explicit exit
           mut_status[0] = e.status
           return

--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -87,7 +87,7 @@ if TYPE_CHECKING:
   from core.vm import _Executor, _AssignBuiltin
   from oil_lang import expr_eval
   from osh import word_eval
-  from osh.builtin_trap import HookState
+  from osh.builtin_trap import HookState, SignalState
 
 # flags for main_loop.Batch, ExecuteAndCatch.  TODO: Should probably in
 # ExecuteAndCatch, along with SetValue() flags.
@@ -256,7 +256,7 @@ class CommandEvaluator(object):
                assign_builtins,  # type: Dict[builtin_t, _AssignBuiltin]
                arena,            # type: Arena
                cmd_deps,         # type: Deps
-               sig_state,        # type: pyos.SignalState
+               sig_state,        # type: SignalState
                hook_state,       # type: HookState
   ):
     # type: (...) -> None


### PR DESCRIPTION
This is the second-to-last PR in the signal series. It's size is primarily because of the cut-and-paste of `SignalState` from `pyos` into `builtin_trap`. Otherwise it's mostly some house-keeping. After this the API between the main loop and pyos/kernel is just the six small functions below. The rest of the signal handling code is shared with the hook handling code in the main loop and is all translatable python. I think I like this API, but I'm open to comments, e.g. `SetSigwinchCode()` is a little awkward, but I think it's the least awkward option.
```
def Sigaction(sig_num, handler):
  # type: (int, Any) -> None
  """Set the disposition of a signal. handler is either SIG_DFL or SIG_IGN"""

def RegisterSignalInterest(sig_num):
  # type: (int) -> None
  """Have the kernel notify the main loop about the given signal"""

def GetPendingSignals():
  # type: () -> List[int]
  """Transfer ownership of the current queue of pending signals to the caller."""

def LastSignal():
  # type: () -> int
  """Returns the number of the last signal that fired"""

def SetSigwinchCode(code):
  # type: (int) -> None
  """
  Depending on whether or not SIGWINCH is trapped by a user, it is expected to
  report a different code to `wait`. SetSigwinchCode() lets us set which code is
  reported.
  """

def InitShell():
  # type: () -> None
  """Opaquely initialize state""" 
```

This brings `oil-native` and `opy` up to parity on `spec/builtin-trap`! A follow up PR will do some additional house-keeping to make some interactive shell and SIGWINCH stuff translatable too. 
