### PR TITLE
Move clang-format config to .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,12 @@
+BasedOnStyle: Google
+# We have a lot of switch statements, and the extra indent doesn't help.
+IndentCaseLabels: false
+# I like consistent Python-style functions and blocks, e.g. not if (x) return
+AllowShortFunctionsOnASingleLine: None
+AllowShortBlocksOnASingleLine: false
+IndentPPDirectives: BeforeHash
+
+# Does not do what I want
+# TypenameMacros: ["SUM", "VARIANT"]
+WhitespaceSensitiveMacros: ["SUM", "VARIANT", "SCHEMA"]
+TypenameMacros: ["SUM_NS", "PROD"]

--- a/test/lint.sh
+++ b/test/lint.sh
@@ -29,22 +29,8 @@ cpplint() {
 }
 
 clang-format() {
-  # I like consistent Python-style functions and blocks, e.g. not if (x) return
-  local style='{
-      BasedOnStyle: Google,
-      IndentCaseLabels: false,
-      AllowShortFunctionsOnASingleLine: None,
-      AllowShortBlocksOnASingleLine: false,
-      IndentPPDirectives: BeforeHash,
-
-      # Does not do what I want
-      # TypenameMacros: ["SUM", "VARIANT"]
-      WhitespaceSensitiveMacros: ["SUM", "VARIANT", "SCHEMA"]
-      TypenameMacros: ["SUM_NS", "PROD"]
-    }
-  '
-  # We have a lot of switch statements, and the extra indent doesn't help.
-  $CLANG_DIR/bin/clang-format -style="$style" "$@"
+  # See //.clang-format for the style config.
+  $CLANG_DIR/bin/clang-format --style=file "$@"
 }
 
 readonly -a CPP_FILES=(


### PR DESCRIPTION
This makes it easier to use clang-format in other ways (e.g., `git clang-format`) or via an editor. 