### PR TITLE
[cpp] Remove StackRoots in hand-written code

### DIFF
--- a/mycpp/README.md
+++ b/mycpp/README.md
@@ -202,17 +202,6 @@ Issue on mycpp improvements: <https://github.com/oilshell/oil/issues/568>
   collisions.
   - Could enforce this if it becomes a problem
 
-### Due to Garbage Collection
-
-- Big limitation: I think `f(g(x))` is not allowed if g() returns a
-  pointer!  Due to `StackRoots`.
-  - TODO: enforce this or translate it.
-- Likewise `for x in [1, 2, 3]` is not allowed.  Assign it to a temporary
-  variable first, so it can be picked up in `StackRoots()`.
-- Generally constructors should only assign members.  They shouldn't call
-  functions or raise exceptions.
-  - TODO: we could enforce this.
-
 ## C++
 
 ### Interactions Between C++ and Garbage Collection

--- a/mycpp/gc_dict.h
+++ b/mycpp/gc_dict.h
@@ -19,8 +19,6 @@ template <typename T>
 List<T>* ListFromDictSlab(Slab<int>* index, Slab<T>* slab, int n) {
   // TODO: Reserve the right amount of space
   List<T>* result = nullptr;
-  StackRoots _roots({&index, &slab, &result});
-
   result = Alloc<List<T>>();
 
   for (int i = 0; i < n; ++i) {
@@ -96,8 +94,6 @@ class Dict : public Obj {
   V get(K key, V default_val);
 
   // Implements d[k] = v.  May resize the dictionary.
-  //
-  // TODO: Need to specialize this for StackRoots!  Gah!
   void set(K key, V val);
 
   List<K>* keys();
@@ -141,10 +137,10 @@ inline bool dict_contains(Dict<K, V>* haystack, K needle) {
   return haystack->position_of_key(needle) != -1;
 }
 
+// TODO: Remove one of these styles using mycpp code gen
 template <typename K, typename V>
 Dict<K, V>* NewDict() {
-  auto self = Alloc<Dict<K, V>>();
-  return self;
+  return Alloc<Dict<K, V>>();
 }
 
 template <typename K, typename V>
@@ -152,8 +148,6 @@ Dict<K, V>* NewDict(std::initializer_list<K> keys,
                     std::initializer_list<V> values) {
   assert(keys.size() == values.size());
   auto self = Alloc<Dict<K, V>>();
-  StackRoots _roots({&self});
-
   auto v = values.begin();  // This simulates a "zip" loop
   for (auto key : keys) {
     self->set(key, *v);
@@ -169,8 +163,6 @@ void Dict<K, V>::reserve(int n) {
   Slab<int>* new_i = nullptr;
   Slab<K>* new_k = nullptr;
   Slab<V>* new_v = nullptr;
-  StackRoots _roots({&self, &new_i, &new_k, &new_v});
-
   // log("--- reserve %d", capacity_);
   //
   if (self->capacity_ < n) {  // TODO: use load factor, not exact fit
@@ -278,72 +270,23 @@ void Dict<K, V>::clear() {
 //   This will enable duplicate copies of the string to be garbage collected
 template <typename K, typename V>
 int Dict<K, V>::position_of_key(K key) {
-  auto self = this;
-  StackRoots _roots({&self});
-
-  for (int i = 0; i < self->capacity_; ++i) {
-    int special = self->entry_->items_[i];  // NOT an index now
+  for (int i = 0; i < capacity_; ++i) {
+    int special = entry_->items_[i];  // NOT an index now
     if (special == kDeletedEntry) {
       continue;  // keep searching
     }
     if (special == kEmptyEntry) {
       return -1;  // not found
     }
-    if (keys_equal(self->keys_->items_[i], key)) {
+    if (keys_equal(keys_->items_[i], key)) {
       return i;
     }
   }
   return -1;  // table is completely full?  Does this happen?
 }
 
-// Four overloads for dict_set()!  TODO: Is there a nicer way to do this?
-// e.g. Dict<int, int>
 template <typename K, typename V>
 void dict_set(Dict<K, V>* self, K key, V val) {
-  StackRoots _roots({&self});
-
-  self->reserve(self->len_ + 1);
-  self->keys_->items_[self->len_] = key;
-  self->values_->items_[self->len_] = val;
-
-  self->entry_->items_[self->len_] = 0;  // new special value
-
-  ++self->len_;
-}
-
-// e.g. Dict<Str*, int>
-template <typename K, typename V>
-void dict_set(Dict<K*, V>* self, K* key, V val) {
-  StackRoots _roots({&self, &key});
-
-  self->reserve(self->len_ + 1);
-  self->keys_->items_[self->len_] = key;
-  self->values_->items_[self->len_] = val;
-
-  self->entry_->items_[self->len_] = 0;  // new special value
-
-  ++self->len_;
-}
-
-// e.g. Dict<int, Str*>
-template <typename K, typename V>
-void dict_set(Dict<K, V*>* self, K key, V* val) {
-  StackRoots _roots({&self, &val});
-
-  self->reserve(self->len_ + 1);
-  self->keys_->items_[self->len_] = key;
-  self->values_->items_[self->len_] = val;
-
-  self->entry_->items_[self->len_] = 0;  // new special value
-
-  ++self->len_;
-}
-
-// e.g. Dict<Str*, Str*>
-template <typename K, typename V>
-void dict_set(Dict<K*, V*>* self, K* key, V* val) {
-  StackRoots _roots({&self, &key, &val});
-
   self->reserve(self->len_ + 1);
   self->keys_->items_[self->len_] = key;
   self->values_->items_[self->len_] = val;
@@ -355,14 +298,11 @@ void dict_set(Dict<K*, V*>* self, K* key, V* val) {
 
 template <typename K, typename V>
 void Dict<K, V>::set(K key, V val) {
-  auto self = this;
-  StackRoots _roots({&self});  // May not need this here?
-
-  int pos = self->position_of_key(key);
+  int pos = position_of_key(key);
   if (pos == -1) {             // new pair
-    dict_set(self, key, val);  // ALLOCATES
+    dict_set(this, key, val);  // ALLOCATES
   } else {
-    self->values_->items_[pos] = val;
+    values_->items_[pos] = val;
   }
 }
 

--- a/mycpp/gc_list.h
+++ b/mycpp/gc_list.h
@@ -56,8 +56,6 @@ class List : public Obj {
   int index(T element);
 
   // Implements L[i] = item
-  // Note: Unlike Dict::set(), we don't need to specialize List::set() on T for
-  // StackRoots because it doesn't allocate.
   void set(int i, T item);
 
   // L[begin:]
@@ -115,7 +113,6 @@ List<T>* NewList() {
 template <typename T>
 List<T>* NewList(std::initializer_list<T> init) {
   auto self = Alloc<List<T>>();
-  StackRoots _roots({&self});
 
   int n = init.size();
   self->reserve(n);
@@ -133,7 +130,6 @@ List<T>* NewList(std::initializer_list<T> init) {
 template <typename T>
 List<T>* NewList(T item, int times) {
   auto self = Alloc<List<T>>();
-  StackRoots _roots({&self});
 
   self->reserve(times);
   self->len_ = times;
@@ -143,21 +139,8 @@ List<T>* NewList(T item, int times) {
   return self;
 }
 
-// e.g. List<int>
 template <typename T>
 void list_append(List<T>* self, T item) {
-  StackRoots _roots({&self});
-
-  self->reserve(self->len_ + 1);
-  self->set(self->len_, item);
-  ++self->len_;
-}
-
-// e.g. List<Str*>
-template <typename T>
-void list_append(List<T*>* self, T* item) {
-  StackRoots _roots({&self, &item});
-
   self->reserve(self->len_ + 1);
   self->set(self->len_, item);
   ++self->len_;
@@ -209,8 +192,6 @@ List<T>* List<T>::slice(int begin) {
 
   auto self = this;
   List<T>* result = nullptr;
-  StackRoots _roots({&self, &result});
-
   result = NewList<T>();
 
   for (int i = begin; i < self->len_; i++) {
@@ -235,13 +216,9 @@ List<T>* List<T>::slice(int begin, int end) {
   assert(begin >= 0);
   assert(end >= 0);
 
-  auto self = this;
-  List<T>* result = nullptr;
-  StackRoots _roots({&self, &result});
-
-  result = NewList<T>();
+  List<T>* result = NewList<T>();
   for (int i = begin; i < end; i++) {
-    result->append(self->slab_->items_[i]);
+    result->append(slab_->items_[i]);
   }
 
   return result;
@@ -251,29 +228,27 @@ List<T>* List<T>::slice(int begin, int end) {
 template <typename T>
 void List<T>::reserve(int n) {
   // log("reserve capacity = %d, n = %d", capacity_, n);
-  auto self = this;
-  StackRoots _roots({&self});
 
   // Don't do anything if there's already enough space.
-  if (self->capacity_ >= n) return;
+  if (capacity_ >= n) {
+    return;
+  }
 
   // Example: The user asks for space for 7 integers.  Account for the
   // header, and say we need 9 to determine the obj length.  9 is
   // rounded up to 16, for a 64-byte obj.  Then we actually have space
   // for 14 items.
-  self->capacity_ = RoundUp(n + kCapacityAdjust) - kCapacityAdjust;
-  auto new_slab = NewSlab<T>(self->capacity_);
+  capacity_ = RoundUp(n + kCapacityAdjust) - kCapacityAdjust;
+  auto new_slab = NewSlab<T>(capacity_);
 
-  if (self->len_ > 0) {
+  if (len_ > 0) {
     // log("Copying %d bytes", len_ * sizeof(T));
-    memcpy(new_slab->items_, self->slab_->items_, self->len_ * sizeof(T));
+    memcpy(new_slab->items_, slab_->items_, len_ * sizeof(T));
   }
-  self->slab_ = new_slab;
+  slab_ = new_slab;
 }
 
 // Implements L[i] = item
-// Note: Unlike Dict::set(), we don't need to specialize List::set() on T for
-// StackRoots because it doesn't allocate.
 template <typename T>
 void List<T>::set(int i, T item) {
   if (i < 0) {
@@ -368,17 +343,14 @@ void List<T>::reverse() {
 // Extend this list with multiple elements.
 template <typename T>
 void List<T>::extend(List<T>* other) {
-  auto self = this;
-  StackRoots _roots({&self, &other});
-
   int n = other->len_;
-  int new_len = self->len_ + n;
-  self->reserve(new_len);
+  int new_len = len_ + n;
+  reserve(new_len);
 
   for (int i = 0; i < n; ++i) {
-    self->set(self->len_ + i, other->slab_->items_[i]);
+    set(len_ + i, other->slab_->items_[i]);
   }
-  self->len_ = new_len;
+  len_ = new_len;
 }
 
 // Used by [[ a > b ]] and so forth
@@ -406,11 +378,6 @@ void List<T>::sort() {
   std::sort(slab_->items_, slab_->items_ + len_, _cmp);
 }
 
-/* template <typename T> */
-/* int len(const List<T>* L) { */
-/*   return L->len_; */
-/* } */
-
 // TODO: mycpp can just generate the constructor instead?
 // e.g. [None] * 3
 template <typename T>
@@ -418,50 +385,9 @@ List<T>* list_repeat(T item, int times) {
   return NewList<T>(item, times);
 }
 
-#if 0
-template <typename T>
-List<T>* NewList() {
-  return Alloc<List<T>>();
-}
-
-// Literal ['foo', 'bar']
-template <typename T>
-List<T>* NewList(std::initializer_list<T> init) {
-  auto self = Alloc<List<T>>();
-  StackRoots _roots({&self});
-
-  int n = init.size();
-  self->reserve(n);
-
-  int i = 0;
-  for (auto item : init) {
-    self->set(i, item);
-    ++i;
-  }
-  self->len_ = n;
-  return self;
-}
-
-// ['foo'] * 3
-template <typename T>
-List<T>* NewList(T item, int times) {
-  auto self = Alloc<List<T>>();
-  StackRoots _roots({&self});
-
-  self->reserve(times);
-  self->len_ = times;
-  for (int i = 0; i < times; ++i) {
-    self->set(i, item);
-  }
-  return self;
-}
-#endif
-
 // e.g. 'a' in ['a', 'b', 'c']
 template <typename T>
 inline bool list_contains(List<T>* haystack, T needle) {
-  // StackRoots _roots({&haystack, &needle});  // doesn't allocate
-
   int n = len(haystack);
   for (int i = 0; i < n; ++i) {
     if (are_equal(haystack->index_(i), needle)) {

--- a/mycpp/gc_mylib.cc
+++ b/mycpp/gc_mylib.cc
@@ -18,10 +18,7 @@ MutableStr* NewMutableStr(int cap) {
   return reinterpret_cast<MutableStr*>(NewStr(cap));
 }
 
-// TODO: remove unnecessary rooting
 Tuple2<Str*, Str*> split_once(Str* s, Str* delim) {
-  StackRoots _roots({&s, &delim});
-
   assert(len(delim) == 1);
 
   const char* start = s->data_;  // note: this pointer may move
@@ -36,7 +33,6 @@ Tuple2<Str*, Str*> split_once(Str* s, Str* delim) {
 
     Str* s1 = nullptr;
     Str* s2 = nullptr;
-    StackRoots _roots({&s1, &s2});
     // Allocate together to avoid 's' moving in between
     s1 = NewStr(len1);
     s2 = NewStr(len2);
@@ -53,8 +49,6 @@ Tuple2<Str*, Str*> split_once(Str* s, Str* delim) {
 LineReader* gStdin;
 
 LineReader* open(Str* path) {
-  StackRoots _roots({&path});
-
   // TODO: Don't use C I/O; use POSIX I/O!
   FILE* f = fopen(path->data_, "r");
 
@@ -95,7 +89,6 @@ Str* CFileLineReader::readline() {
 Str* BufLineReader::readline() {
   auto self = this;
   Str* line = nullptr;
-  StackRoots _roots({&self, &line});
 
   int buf_len = len(s_);
   if (pos_ == buf_len) {


### PR DESCRIPTION
It's no longer necessary because of our manual collection points policy.

This is a lot cleaner and faster!