### PR TITLE
[spec/redirect] Add a test for bash's handling of >&file

### DIFF
--- a/spec/redirect.test.sh
+++ b/spec/redirect.test.sh
@@ -356,31 +356,42 @@ ZZ
 ## END
 
 #### &> redirects stdout and stderr
-stdout_stderr.py &> $TMP/f.txt
+tmp="$(basename $SH)-$$.txt"  # unique name for shell and test case
+#echo $tmp
+
+stdout_stderr.py &> $tmp
+
 # order is indeterminate
-grep STDOUT $TMP/f.txt >/dev/null && echo 'ok'
-grep STDERR $TMP/f.txt >/dev/null && echo 'ok'
+grep STDOUT $tmp
+grep STDERR $tmp
+
 ## STDOUT:
-ok
-ok
+STDOUT
+STDERR
 ## END
 ## N-I dash stdout: STDOUT
 ## N-I dash stderr: STDERR
 ## N-I dash status: 1
 
 #### >&word redirects stdout and stderr when word is not a number or -
+
 # dash, mksh don't implement this bash behaviour.
 case $SH in (dash|mksh) exit 1 ;; esac
-stdout_stderr.py >&$TMP/f.txt
+
+tmp="$(basename $SH)-$$.txt"  # unique name for shell and test case
+
+stdout_stderr.py >&$tmp
+
 # order is indeterminate
-grep STDOUT $TMP/f.txt >/dev/null && echo 'ok'
-grep STDERR $TMP/f.txt >/dev/null && echo 'ok'
+grep STDOUT $tmp
+grep STDERR $tmp
+
 ## STDOUT:
-ok
-ok
+STDOUT
+STDERR
 ## END
-## OK dash/mksh status: 1
-## OK dash/mksh stdout-json: ""
+## N-I dash/mksh status: 1
+## N-I dash/mksh stdout-json: ""
 
 #### 1>&- to close file descriptor
 exec 5> "$TMP/f.txt"

--- a/spec/redirect.test.sh
+++ b/spec/redirect.test.sh
@@ -368,6 +368,20 @@ ok
 ## N-I dash stderr: STDERR
 ## N-I dash status: 1
 
+#### >&word redirects stdout and stderr when word is not a number or -
+# dash, mksh don't implement this bash behaviour.
+case $SH in (dash|mksh) exit 1 ;; esac
+stdout_stderr.py >&$TMP/f.txt
+# order is indeterminate
+grep STDOUT $TMP/f.txt >/dev/null && echo 'ok'
+grep STDERR $TMP/f.txt >/dev/null && echo 'ok'
+## STDOUT:
+ok
+ok
+## END
+## OK dash/mksh status: 1
+## OK dash/mksh stdout-json: ""
+
 #### 1>&- to close file descriptor
 exec 5> "$TMP/f.txt"
 echo hello >&5

--- a/test/spec.sh
+++ b/test/spec.sh
@@ -544,7 +544,7 @@ here-doc() {
 }
 
 redirect() {
-  sh-spec spec/redirect.test.sh --osh-failures-allowed 1 \
+  sh-spec spec/redirect.test.sh --osh-failures-allowed 2 \
     ${REF_SHELLS[@]} $OSH_LIST "$@"
 }
 


### PR DESCRIPTION
Add a spec test for this bash only behaviour. From the man page:
```
There are two formats for redirecting standard output and standard error:
    &>word
and
    >&word
```

Should osh be matching this behaviour do you think? It's in ubuntu's default bashrc (which is how I came across this):
```
λ grep '>&' /etc/skel/.bashrc
    if [ -x /usr/bin/tput ] && tput setaf 1 >&/dev/null; then
```

