### PR TITLE
[refactor] Type-driven refactoring: remove span_id in PrefixPrint()

### DIFF
--- a/core/executor.py
+++ b/core/executor.py
@@ -139,7 +139,7 @@ class ShellExecutor(vm._Executor):
           if e.span_id == runtime.NO_SPID:
             e.span_id = self.errfmt.CurrentLocation()
           # e.g. 'type' doesn't accept flag '-x'
-          self.errfmt.PrefixPrint(e.msg, prefix='%r ' % arg0, span_id=e.span_id)
+          self.errfmt.PrefixPrint(e.msg, '%r ' % arg0, loc.Span(e.span_id))
           status = 2  # consistent error code for usage error
 
     return status

--- a/core/ui.py
+++ b/core/ui.py
@@ -11,7 +11,7 @@ from __future__ import print_function
 
 from _devbuild.gen.id_kind_asdl import Id, Id_t, Id_str
 from _devbuild.gen.syntax_asdl import (
-    Token, SourceLine, command_t, command_str,
+    loc_t, Token, SourceLine, command_t, command_str,
     source_e, source__Stdin, source__MainFile, source__SourcedFile,
     source__Alias, source__Reparsed, source__Variable, source__VarRef,
     source__ArgvWord, source__Synthetic
@@ -304,9 +304,10 @@ class ErrorFormatter(object):
     else:
       return runtime.NO_SPID
 
-  def PrefixPrint(self, msg, prefix, span_id=runtime.NO_SPID):
-    # type: (str, str, int) -> None
+  def PrefixPrint(self, msg, prefix, blame_loc):
+    # type: (str, str, loc_t) -> None
     """Print a hard-coded message with a prefix, and quote code."""
+    span_id = location.GetSpanId(blame_loc)
     _PrintWithSpanId(prefix, msg, span_id, self.arena, show_code=True)
 
   def Print_(self, msg, span_id=runtime.NO_SPID):

--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -316,7 +316,7 @@ class CommandEvaluator(object):
           arg0 = cmd_val.argv[0]
           if e.span_id == runtime.NO_SPID:  # fill in default location.
             e.span_id = self.errfmt.CurrentLocation()
-          self.errfmt.PrefixPrint(e.msg, prefix='%r ' % arg0, span_id=e.span_id)
+          self.errfmt.PrefixPrint(e.msg, '%r ' % arg0, loc.Span(e.span_id))
           status = 2  # consistent error code for usage error
 
     return status
@@ -1046,7 +1046,7 @@ class CommandEvaluator(object):
           else:
             # Only print warnings, never fatal.
             # Bash oddly only exits 1 for 'return', but no other shell does.
-            self.errfmt.PrefixPrint(msg, prefix='warning: ', span_id=tok.span_id)
+            self.errfmt.PrefixPrint(msg, 'warning: ', tok)
             status = 0
 
       # Note CommandList and DoGroup have no redirects, but BraceGroup does.

--- a/soil/worker.sh
+++ b/soil/worker.sh
@@ -447,8 +447,6 @@ job-main() {
 
   log-context 'job-main'
   mkdir -v -p $out_dir
-
-  set -x
   ls -l -d $out_dir
 
   disable-git-errors


### PR DESCRIPTION
The same can be done for Print_() and PrintMessage(), which now take a span_id, but should take a location.