### PR TITLE
[pyext/posix] add system(3)

### DIFF
--- a/build/oil-defs/Python-2.7.13/Modules/posixmodule.c/posix_methods.def
+++ b/build/oil-defs/Python-2.7.13/Modules/posixmodule.c/posix_methods.def
@@ -35,6 +35,7 @@ static PyMethodDef posix_methods[] = {
   {"putenv", posix_putenv, METH_VARARGS},
   /*{"unsetenv", posix_unsetenv, METH_VARARGS},*/
   {"strerror", posix_strerror, METH_VARARGS},
+  {"system", posix_system, METH_VARARGS},
 
   /* job control stuff */
   {"setpgid", posix_setpgid, METH_VARARGS},

--- a/pyext/posix_test.py
+++ b/pyext/posix_test.py
@@ -175,6 +175,9 @@ class PosixTest(unittest.TestCase):
       print('x'*65537, file=f)
       log('2: done')
 
+  def testSystem(self):
+    posix_.system("uname -a")
+
 
 def _Handler(x, y):
   log('Got signal %s %s', x, y)

--- a/pyext/posixmodule.c
+++ b/pyext/posixmodule.c
@@ -2398,6 +2398,22 @@ posix_strerror(PyObject *self, PyObject *args)
     return PyString_FromString(message);
 }
 
+#ifdef HAVE_STDLIB_H
+
+#include <stdlib.h>
+
+PyDoc_STRVAR_remove(posix_system__doc__,
+"system(command)\n\n\
+Execute the command (a string) in a subshell.");
+
+static PyObject *
+posix_system(PyObject *self, PyObject *args)
+{
+    return posix_1str(args, "et:system", system);
+}
+
+#endif /* HAVE_STDLIB_H */
+
 
 #ifdef HAVE_SYS_WAIT_H
 


### PR DESCRIPTION
`core/main_loop.py` uses this [here](https://github.com/oilshell/oil/blob/master/core/main_loop.py#L102). If we add `system()` to `posix_` we can use it instead of `os.system()`. Then we can add a specialization to `cpp/stdlib` to translate the main loop stuff.

Does this seem reasonable?