### PR TITLE
[mycpp/runtime] Move string length out of object header

### DIFF
--- a/benchmarks/compute.sh
+++ b/benchmarks/compute.sh
@@ -310,7 +310,7 @@ task-all() {
     case $task_name in
       (hello|fib)
         # Run it DIRECTLY, do not run $0.  Because we do NOT want to fork bash
-        # than dash, because bash uses more memory.
+        # then dash, because bash uses more memory.
         cmd=($runtime benchmarks/compute/$task_name.$(ext $runtime) "$arg1" "$arg2")
         ;;
       (*)
@@ -382,6 +382,7 @@ measure() {
 
   mkdir -p $BASE_DIR/{tmp,raw,stage1} $out_dir
 
+  # set -x
   hello-all $provenance $host_job_id $out_dir
   fib-all $provenance $host_job_id $out_dir
 

--- a/core/pyos.py
+++ b/core/pyos.py
@@ -364,6 +364,11 @@ class SignalSafe(object):
     self.pending_signals = new_queue
     return ret
 
+  def ReuseEmptyList(self, empty_list):
+    # type: (List[int]) -> None
+    """This optimization only happens in C++."""
+    pass
+
 
 gSignalSafe = None  #  type: SignalSafe
 

--- a/cpp/core.h
+++ b/cpp/core.h
@@ -196,7 +196,8 @@ class SignalSafe {
   }
 
   static constexpr uint16_t field_mask() {
-    return maskbit(offsetof(SignalSafe, pending_signals_));
+    return maskbit(offsetof(SignalSafe, pending_signals_)) |
+           maskbit(offsetof(SignalSafe, empty_list_));
   }
 
   GC_OBJ(header_);

--- a/cpp/core.h
+++ b/cpp/core.h
@@ -151,7 +151,7 @@ class SignalSafe {
     List<int>* ret = pending_signals_;
 
     // Make sure we have a distinct list to reuse.
-    DCHECK(empty_list_ != pending_signals_);
+    CHECK(empty_list_ != pending_signals_);
     pending_signals_ = empty_list_;
 
     return ret;
@@ -159,8 +159,8 @@ class SignalSafe {
 
   // Main thread returns the same list as an optimization to avoid allocation.
   void ReuseEmptyList(List<int>* empty_list) {
-    DCHECK(len(empty_list) == 0);            // main thread clears
-    DCHECK(empty_list != pending_signals_);  // must be different
+    CHECK(len(empty_list) == 0);            // main thread clears
+    CHECK(empty_list != pending_signals_);  // must be different
 
     empty_list_ = empty_list;
   }

--- a/cpp/core_test.cc
+++ b/cpp/core_test.cc
@@ -212,6 +212,7 @@ TEST signal_test() {
     List<int>* q = signal_safe->TakePendingSignals();
     ASSERT(q != nullptr);
     ASSERT_EQ(0, len(q));
+    signal_safe->ReuseEmptyList(q);
   }
 
   pid_t mypid = getpid();
@@ -231,6 +232,9 @@ TEST signal_test() {
     ASSERT_EQ(2, len(q));
     ASSERT_EQ(SIGUSR1, q->index_(0));
     ASSERT_EQ(SIGUSR2, q->index_(1));
+
+    q->clear();
+    signal_safe->ReuseEmptyList(q);
   }
 
   pyos::Sigaction(SIGUSR1, SIG_IGN);
@@ -239,6 +243,7 @@ TEST signal_test() {
     List<int>* q = signal_safe->TakePendingSignals();
     ASSERT(q != nullptr);
     ASSERT(len(q) == 0);
+    signal_safe->ReuseEmptyList(q);
   }
   pyos::Sigaction(SIGUSR2, SIG_IGN);
 

--- a/cpp/data_race_test.cc
+++ b/cpp/data_race_test.cc
@@ -88,7 +88,13 @@ TEST take_pending_signals_test() {
 
   // Concurrent access in main thread
   List<int>* received = signal_safe.TakePendingSignals();
-  log("received %d signals", len(received));
+  log("(1) received %d signals", len(received));
+
+  received->clear();
+  signal_safe.ReuseEmptyList(received);
+
+  received = signal_safe.TakePendingSignals();
+  log("(2) received %d signals", len(received));
 
   pthread_join(t, 0);
 


### PR DESCRIPTION
Making room for a bigger 30-bit object ID

To avoid bloating metrics, we're using the unused hash value field for now.

Remove the #ifdef for Cheney heap.  It seems unlikely we'll use it, so let's keep the code simple.