### PR TITLE
[cpp/qsn] Optimize rooting for core/qsn functions

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -3,44 +3,53 @@
 
 Structure of this directory:
 
+Correspond to Python standard library modules:
+
+    stdlib{.h,.cc,_test.cc}
+      import fcntl
+      import time
+      import posix  # forked in pyext/posixmodule.c
+
 Correspond to repo directories:
 
-    core.{cc,h}
-    osh.{cc,h}
+    core{.h,.cc,_test.cc}
+
+    osh{.h,.cc,_test.cc}
       from osh import arith_parse
       from osh import bool_stat
 
-    pylib.{cc,h}  # Corresponds to pylib/
+    pylib{.h,.cc,_test.cc}
       from pylib import os_path
       from pylib import path_stat
 
-    pgen2.{cc,h}
+    pgen2{.h,.cc,_test.cc}
       from pgen2 import parse
 
-    stdlib.{cc,h}  # Python standard library modules
-      import fcntl
-      import time
-      import posix  # forked in native/posixmodule.c
+    qsn{.h,_test.cc}
 
-    qsn.h
+Corresponds to our Python extensions:
 
-Correspond to files:
+    libc{.h,.cc,_test.cc}  # Python module pyext/libc.c
 
-    core_error.h    # Straggler for core/error.py
-    core_pyerror.h  # core/pyerror.py
+Correspond to individual files:
 
-    libc.{cc,h}  # Corresponds to Python extension native/libc.c
+    core_error.h    # corresponds to core/error.py
+    core_pyerror.h  # corresponds to core/pyerror.py
 
     # These three are separate because there is generated code associated with
     # them, like the re2c lexer.
 
-    frontend_flag_spec.{cc,h}
+    frontend_flag_spec{.h,.cc,_test.cc}
       from frontend import flag_spec
 
-    frontend_match.{cc,h}
+    frontend_match{.h,.cc,_test.cc}
       from frontend import match
 
-    osh_tdop.{cc,h}
+    osh_tdop.{h,cc}
       from frontend import tdop
 
-TODO: We want non-leaky versions of all files!
+Other files:
+
+    preamble.h           # for the big mycpp translation unit
+    translation_stubs.h      
+

--- a/cpp/qsn.h
+++ b/cpp/qsn.h
@@ -31,25 +31,24 @@ inline bool IsPlainChar(Str* ch) {
 }
 
 inline Str* XEscape(Str* ch) {
-  RootsFrame _r{FUNC_NAME};
+  NO_ROOTS_FRAME(FUNC_NAME);  // NewStr does it
+
   assert(len(ch) == 1);
-  StackRoots _roots({&ch});
   Str* result = NewStr(4);
   sprintf(result->data(), "\\x%02x", ch->data_[0] & 0xff);
-  gHeap.RootOnReturn(result);
   return result;
 }
 
 inline Str* UEscape(int codepoint) {
+  NO_ROOTS_FRAME(FUNC_NAME);  // OverAllocatedStr does it
+
   // maximum length:
   // 3 for \u{
   // 6 for codepoint
   // 1 for }
-  RootsFrame _r{FUNC_NAME};
   Str* result = OverAllocatedStr(10);
   int n = sprintf(result->data(), "\\u{%x}", codepoint);
   result->SetObjLenFromStrLen(n);  // truncate to what we wrote
-  gHeap.RootOnReturn(result);
   return result;
 }
 

--- a/cpp/qsn_test.cc
+++ b/cpp/qsn_test.cc
@@ -4,17 +4,11 @@
 #include "vendor/greatest.h"
 
 TEST qsn_test() {
-  Str* s = nullptr;
-  Str* x = nullptr;
-  Str* u = nullptr;
-  StackRoots _roots({&s, &x, &u});
-
-  s = StrFromC("a");
-  x = qsn::XEscape(s);
+  Str* x = qsn::XEscape(StrFromC("a"));
   log("XEscape %s", x->data_);
   ASSERT(str_equals(x, StrFromC("\\x61")));
 
-  u = qsn::UEscape(0x61);
+  Str* u = qsn::UEscape(0x61);
   log("UEScape %s", u->data_);
   ASSERT(str_equals(u, StrFromC("\\u{61}")));
 

--- a/mycpp/gc_str.h
+++ b/mycpp/gc_str.h
@@ -101,7 +101,7 @@ inline int len(const Str* s) {
 //
 
 inline Str* NewStr(int len) {
-  NO_ROOTS_FRAME(FUNC_NAME);
+  NO_ROOTS_FRAME(FUNC_NAME);  // Allocate() does it
 
   int obj_len = kStrHeaderSize + len + 1;
 
@@ -116,6 +116,8 @@ inline Str* NewStr(int len) {
 // Like NewStr, but allocate more than you need, e.g. for snprintf() to write
 // into.  CALLER IS RESPONSIBLE for calling s->SetObjLenFromStrLen() afterward!
 inline Str* OverAllocatedStr(int len) {
+  NO_ROOTS_FRAME(FUNC_NAME);  // Allocate() does it
+
   int obj_len = kStrHeaderSize + len + 1;  // NUL terminator
   void* place = gHeap.Allocate(obj_len);
   auto s = new (place) Str();
@@ -123,7 +125,7 @@ inline Str* OverAllocatedStr(int len) {
 }
 
 inline Str* StrFromC(const char* data, int len) {
-  NO_ROOTS_FRAME(FUNC_NAME);
+  NO_ROOTS_FRAME(FUNC_NAME);  // NewStr() does it
 
   Str* s = NewStr(len);
   memcpy(s->data_, data, len);


### PR DESCRIPTION
Remove the old rooting style.

Also update cpp/README.md with the new structure.