### PR TITLE
Add usage info to test/spec.sh

### DIFF
--- a/test/spec.sh
+++ b/test/spec.sh
@@ -1156,4 +1156,29 @@ one-off() {
   test/spec.sh builtin-vars -r 39-40
 }
 
-"$@"
+# List all functions defined in this file (and not in sourced files).
+_list-funcs() {
+    local funcs=($(compgen -A function))
+    # extdebug makes `declare -F` print the file path, but, annoyingly, only
+    # if you pass the function names as arguments.
+    shopt -s extdebug
+    declare -F "${funcs[@]}" | grep --fixed-strings " $0" | awk '{print $1}'
+}
+
+main() {
+  if [[ $# -eq 0 || $1 =~ ^(--help|-h)$ ]]; then
+      echo "Usage: $0 <function> [<args>]"
+      echo
+      echo "For bash completion of available functions, run:"
+      echo "   source devtools/completion.bash"
+      echo
+      echo "For more help try passing --help, e.g.,"
+      echo "   $0 alias --help"
+      echo
+      echo "Available functions:"
+      _list-funcs | column
+  fi
+  "$@"
+}
+
+main "$@"

--- a/test/spec.sh
+++ b/test/spec.sh
@@ -1177,6 +1177,7 @@ main() {
       echo
       echo "Available functions:"
       _list-funcs | column
+      exit
   fi
   "$@"
 }


### PR DESCRIPTION
Make test/spec.sh slightly friendlier/discoverable by listing available functions/subcommands when invoked with -h/--help or no args.

This uses a simplistic method to list the functions which has problems (main is listed, for example) but it's a good start and goes most of the way to making it more usable for new contributors.

Here's the output (with a wide terminal):

```
λ test/spec.sh --help
Usage: test/spec.sh <function> [<args>]

For bash completion of available functions, run:
   source devtools/completion.bash

For more help try passing --help, e.g.,
   test/spec.sh alias --help

Available functions:
TODO-deprecate                  builtin-vars                    loop                            oil-options                     sh-spec-smoosh-env
_list-funcs                     builtins                        main                            oil-options-assign              sh-usage
_one-html                       builtins2                       maybe-show                      oil-proc                        shell-grammar
alias                           case_                           nameref                         oil-regex                       smoke
all-and-smoosh                  check-survey-shells             nix-idioms                      oil-reserved                    smoosh
append                          command-parsing                 nocasematch-match               oil-scope                       smoosh-hang
arith                           command-sub                     nul-bytes                       oil-slice-range                 smoosh-hang-html
arith-context                   command_                        oil-all                         oil-special-vars                smoosh-html
array                           comments                        oil-all-serial                  oil-string                      soil-run-osh
array-compat                    dbg                             oil-array                       oil-tuple                       strict-options
assign                          dbg-all                         oil-assign                      oil-usage                       subshell
assign-deferred                 dbracket                        oil-bin                         oil-user-feedback               tea-all
assign-dialects                 dparen                          oil-blocks                      oil-var-sub                     tea-all-serial
assign-extended                 empty-bodies                    oil-bugs                        oil-version-text                tea-func
assoc                           errexit                         oil-builtin-argparse            oil-with-sh                     tea-version-text
assoc-zsh                       errexit-oil                     oil-builtin-describe            oil-word-eval                   tilde
background                      exit-status                     oil-builtin-error               oil-xtrace                      toysh
ble-features                    explore-parsing                 oil-builtin-pp                  one-off                         toysh-posix
ble-idioms                      extglob-files                   oil-builtin-process             osh-all                         trace-var-sub
blog-other1                     extglob-match                   oil-builtin-shopt               osh-all-serial                  type-compat
blog1                           fatal-errors                    oil-builtins                    osh-minimal                     var-num
blog2                           for-expr                        oil-case                        osh-minimal-version-text        var-op-bash
brace-expansion                 func-parsing                    oil-command-sub                 osh-only                        var-op-len
bugs                            glob                            oil-demo                        osh-version-text                var-op-patsub
builtin-bash                    hay                             oil-expr                        parse-errors                    var-op-slice
builtin-bracket                 hay-isolation                   oil-expr-arith                  pipeline                        var-op-strip
builtin-completion              hay-meta                        oil-expr-compare                posix                           var-op-test
builtin-dirs                    here-doc                        oil-expr-sub                    process-sub                     var-ref
builtin-eval-source             html-demo                       oil-for                         prompt                          var-sub
builtin-getopts                 if_                             oil-funcs-builtin               quote                           var-sub-quote
builtin-io                      install-shells-with-apt         oil-funcs-external              redirect                        vars-bash
builtin-printf                  interactive                     oil-interactive                 regex                           vars-special
builtin-special                 introspect                      oil-json                        serialize                       word-eval
builtin-times                   let                             oil-keywords                    sh-func                         word-split
builtin-trap                    link-busybox-ash                oil-multiline                   sh-options                      xtrace


```