### PR TITLE
History in XDG_DATA_HOME, configurable via Environment variable

### DIFF
--- a/core/shell.py
+++ b/core/shell.py
@@ -611,7 +611,6 @@ def Main(lang, arg_r, environ, login_shell, loader, line_input):
         display = comp_ui.MinimalDisplay(comp_ui_state, prompt_state, debug_f)
       if 'HISTFILE_%s' % lang.upper() in environ:
         history_filename = environ.get('HISTFILE_%s' % lang.upper())
-        print(repr(history_filename))
       elif 'XDG_DATA_HOME' in environ:
         history_filename = os_path.join(
           environ.get('XDG_DATA_HOME'), 'oil/history_%s' % lang)

--- a/oil-version.txt
+++ b/oil-version.txt
@@ -1,5 +1,4 @@
-0.12.9-hist
-
+0.12.9
 # The first line of this file is the Oil version, and the rest is ignored.
 # It's used at build time for the release tarball, and at runtime for oil
 # --version / osh --version.


### PR DESCRIPTION
I created a modified version of 0.12.8, then ported my changes to 0.12.9, that changes the history file path to have the following behavior:

If `$HISTFILE_OIL`/`$HISTFILE_OSH` environment variable for the current language is set, use that.
Otherwise, if `$XDG_DATA_HOME` is set, save to `"$XDG_DATA_HOME"/oil/history_oil` or `"$XDG_DATA_HOME"/oil/history_osh`.
If neither option is set, fall back to `~/.local/share/oil/history_oil` or `~/.local/share/oil/history_osh`.