### PR TITLE
[osh] replace print in compgen builtin

### DIFF
--- a/osh/builtin_comp.py
+++ b/osh/builtin_comp.py
@@ -332,9 +332,10 @@ class CompGen(vm._Builtin):
     comp = completion.Api('', 0, 0)
     comp.Update('compgen', to_complete, '', -1, None)
     try:
+      f = mylib.Stdout()
       for m, _ in user_spec.Matches(comp):
         matched = True
-        print(m)
+        f.write(m + '\n')
     except error.FatalRuntime:
       # - DynamicWordsAction: We already printed an error, so return failure.
       return 1


### PR DESCRIPTION
For some reason mycpp removes calls to `print` in this file.

This fix reduces the `spec/builtin-completion` delta to 3 (with c++ passing some tests that python doesn't...)!