### PR TITLE
[mycpp] emit code for generators

### DIFF
--- a/mycpp/cppgen_pass.py
+++ b/mycpp/cppgen_pass.py
@@ -276,7 +276,8 @@ def get_c_type(t, param=False, local=False):
 
 def get_c_return_type(t) -> Tuple[str, bool, Optional[str]]:
   """
-  Returns a C string, and whether the tuple-by-value optimization was applied
+  Returns a C string, whether the tuple-by-value optimization was applied, and
+  the C type of an extra output param if the function is a generator.
   """
 
   c_ret_type = get_c_type(t)
@@ -563,11 +564,11 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
       # a) accumulating the output of an iterator
       # b) constructing an iterator with the result of (a)
       if self.current_stmt_node in self.yield_accumulators:
-          if len(o.args) > 0:
-            self.write(', ')
+        if len(o.args) > 0:
+          self.write(', ')
 
-          arg_name, _ = self.yield_accumulators[self.current_stmt_node]
-          self.write('&%s', arg_name)
+        arg_name, _ = self.yield_accumulators[self.current_stmt_node]
+        self.write('&%s', arg_name)
 
       self.write(')')
 
@@ -726,7 +727,7 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
 
         if isinstance(o.callee, MemberExpr) and callee_name == 'next':
           self.accept(o.callee.expr)
-          self.write('.NextValue')
+          self.write('.iterNext')
           self._WriteArgList(o)
           return
 

--- a/mycpp/examples/iterators.py
+++ b/mycpp/examples/iterators.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python2
+"""
+iterators.py: Simple iterators
+"""
+from __future__ import print_function
+
+import os
+
+from mycpp import mylib
+from mycpp.mylib import log, iteritems
+
+from typing import Iterator, Tuple
+
+
+def g(n):
+  # type: (int) -> Iterator[Tuple[int, str]]
+  for i in f(n):
+    yield (i, '2 * %d = %d' % (i, 2*i))
+
+
+def f(n):
+  # type: (int) -> Iterator[int]
+  for i in xrange(0, n):
+    yield i
+
+
+class Foo(object):
+
+  def __init__(self):
+    # type: () -> None
+    pass
+
+  def bar(self, n):
+    # type: (int) -> Iterator[int]
+    for i in xrange(0, n):
+      yield i
+
+  def baz(self, n):
+    # type: (int) -> Iterator[Tuple[int, str]]
+    for i in g(n):
+      yield i
+
+
+def run_tests():
+  # type: () -> None
+  log('--- simple iterators')
+  for i in f(3):
+    log("f() gave %d", i)
+
+  foo = Foo()
+  for i in foo.bar(4):
+    log("Foo.bar() gave %d", i)
+
+  log('--- nested iterators')
+  for i, s in g(3):
+    log("g() gave (%d, %r)", i, s)
+
+  for i, s in foo.baz(3):
+    log("Foo.baz() gave (%d, %r)", i, s)
+
+  for i in f(3):
+    for j in f(3):
+      log("f() gave %d, %d", i, j)
+
+  log('--- iterator assignment')
+  it_f = f(5)
+  while True:
+    try:
+      log("next(f()) gave %d", it_f.next())
+    except StopIteration:
+      break
+
+  it_g = g(5)
+  while True:
+    try:
+      i, s = it_g.next()
+      log("next(g()) gave (%d, %r)", i, s)
+    except StopIteration:
+      break
+
+
+def run_benchmarks():
+  # type: () -> None
+  pass
+
+
+if __name__ == '__main__':
+  if os.getenv('BENCHMARK'):
+    log('Benchmarking...')
+    run_benchmarks()
+  else:
+    run_tests()

--- a/mycpp/examples/iterators.py
+++ b/mycpp/examples/iterators.py
@@ -37,8 +37,12 @@ class Foo(object):
 
   def baz(self, n):
     # type: (int) -> Iterator[Tuple[int, str]]
-    for i in g(n):
-      yield i
+    it_g = g(n)
+    while True:
+      try:
+        yield it_g.next()
+      except StopIteration:
+        break
 
 
 def run_tests():

--- a/mycpp/gc_builtins.h
+++ b/mycpp/gc_builtins.h
@@ -28,6 +28,8 @@ class EOFError : public _ExceptionOpaque {};
 
 class KeyboardInterrupt : public _ExceptionOpaque {};
 
+class StopIteration : public _ExceptionOpaque {};
+
 class ValueError {
  public:
   ValueError()

--- a/mycpp/gc_list.h
+++ b/mycpp/gc_list.h
@@ -434,7 +434,7 @@ class ListIter {
   T Value() {
     return L_->slab_->items_[i_];
   }
-  T NextValue() {
+  T iterNext() {
     if (Done()) {
       throw Alloc<StopIteration>();
     }

--- a/mycpp/gc_list.h
+++ b/mycpp/gc_list.h
@@ -434,6 +434,14 @@ class ListIter {
   T Value() {
     return L_->slab_->items_[i_];
   }
+  T NextValue() {
+    if (Done()) {
+      throw Alloc<StopIteration>();
+    }
+    T ret = L_->slab_->items_[i_];
+    Next();
+    return ret;
+  }
 
  private:
   List<T>* L_;


### PR DESCRIPTION
This commit is a first attempt at translating generator functions. If mycpp sees a function that returns `typing.Iterator[T]` it will generate a C++ function with a type signature that differs in the following ways:

  1) it returns `void` instead of `Iterator[T]`
  2) it has an extra ouput param of type `List<T>*`

The defintion of the function emitted by mycpp will be identical to its pythonic ancestor, except all `yield ...` statements will be translated into calls to `append(...)` on the output param from (2).

At the call sites for the function mycpp will allocate a temporary `List<T>` on the stack and pass it as an ouput param to the modified function as an accumulator the generator's output, which will be computed in one big batch. All subsequent statements that refer to the generator will operate, unmodified, on an `ListIter<T>` that wraps the accumulator.

This approach described by @andychu here:
https://oilshell.zulipchat.com/#narrow/stream/121539-oil-dev/topic/Solutions.20to.20yield.20problem/near/316873052