### PR TITLE
[translation] make iterator state in ReadlineCallback translatable

### DIFF
--- a/mycpp/examples/iterators.py
+++ b/mycpp/examples/iterators.py
@@ -82,6 +82,11 @@ def run_tests():
     except StopIteration:
       break
 
+  it = f(5)
+  l = list(it)
+  for i, x in enumerate(l):
+    log("l[%d] = %d", i, x)
+
 
 def run_benchmarks():
   # type: () -> None

--- a/mycpp/gc_list.h
+++ b/mycpp/gc_list.h
@@ -434,10 +434,19 @@ class ListIter {
     return ret;
   }
 
+  // only for use with generators
+  List<T>* GetList() { return L_; }
+
  private:
   List<T>* L_;
   int i_;
 };
+
+// list(it) returns the iterator's backing list
+template <typename T>
+List<T>* list(ListIter<T> it) {
+  return list(it.GetList());
+}
 
 // TODO: Does using pointers rather than indices make this more efficient?
 template <class T>

--- a/mycpp/gc_list_test.cc
+++ b/mycpp/gc_list_test.cc
@@ -247,6 +247,14 @@ TEST test_list_iters() {
     log("x = %d", x);
   }
 
+  {
+    ListIter<int> it(ints);
+    auto ints2 = list(it);
+    ASSERT_EQ(ints->index_(0), ints2->index_(0));
+    ASSERT_EQ(ints->index_(1), ints2->index_(1));
+    ASSERT_EQ(ints->index_(2), ints2->index_(2));
+  }
+
   log("  backward iteration over list");
   for (ReverseListIter<int> it(ints); !it.Done(); it.Next()) {
     int x = it.Value();


### PR DESCRIPTION
This is the last non-mechanical thing we need to figure out before completion can be made translatable.