### PR TITLE
[core] make comp_ui translatable

### DIFF
--- a/build/dynamic-deps.sh
+++ b/build/dynamic-deps.sh
@@ -63,7 +63,6 @@ _gen/
 .*_spec\.py
 asdl/py.*
 core/py.*
-core/comp_ui.py
 core/optview.py
 frontend/consts.py
 frontend/match.py

--- a/core/comp_ui_test.py
+++ b/core/comp_ui_test.py
@@ -120,7 +120,7 @@ class UiTest(unittest.TestCase):
 
     # terminal width
     d1 = comp_ui.NiceDisplay(80, comp_ui_state, prompt_state, debug_f,
-                             line_input, bold_line=False)
+                             line_input)
     d2 = comp_ui.MinimalDisplay(comp_ui_state, prompt_state, debug_f)
 
     prompt_state.SetLastPrompt('$ ')

--- a/core/shell_native.py
+++ b/core/shell_native.py
@@ -15,6 +15,7 @@ from _devbuild.gen.syntax_asdl import source
 from asdl import runtime
 
 from core import alloc
+from core import comp_ui
 from core import dev
 from core import error
 from core import executor
@@ -379,8 +380,8 @@ def Main(lang, arg_r, environ, login_shell, loader, line_input):
 
   # Various Global State objects to work around readline interfaces
   #compopt_state = completion.OptionState()
-  #comp_ui_state = comp_ui.State()
-  #prompt_state = comp_ui.PromptState()
+  comp_ui_state = comp_ui.State()
+  prompt_state = comp_ui.PromptState()
 
   dir_stack = state.DirStack()
 

--- a/cpp/core.h
+++ b/cpp/core.h
@@ -10,8 +10,8 @@
 #include "mycpp/runtime.h"
 
 // Hacky forward declaration
-namespace comp_ui {
-class _IDisplay;
+namespace completion {
+class RootCompleter;
 };
 
 namespace pyos {

--- a/cpp/libc.h
+++ b/cpp/libc.h
@@ -29,6 +29,9 @@ Tuple2<int, int>* regex_first_group_match(Str* pattern, Str* str, int pos);
 
 List<Str*>* regex_match(Str* pattern, Str* str);
 
+int wcswidth(Str* str);
+int get_terminal_width();
+
 }  // namespace libc
 
 #endif  // LIBC_H

--- a/mycpp/gc_builtins.cc
+++ b/mycpp/gc_builtins.cc
@@ -268,3 +268,35 @@ bool str_equals0(const char* c_string, Str* s) {
     return false;
   }
 }
+
+int hash(Str* s) {
+  // FNV-1 from http://www.isthe.com/chongo/tech/comp/fnv/#FNV-1
+  int h = 2166136261;          // 32-bit FNV-1 offset basis
+  constexpr int p = 16777619;  // 32-bit FNV-1 prime
+  for (int i = 0; i < len(s); i++) {
+    h *= s->data()[i];
+    h ^= p;
+  }
+  return h;
+}
+
+int max(int a, int b) {
+  return std::max(a, b);
+}
+
+int max(List<int>* elems) {
+  int n = len(elems);
+  if (n < 1) {
+    throw Alloc<ValueError>();
+  }
+
+  int ret = elems->index_(0);
+  for (int i = 0; i < n; ++i) {
+    int cand = elems->index_(i);
+    if (cand > ret) {
+      ret = cand;
+    }
+  }
+
+  return ret;
+}

--- a/mycpp/gc_builtins.cc
+++ b/mycpp/gc_builtins.cc
@@ -1,4 +1,5 @@
 #include <ctype.h>  // isspace()
+#include <errno.h>  // errno
 
 #include "mycpp/runtime.h"
 

--- a/mycpp/gc_builtins.h
+++ b/mycpp/gc_builtins.h
@@ -16,6 +16,8 @@ class _ExceptionOpaque : public Obj {
 };
 
 // mycpp removes constructor arguments
+class Exception : public _ExceptionOpaque {};
+
 class AssertionError : public _ExceptionOpaque {};
 
 class IndexError : public _ExceptionOpaque {};
@@ -58,6 +60,20 @@ constexpr uint16_t maskof_RuntimeError() {
 inline RuntimeError::RuntimeError(Str* message)
     : Obj(Tag::FixedSize, maskof_RuntimeError(), kNoObjLen), message(message) {
 }
+
+// libc::wcswidth raises UnicodeError
+class UnicodeError : public Obj {
+ public:
+  explicit UnicodeError(Str* message)
+    : Obj(Tag::FixedSize, UnicodeError::field_mask(), kNoObjLen),
+      message(message) {}
+
+  Str* message;
+
+  static constexpr uint16_t field_mask() {
+    return maskbit(offsetof(UnicodeError, message));
+  }
+};
 
 // Python 2 has a dubious distinction between IOError and OSError, so mycpp
 // generates this base class to catch both.
@@ -139,5 +155,9 @@ extern Str* kEmptyString;
 inline Str* dynamic_fmt_dummy() {
   return kEmptyString;
 }
+
+int hash(Str* s);
+
+int max(int a, int b);
 
 #endif  // GC_BUILTINS_H

--- a/mycpp/gc_builtins_test.cc
+++ b/mycpp/gc_builtins_test.cc
@@ -885,6 +885,26 @@ TEST exceptions_test() {
   PASS();
 }
 
+TEST str_hash_test() {
+  // two strings known not to collide ahead of time
+  Str* a = StrFromC("foobarbaz");
+  Str* b = StrFromC("123456789");
+  ASSERT(hash(a) != hash(b));
+
+  PASS();
+}
+
+TEST max_test() {
+  ASSERT(max(-1, 0) == 0);
+  ASSERT(max(0, -1) == max(-1, 0));
+  ASSERT(max(42, 13) == 42);
+
+  auto* ints = NewList<int>(std::initializer_list<int>{13, 0, 42, -1});
+  ASSERT(max(ints) == 42);
+
+  PASS();
+}
+
 GREATEST_MAIN_DEFS();
 
 int main(int argc, char** argv) {
@@ -921,6 +941,10 @@ int main(int argc, char** argv) {
   RUN_TEST(dict_iters_test);
 
   RUN_TEST(exceptions_test);
+
+  RUN_TEST(str_hash_test);
+
+  RUN_TEST(max_test);
 
   gHeap.CleanProcessExit();
 

--- a/mycpp/gc_list.h
+++ b/mycpp/gc_list.h
@@ -460,4 +460,6 @@ class ReverseListIter {
   int i_;
 };
 
+int max(List<int>* elems);
+
 #endif  // MYCPP_GC_LIST_H

--- a/prebuilt/dynamic-deps/filter-translate.txt
+++ b/prebuilt/dynamic-deps/filter-translate.txt
@@ -4,7 +4,6 @@ _gen/
 .*_spec\.py
 asdl/py.*
 core/py.*
-core/comp_ui.py
 core/optview.py
 frontend/consts.py
 frontend/match.py


### PR DESCRIPTION
Everything but the readline and completion dependencies can be translated now. Let's fold them into `shell_native.py`.

This PR also includes some commits that add C++ versions of the builtins needed by `comp_ui`.