### PR TITLE
[mycpp] add StrFormat()

### DIFF
--- a/mycpp/gc_builtins.cc
+++ b/mycpp/gc_builtins.cc
@@ -28,7 +28,7 @@ Str* repr(Str* s) {
 }
 
 // Helper for str_to_int() that doesn't use exceptions.
-bool StringToInteger(char* s, int length, int base, int* result) {
+bool StringToInteger(const char* s, int length, int base, int* result) {
   if (length == 0) {
     return false;  // empty string isn't a valid integer
   }

--- a/mycpp/gc_builtins.h
+++ b/mycpp/gc_builtins.h
@@ -101,7 +101,7 @@ Str* str(int i);
 // Helper function: returns whether the string is a valid integer, and
 // populates the result.  (Also used by marksweep_heap.cc; could be moved
 // there)
-bool StringToInteger(char* s, int len, int base, int* result);
+bool StringToInteger(const char* s, int len, int base, int* result);
 
 // String to integer, raising ValueError if invalid
 int to_int(Str* s);

--- a/mycpp/gc_str.cc
+++ b/mycpp/gc_str.cc
@@ -482,13 +482,13 @@ static inline Str* _StrFormat(const char* fmt, va_list args) {
     const std::csub_match& lit_m = match[1];
     assert(lit_m.matched);
     const std::string& lit_s = lit_m.str();
-    buf.append(lit_s.c_str());
+    buf.append(lit_s);
 
     int width = 0;
     bool zero_pad = false;
     const std::csub_match& width_m = match[2];
     const std::string& width_s = width_m.str();
-    if (width_m.matched && !width_m.str().empty()) {
+    if (width_m.matched && !width_s.empty()) {
       if (width_s[0] == '0') {
         zero_pad = true;
         assert(width_s.size() > 1);
@@ -530,7 +530,8 @@ static inline Str* _StrFormat(const char* fmt, va_list args) {
     case 'd':  // fallthrough
     case 'o': {
       int d = va_arg(args, int);
-      assert(snprintf(int_buf, kMaxFmtWidth, match.str().c_str(), d) > 0);
+      assert(snprintf(int_buf, kMaxFmtWidth, match.str().c_str() + lit_s.size(),
+                      d) > 0);
       str_to_add = int_buf;
       break;
     }

--- a/mycpp/gc_str.cc
+++ b/mycpp/gc_str.cc
@@ -505,7 +505,7 @@ static inline Str* _StrFormat(const char* fmt, int fmt_len, va_list args) {
     const std::string& code_s = code_m.str();
     if (!code_m.matched) {
       assert(!width_m.matched);  // python errors on invalid format operators
-      goto done;
+      break;
     }
     assert(code_s.size() == 1);
     switch (code_s[0]) {
@@ -544,15 +544,12 @@ static inline Str* _StrFormat(const char* fmt, int fmt_len, va_list args) {
     }
     assert(str_to_add != nullptr);
 
-  done:
-    if (str_to_add != nullptr) {
-      if (add_len < width) {
-        for (int i = 0; i < width - add_len; ++i) {
-          buf.push_back(zero_pad ? '0' : ' ');
-        }
+    if (add_len < width) {
+      for (int i = 0; i < width - add_len; ++i) {
+        buf.push_back(zero_pad ? '0' : ' ');
       }
-      buf.append(str_to_add, add_len);
     }
+    buf.append(str_to_add, add_len);
   }
 
   return StrFromC(buf.c_str(), buf.size());

--- a/mycpp/gc_str.h
+++ b/mycpp/gc_str.h
@@ -132,6 +132,9 @@ inline Str* StrFromC(const char* data) {
   return StrFromC(data, strlen(data));
 }
 
+Str* StrFormat(const char* fmt, ...);
+Str* StrFormat(Str* fmt, ...);
+
 // NOTE: This iterates over bytes.
 class StrIter {
  public:

--- a/mycpp/gc_str_test.cc
+++ b/mycpp/gc_str_test.cc
@@ -1040,6 +1040,52 @@ TEST test_str_join() {
   PASS();
 }
 
+TEST test_str_format() {
+  // check trivial case
+  ASSERT(str_equals(StrFromC("foo"), StrFormat("foo")));
+
+  // check %s
+  ASSERT(str_equals(StrFromC("foo"), StrFormat("%s", StrFromC("foo"))));
+  ASSERT(str_equals(StrFromC("              foo"),
+                    StrFormat("%17s", StrFromC("foo"))));
+
+  // check %d
+  ASSERT(str_equals(StrFromC("12345"), StrFormat("%d", 12345)));
+  ASSERT(str_equals(StrFromC("            12345"), StrFormat("%17d", 12345)));
+  ASSERT(str_equals(StrFromC("00000000000012345"), StrFormat("%017d", 12345)));
+
+  // check %o
+  ASSERT(str_equals(StrFromC("30071"), StrFormat("%o", 12345)));
+  ASSERT(str_equals(StrFromC("            30071"), StrFormat("%17o", 12345)));
+  ASSERT(str_equals(StrFromC("00000000000030071"), StrFormat("%017o", 12345)));
+
+  // check that %% escape works
+  ASSERT(str_equals(StrFromC("%12345"), StrFormat("%%%d", 12345)));
+  ASSERT(str_equals(StrFromC("%12345%%"), StrFormat("%%%d%%%%", 12345)));
+
+  // check that operators can be combined
+  ASSERT(str_equals(StrFromC("      1234foo"),
+                    StrFormat("%10d%s", 1234, StrFromC("foo"))));
+
+  // check StrFormat(char*) == StrFormat(Str*)
+  ASSERT(str_equals(StrFormat("%10d%s", 1234, StrFromC("foo")),
+                    StrFormat(StrFromC("%10d%s"), 1234, StrFromC("foo"))));
+
+  // check that %r behaves like repr()
+  ASSERT(str_equals0("''", StrFormat("%r", kEmptyString)));
+  ASSERT(str_equals0("\"'\"", StrFormat("%r", StrFromC("'"))));
+  ASSERT(str_equals0("\"'single'\"", StrFormat("%r", StrFromC("'single'"))));
+  ASSERT(str_equals0("'\"double\"'", StrFormat("%r", StrFromC("\"double\""))));
+  ASSERT(str_equals0("'NUL \\x00 NUL'",
+                     StrFormat("%r", StrFromC("NUL \x00 NUL", 9))));
+  ASSERT(str_equals0("'tab\\tline\\nline\\r\\n'",
+                     StrFormat("%r", StrFromC("tab\tline\nline\r\n"))));
+  ASSERT(str_equals0("'high \\xff \\xfe high'",
+                     StrFormat("%r", StrFromC("high \xFF \xFE high"))));
+
+  PASS();
+}
+
 GREATEST_MAIN_DEFS();
 
 int main(int argc, char** argv) {
@@ -1068,6 +1114,8 @@ int main(int argc, char** argv) {
 
   RUN_TEST(test_str_split);
   RUN_TEST(test_str_join);
+
+  RUN_TEST(test_str_format);
 
   gHeap.CleanProcessExit();
 

--- a/mycpp/gc_str_test.cc
+++ b/mycpp/gc_str_test.cc
@@ -1048,6 +1048,13 @@ TEST test_str_format() {
   ASSERT(str_equals(StrFromC("foo"), StrFormat("%s", StrFromC("foo"))));
   ASSERT(str_equals(StrFromC("              foo"),
                     StrFormat("%17s", StrFromC("foo"))));
+  ASSERT(str_equals(StrFromC("foo"), StrFormat("foo%s", StrFromC(""))));
+
+  // check that NUL bytes are preserved
+  ASSERT(str_equals(StrFromC("foo b\0ar", 8),
+                    StrFormat("foo %s", StrFromC("b\0ar", 4))));
+  ASSERT(str_equals(StrFromC("foo\0bar", 7),
+                    StrFormat(StrFromC("foo\0%s", 6), StrFromC("bar"))));
 
   // check %d
   ASSERT(str_equals(StrFromC("12345"), StrFormat("%d", 12345)));

--- a/mycpp/gc_str_test.cc
+++ b/mycpp/gc_str_test.cc
@@ -1064,8 +1064,8 @@ TEST test_str_format() {
   ASSERT(str_equals(StrFromC("%12345%%"), StrFormat("%%%d%%%%", 12345)));
 
   // check that operators can be combined
-  ASSERT(str_equals(StrFromC("      1234foo"),
-                    StrFormat("%10d%s", 1234, StrFromC("foo"))));
+  ASSERT(str_equals(StrFromC("ABC      1234DfooEF"),
+                    StrFormat("ABC%10dD%sEF", 1234, StrFromC("foo"))));
 
   // check StrFormat(char*) == StrFormat(Str*)
   ASSERT(str_equals(StrFormat("%10d%s", 1234, StrFromC("foo")),

--- a/mycpp/mark_sweep_heap.cc
+++ b/mycpp/mark_sweep_heap.cc
@@ -1,5 +1,7 @@
 #include <sys/time.h>  // gettimeofday()
 
+#include <ctime>  // CLOCK_PROCESS_CPUTIME_ID
+
 #include "mycpp/runtime.h"
 
 void MarkSweepHeap::Init() {


### PR DESCRIPTION
This will make it easier to support dynamic format strigns when translating modules like core/comp_ui. It will also allow us to skip gnerating format string functions in mycpp, which should lead to smaller binaries (and less bespoke code to scan when debugging).

This commit just adds a library. A follow-up will update mycpp to generate code that uses it.