### PR TITLE
eggex.md: clarify zero-width assertions

### DIFF
--- a/doc/eggex.md
+++ b/doc/eggex.md
@@ -87,7 +87,7 @@ Eggexes have a consistent syntax:
 
 - Single characters are unadorned, in lowercase: `dot`, `space`, or `s`
 - A sequence of multiple characters looks like `'lit'`, `$var`, etc.
-- Constructs that match **zero** characters look like `%start %end` 
+- Constructs that match **zero** characters look like `%start`, `%word_end`, etc. 
 - Entire subpatterns (which may contain alternation, repetition, etc.) are in
   uppercase like `HexDigit`.  Important: these are **spliced** as syntax trees,
   not strings, so you **don't** need to think about quoting.


### PR DESCRIPTION
The previous formatting and examples could mislead one to think that `%start %end` is an example, using dummy names, for a type of expression that has an opening and a closing marker (and possibly some content within).

By splitting the code markup, adding a comma, and using a second example that isn't complementary to the first one, the actual syntax is made clearer.