### PR TITLE
[frontend] make str lens explicit in lookup tables

### DIFF
--- a/frontend/consts_gen.py
+++ b/frontend/consts_gen.py
@@ -162,7 +162,7 @@ Str* %s(Str* c) {
 
   for char_code in sorted(lookup):
     f.write("  case '%s':\n" % CChar(char_code))
-    f.write('    return StrFromC("%s");\n' % CChar(lookup[char_code]))
+    f.write('    return StrFromC("%s", 1);\n' % CChar(lookup[char_code]))
     f.write("    break;\n");
 
   f.write("  default:\n");


### PR DESCRIPTION
We currently use the `StrFromC(char *)` form for `Str` creation in the generated character lookup tables for C++. This means '\0' gets interpreted as the empty string instead of a string of length one with a NULL byte in it.  Using the `StrFromC(char *, int)` form fixes this. For characters other than '\0' this should make no difference.
