### PR TITLE
Create two basic spectests for argparse

### DIFF
--- a/spec/oil-builtin-argparse.test.sh
+++ b/spec/oil-builtin-argparse.test.sh
@@ -4,14 +4,11 @@
 #
 # The following is as close as possible to the python argparse which seems to work well
 
-#### Argparse basic statement
+#### Argparse boolsche option and positional
 
 #I assume the hay definitions are given.
 ArgSpec myspec {
-  description = '''
-     Reference Implementation
-  '''
-  arg -v --verbose { type = Bool, help = "Verbose" }
+  arg -v --verbose { type = Bool }
   # TODO: can position be implicit (in given order?) or is the order not maintained in hay?
   arg firstPositional
 }
@@ -26,7 +23,7 @@ argparse (myspec, args, :opts)
 (List)   []
 ## END
 
-#### Argparse print automatic option "help"
+#### Argparse basic help message
 ArgSpec myspec {
   description = '''
      Reference Implementation

--- a/spec/oil-builtin-argparse.test.sh
+++ b/spec/oil-builtin-argparse.test.sh
@@ -5,43 +5,55 @@
 # The following is as close as possible to the python argparse which seems to work well
 
 #### Argparse boolsche option and positional
+hay define ArgSpec
+hay define ArgSpec/Arg
 
-#I assume the hay definitions are given.
 ArgSpec myspec {
-  arg -v --verbose { type = Bool }
-  # TODO: can position be implicit (in given order?) or is the order not maintained in hay?
-  arg firstPositional
+  Arg -v --verbose { type = Bool }
+  Arg src
+  Arg dst
 }
-var args = ['-v' 'argument']
+var args = ['-v', 'src/path', 'dst/path']
 argparse (myspec, args, :opts)
 
-= opts
-= args
+json write (opts)
+json write (args)
 ## STDOUT:
-(OrderedDict)   <'verbose': True, 'firstPositional': 'argument'> 
+{
+  "verbose": true,
+  "src": "src/path",
+  "dst": "dst/path"
+}
 # TODO: Should this be empty afterwards? Is it even possible with above call?
-(List)   []
+[
+
+]
 ## END
 
 #### Argparse basic help message
+hay define ArgSpec
+hay define ArgSpec/Arg
+
 ArgSpec myspec {
   description = '''
      Reference Implementation
   '''
   prog = "program-name"
-  arg -v --verbose { type = Bool, help = "Verbose" }
-  arg firstPositional
+  Arg -v --verbose { type = Bool; help = "Verbose" }
+  Arg src
+  Arg dst
 }
-var args = ['-h' 'posone']
+var args = ['-h', 'src', 'dst']
 
 argparse (myspec, args, :opts)
 ## STDOUT:
-usage: program-name [-h] [-v] firstPositional
+usage: program-name [-h] [-v] src dst
 
 Reference Implementation
 
 positional arguments:
- firstPositional
+ src
+ dst
 
 options:
  -h, --help           show this help message and exit

--- a/spec/oil-builtin-argparse.test.sh
+++ b/spec/oil-builtin-argparse.test.sh
@@ -2,34 +2,51 @@
 #
 # Some thoughts before writing code.  Hm can we do this entirely in user code, not as a builtin?
 #
-# I think it modifies OPT
+# The following is as close as possible to the python argparse which seems to work well
 
+#### Argparse basic statement
 
-#### Argparse Prototype
-
-hay define argparse
-
-# Oops, we're running into this problem ...
-
-hay define argparse/flag
-
-# This means we need expr.Type objects?  
-
-argparse foo {
-  flag -v --verbose (Bool) {
-    help = 'fo'
-    default = true
-  }
-
-  flag -h --help (Bool) {
-    help = 'fo'
-  }
-
-  arg name (pos = 1) {
-    foo
-  }
+#I assume the hay definitions are given.
+ArgSpec myspec {
+  description = '''
+     Reference Implementation
+  '''
+  arg -v --verbose { type = Bool, help = "Verbose" }
+  # TODO: can position be implicit (in given order?) or is the order not maintained in hay?
+  arg firstPositional
 }
+var args = ['-v' 'argument']
+argparse (myspec, args, :opts)
 
+= opts
+= args
 ## STDOUT:
-TODO
+(OrderedDict)   <'verbose': True, 'firstPositional': 'argument'> 
+# TODO: Should this be empty afterwards? Is it even possible with above call?
+(List)   []
+## END
+
+#### Argparse print automatic option "help"
+ArgSpec myspec {
+  description = '''
+     Reference Implementation
+  '''
+  prog = "program-name"
+  arg -v --verbose { type = Bool, help = "Verbose" }
+  arg firstPositional
+}
+var args = ['-h' 'posone']
+
+argparse (myspec, args, :opts)
+## STDOUT:
+usage: program-name [-h] [-v] firstPositional
+
+Reference Implementation
+
+positional arguments:
+ firstPositional
+
+options:
+ -h, --help           show this help message and exit
+ -v, --verbose        Verbose
 ## END


### PR DESCRIPTION
I finally found some time to do something about the spec tests for argparse.

Now I'm really unsure if it more or less resembles what we discussed, I think some of your points went over my head plus I read through the python argparse manual and took a lot of inspiration. The idea is that the hay definition should feel as much as possible like the python argparse definitions.

I intentionally only implemented 2 spec tests because I'm very unsure if they make sense! I'll add more spec tests for different features once these are approved 🙂 


I will do a final rebase (with proper commit naming) lateron