### PR TITLE
try removing invalid setlocale()

### DIFF
--- a/core/completion.py
+++ b/core/completion.py
@@ -86,7 +86,7 @@ if TYPE_CHECKING:
 #   ~    in filenames should be quoted
 #
 # TODO: Also escape tabs as \t and newlines at \n?
-SHELL_META_CHARS = r' ~`!$&|;()\"*?[]{}<>' + "'"
+# SHELL_META_CHARS = r' ~`!$&|;()\"*?[]{}<>' + "'"
 
 
 

--- a/soil/worker.sh
+++ b/soil/worker.sh
@@ -211,9 +211,10 @@ build-minimal    build/py.sh minimal                   -
 ninja-config     soil/worker.sh ninja-config           -
 cpp-unit         test/cpp-unit.sh soil-run             _test/cpp-unit.html
 oils-cpp-smoke   build/native.sh oils-cpp-smoke        -
+asan             test/asan.sh soil-run                 -
 line-counts      metrics/source-code.sh write-reports  _tmp/metrics/line-counts/index.html
 preprocessed     metrics/source-code.sh preprocessed   _tmp/metrics/preprocessed/index.html
-native-code      metrics/native-code.sh oils-for-unix     _tmp/metrics/oils-for-unix/index.html
+native-code      metrics/native-code.sh oils-for-unix  _tmp/metrics/oils-for-unix/index.html
 mycpp-examples   mycpp/TEST.sh soil-run                _test/mycpp-examples.html
 parse-errors     test/parse-errors.sh soil-run-cpp     -
 make-tar         devtools/release-native.sh make-tar   _release/oils-for-unix.tar

--- a/test/asan.sh
+++ b/test/asan.sh
@@ -9,13 +9,13 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-# TODO: Make this pass!
-test-gc-cleanup() {
+# Check that we don't have any leaks!
+soil-run() {
   ninja _bin/cxx-asan/osh
 
   OIL_GC_ON_EXIT=1 _bin/cxx-asan/osh --version
 
-  #_bin/cxx-asan/osh -c 'echo hi'
+  OIL_GC_ON_EXIT=1 _bin/cxx-asan/osh -c 'echo hi'
 }
 
 "$@"

--- a/test/spec-cpp.sh
+++ b/test/spec-cpp.sh
@@ -63,7 +63,8 @@ run-file() {
       shells=( "${COMPARE_CPP_SHELLS[@]}" )
       ;;
     *)
-      shells=( $REPO_ROOT/bin/osh $REPO_ROOT/_bin/cxx-dbg/osh )
+      shells=( "${COMPARE_CPP_SHELLS[@]}" )
+      #shells=( $REPO_ROOT/bin/osh $REPO_ROOT/_bin/cxx-dbg/osh )
       ;;
   esac
 


### PR DESCRIPTION
Why did we have this in  the first place?

It came from this commit
https://github.com/oilshell/oil/commit/70447cd2b09176075fc679954592a37ef67f0579

But I see no reason

var-op-patsub still has 2 failures either way

It doesn't have coverage?