### PR TITLE
[cpp] set rl_completion_append_character to NUL

### DIFF
--- a/cpp/frontend_pyreadline.cc
+++ b/cpp/frontend_pyreadline.cc
@@ -34,6 +34,7 @@ static char* do_complete(const char* text, int state) {
 }
 
 static char** completion_handler(const char* text, int start, int end) {
+  rl_completion_append_character = '\0';
   rl_completion_suppress_append = 0;
   gReadline->begidx_ = start;
   gReadline->endidx_ = end;


### PR DESCRIPTION
Else we end up with awkward spaces after <TAB>-completion.