### PR TITLE
fix `-Wcatch-value` in gen code

### DIFF
--- a/mycpp/cppgen_pass.py
+++ b/mycpp/cppgen_pass.py
@@ -2695,7 +2695,7 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
         # DUMMY to prevent compile errors
         # TODO: Remove this
         if not caught:
-          self.write_ind('catch (std::exception) { }\n')
+          self.write_ind('catch (std::exception const&) { }\n')
 
         #if o.else_body:
         #  raise AssertionError('try/else not supported')


### PR DESCRIPTION
This fixes the generated code to catch `std::exception`, as well as anything that inherits from it, rather than just `std::exception`. See `-Wcatch-value` documentation for details.