### PR TITLE
Refactor GC object header initialization

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,12 @@
+BasedOnStyle: Google
+# We have a lot of switch statements, and the extra indent doesn't help.
+IndentCaseLabels: false
+# I like consistent Python-style functions and blocks, e.g. not if (x) return
+AllowShortFunctionsOnASingleLine: None
+AllowShortBlocksOnASingleLine: false
+IndentPPDirectives: BeforeHash
+
+# Does not do what I want
+# TypenameMacros: ["SUM", "VARIANT"]
+WhitespaceSensitiveMacros: ["SUM", "VARIANT", "SCHEMA"]
+TypenameMacros: ["SUM_NS", "PROD"]

--- a/asdl/gen_cpp.py
+++ b/asdl/gen_cpp.py
@@ -383,7 +383,6 @@ class ClassDefVisitor(visitor.AsdlVisitor):
     all_fields = managed_fields + unmanaged_fields
 
     line_break = '\n' + ' ' * 22  # wrapping/indent determined manually
-    header_init = 'GC_ASDL_CLASS(header_, %s, %d)' % (tag, len(managed_fields))
 
     def FieldInitJoin(strs):
       # reflow doesn't work well here, so do it manually
@@ -391,6 +390,7 @@ class ClassDefVisitor(visitor.AsdlVisitor):
 
     params = []
     # All product types and variants have a tag
+    header_init = 'header_(obj_header())'
     inits = [header_init]
 
     # Ensure that the constructor params are listed in the same order as the
@@ -429,6 +429,11 @@ class ClassDefVisitor(visitor.AsdlVisitor):
       for abbrev in PRETTY_METHODS:
         self.Emit('  hnode_t* %s();' % abbrev, depth)
       self.Emit('')
+
+    self.Emit('  static constexpr ObjHeader obj_header() {')
+    self.Emit('    return ObjHeader::AsdlClass(%s, %d);' % (tag, len(managed_fields)))
+    self.Emit('  }')
+    self.Emit('')
 
     #
     # Members

--- a/core/optview_gen.py
+++ b/core/optview_gen.py
@@ -33,7 +33,7 @@ using option_asdl::option_i;
 class _View {
  public:
   _View(List<bool>* opt0_array, List<List<bool>*>* opt_stacks)
-      : GC_CLASS_FIXED(header_, field_mask(), sizeof(_View)),
+      : header_(obj_header()),
         opt0_array(opt0_array), opt_stacks(opt_stacks) {
   }
 
@@ -44,6 +44,10 @@ class _View {
     } else {
       return overlay->index_(-1);
     }
+  }
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(field_mask(), sizeof(_View));
   }
 
   GC_OBJ(header_);

--- a/cpp/core.h
+++ b/cpp/core.h
@@ -46,9 +46,11 @@ Str* GetHomeDir(Str* user_name);
 
 class ReadError {
  public:
-  explicit ReadError(int err_num_)
-      : GC_CLASS_FIXED(header_, kZeroMask, sizeof(ReadError)),
-        err_num(err_num_) {
+  explicit ReadError(int err_num_) : header_(obj_header()), err_num(err_num_) {
+  }
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(ReadError));
   }
 
   GC_OBJ(header_);
@@ -58,10 +60,14 @@ class ReadError {
 class PasswdEntry {
  public:
   explicit PasswdEntry(const passwd* entry)
-      : GC_CLASS_FIXED(header_, field_mask(), sizeof(PasswdEntry)),
+      : header_(obj_header()),
         pw_name(StrFromC(entry->pw_name)),
         pw_uid(entry->pw_uid),
         pw_gid(entry->pw_gid) {
+  }
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(field_mask(), sizeof(PasswdEntry));
   }
 
   GC_OBJ(header_);
@@ -109,7 +115,7 @@ class SignalSafe {
   // State that is shared between the main thread and signal handlers.
  public:
   SignalSafe()
-      : GC_CLASS_FIXED(header_, field_mask(), sizeof(SignalSafe)),
+      : header_(obj_header()),
         pending_signals_(AllocSignalList()),
         empty_list_(AllocSignalList()),  // to avoid repeated allocation
         last_sig_num_(0),
@@ -201,6 +207,10 @@ class SignalSafe {
            maskbit(offsetof(SignalSafe, empty_list_));
   }
 
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(field_mask(), sizeof(SignalSafe));
+  }
+
   GC_OBJ(header_);
   List<int>* pending_signals_;  // public for testing
   List<int>* empty_list_;
@@ -248,11 +258,14 @@ Str* ChArrayToString(List<int>* ch_array);
 
 class _ResourceLoader {
  public:
-  _ResourceLoader()
-      : GC_CLASS_FIXED(header_, kZeroMask, sizeof(_ResourceLoader)) {
+  _ResourceLoader() : header_(obj_header()) {
   }
 
   virtual Str* Get(Str* path);
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(_ResourceLoader));
+  }
 
   GC_OBJ(header_);
 };

--- a/cpp/frontend_flag_spec.h
+++ b/cpp/frontend_flag_spec.h
@@ -85,12 +85,16 @@ namespace flag_spec {
 class _FlagSpec {
  public:
   _FlagSpec()
-      : GC_CLASS_FIXED(header_, field_mask(), sizeof(_FlagSpec)),
+      : header_(obj_header()),
         arity0(nullptr),
         arity1(nullptr),
         plus_flags(nullptr),
         actions_long(nullptr),
         defaults(nullptr) {
+  }
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(field_mask(), sizeof(_FlagSpec));
   }
 
   GC_OBJ(header_);
@@ -112,11 +116,15 @@ class _FlagSpec {
 class _FlagSpecAndMore {
  public:
   _FlagSpecAndMore()
-      : GC_CLASS_FIXED(header_, field_mask(), sizeof(_FlagSpecAndMore)),
+      : header_(obj_header()),
         actions_long(nullptr),
         actions_short(nullptr),
         plus_flags(nullptr),
         defaults(nullptr) {
+  }
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(field_mask(), sizeof(_FlagSpecAndMore));
   }
 
   GC_OBJ(header_);

--- a/cpp/frontend_match.h
+++ b/cpp/frontend_match.h
@@ -24,14 +24,15 @@ typedef void (*MatchFunc)(const unsigned char* line, int line_len,
 class SimpleLexer {
  public:
   SimpleLexer(MatchFunc match_func, Str* s)
-      : GC_CLASS_FIXED(header_, field_mask(), sizeof(SimpleLexer)),
-        match_func_(match_func),
-        s_(s),
-        pos_(0) {
+      : header_(obj_header()), match_func_(match_func), s_(s), pos_(0) {
   }
 
   Tuple2<Id_t, Str*> Next();
   List<Tuple2<Id_t, Str*>*>* Tokens();
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(field_mask(), sizeof(SimpleLexer));
+  }
 
   static constexpr uint16_t field_mask() {
     return maskbit(offsetof(SimpleLexer, s_));

--- a/cpp/frontend_pyreadline.cc
+++ b/cpp/frontend_pyreadline.cc
@@ -65,7 +65,7 @@ static void display_matches_hook(char** matches, int num_matches,
 #endif
 
 Readline::Readline()
-    : GC_CLASS_FIXED(header_, Readline::field_mask(), sizeof(Readline)),
+    : header_(obj_header()),
       begidx_(),
       endidx_(),
       completer_delims_(StrFromC(" \t\n`~!@#$%^&*()-=+[{]}\\|;:'\",<>/?")),

--- a/cpp/frontend_pyreadline.h
+++ b/cpp/frontend_pyreadline.h
@@ -39,12 +39,17 @@ class Readline {
   int get_current_history_length();
   void resize_terminal();
 
-  GC_OBJ(header_);
   static constexpr uint16_t field_mask() {
     return maskbit(offsetof(Readline, completer_delims_)) |
            maskbit(offsetof(Readline, completer_)) |
            maskbit(offsetof(Readline, display_));
   }
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(field_mask(), sizeof(Readline));
+  }
+
+  GC_OBJ(header_);
 
   int begidx_;
   int endidx_;

--- a/cpp/osh_tdop.h
+++ b/cpp/osh_tdop.h
@@ -35,12 +35,16 @@ struct NullInfo {
 class ParserSpec {
  public:
   // No fields
-  ParserSpec() : GC_CLASS_FIXED(header_, kZeroMask, sizeof(ParserSpec)) {
+  ParserSpec() : header_(obj_header()) {
   }
   LeftInfo* LookupLed(Id_t id);
   NullInfo* LookupNud(Id_t id);
 
   DISALLOW_COPY_AND_ASSIGN(ParserSpec)
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(ParserSpec));
+  }
 
   GC_OBJ(header_);
 };

--- a/frontend/flag_gen.py
+++ b/frontend/flag_gen.py
@@ -260,8 +260,8 @@ attrs->index_(StrFromC("%s"))->tag_() == value_e::Undef
 class %s {
  public:
   %s(Dict<Str*, runtime_asdl::value_t*>* attrs)
-      : GC_CLASS(header_, %s, %s, sizeof(%s)),
-""" % (spec_name, spec_name, obj_tag, mask_str, spec_name))
+      : header_(obj_header()),
+""" % (spec_name, spec_name))
 
     for i, field_name in enumerate(field_names):
       if i != 0:
@@ -274,6 +274,11 @@ class %s {
     header_f.write('  GC_OBJ(header_);\n')
     for decl in field_decls:
       header_f.write('  %s\n' % decl)
+
+    header_f.write('\n')
+    header_f.write('  static constexpr ObjHeader obj_header() {\n')
+    header_f.write('    return ObjHeader::Class(%s, %s, sizeof(%s));\n' % (obj_tag, mask_str, spec_name))
+    header_f.write('  }\n')
 
     if bits:
       header_f.write('\n')

--- a/mycpp/demo/gc_header.cc
+++ b/mycpp/demo/gc_header.cc
@@ -86,11 +86,15 @@ TEST gc_header_test() {
 
 class Node {
  public:
-  Node() : GC_CLASS_FIXED(header_, field_mask(), sizeof(Node)) {
+  Node() : header_(obj_header()) {
   }
 
   virtual int Method() {
     return 42;
+  }
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(field_mask(), sizeof(Node));
   }
 
   GC_OBJ(header_);
@@ -120,7 +124,11 @@ class Derived : public Node {
 
 class NoVirtual {
  public:
-  NoVirtual() : GC_CLASS_FIXED(header_, field_mask(), sizeof(NoVirtual)) {
+  NoVirtual() : header_(obj_header()) {
+  }
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(field_mask(), sizeof(NoVirtual));
   }
 
   GC_OBJ(header_);

--- a/mycpp/demo/target_lang.cc
+++ b/mycpp/demo/target_lang.cc
@@ -544,7 +544,10 @@ TEST field_mask_demo() {
 
 class Base {
  public:
-  Base(int i) : GC_CLASS_FIXED(header_, kZeroMask, kNoObjLen), i(i) {
+  Base(int i) : header_(obj_header()), i(i) {
+  }
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(Base));
   }
   GC_OBJ(header_);
   int i;

--- a/mycpp/gc_builtins.h
+++ b/mycpp/gc_builtins.h
@@ -14,9 +14,12 @@ class Str;
 
 class _ExceptionOpaque {
  public:
-  _ExceptionOpaque()
-      : GC_CLASS_FIXED(header_, kZeroMask, sizeof(_ExceptionOpaque)) {
+  _ExceptionOpaque() : header_(obj_header()) {
   }
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(_ExceptionOpaque));
+  }
+
   GC_OBJ(header_);
 };
 
@@ -35,13 +38,13 @@ class StopIteration : public _ExceptionOpaque {};
 
 class ValueError {
  public:
-  ValueError()
-      : GC_CLASS_FIXED(header_, field_mask(), sizeof(ValueError)),
-        message(nullptr) {
+  ValueError() : header_(obj_header()), message(nullptr) {
   }
-  explicit ValueError(Str* message)
-      : GC_CLASS_FIXED(header_, field_mask(), sizeof(ValueError)),
-        message(message) {
+  explicit ValueError(Str* message) : header_(obj_header()), message(message) {
+  }
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(field_mask(), sizeof(ValueError));
   }
 
   GC_OBJ(header_);
@@ -60,8 +63,11 @@ class ValueError {
 class RuntimeError {
  public:
   explicit RuntimeError(Str* message)
-      : GC_CLASS_FIXED(header_, field_mask(), sizeof(RuntimeError)),
-        message(message) {
+      : header_(obj_header()), message(message) {
+  }
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(field_mask(), sizeof(RuntimeError));
   }
 
   GC_OBJ(header_);

--- a/mycpp/gc_dict.h
+++ b/mycpp/gc_dict.h
@@ -44,7 +44,7 @@ class Dict {
 
  public:
   Dict()
-      : GC_CLASS_FIXED(header_, field_mask(), sizeof(Dict)),
+      : header_(obj_header()),
         len_(0),
         capacity_(0),
         entry_(nullptr),
@@ -53,7 +53,7 @@ class Dict {
   }
 
   Dict(std::initializer_list<K> keys, std::initializer_list<V> values)
-      : GC_CLASS_FIXED(header_, field_mask(), sizeof(Dict)),
+      : header_(obj_header()),
         len_(0),
         capacity_(0),
         entry_(nullptr),
@@ -107,6 +107,10 @@ class Dict {
   //   - SetAndIntern<V>(D, &string_key, value)
   //   This will enable duplicate copies of the string to be garbage collected
   int position_of_key(K key);
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(field_mask(), sizeof(Dict));
+  }
 
   GC_OBJ(header_);
   int len_;       // number of entries (keys and values, almost dense)

--- a/mycpp/gc_heap_test.cc
+++ b/mycpp/gc_heap_test.cc
@@ -115,12 +115,16 @@ TEST roundup_test() {
 
 class Point {
  public:
-  Point(int x, int y)
-      : GC_CLASS_FIXED(header_, kZeroMask, sizeof(Point)), x_(x), y_(y) {
+  Point(int x, int y) : header_(obj_header()), x_(x), y_(y) {
   }
   int size() {
     return x_ + y_;
   }
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(Point));
+  }
+
   GC_OBJ(header_);
   int x_;
   int y_;
@@ -130,11 +134,13 @@ const int kLineMask = 0x3;  // 0b0011
 
 class Line {
  public:
-  Line()
-      : GC_CLASS_FIXED(header_, kLineMask, sizeof(Line)),
-        begin_(nullptr),
-        end_(nullptr) {
+  Line() : header_(obj_header()), begin_(nullptr), end_(nullptr) {
   }
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kLineMask, sizeof(Line));
+  }
+
   GC_OBJ(header_);
   Point* begin_;
   Point* end_;
@@ -282,14 +288,17 @@ TEST global_trace_test() {
 // 8 byte vtable, 8 byte ObjHeader, then member_
 class BaseObj {
  public:
-  explicit BaseObj(uint32_t obj_len)
-      : GC_CLASS_FIXED(header_, kZeroMask, obj_len) {
+  explicit BaseObj(uint32_t obj_len) : header_(obj_header(obj_len)) {
   }
   BaseObj() : BaseObj(sizeof(BaseObj)) {
   }
 
   virtual int Method() {
     return 3;
+  }
+
+  static constexpr ObjHeader obj_header(uint32_t obj_len) {
+    return ObjHeader::ClassFixed(kZeroMask, obj_len);
   }
 
   GC_OBJ(header_);

--- a/mycpp/gc_list.h
+++ b/mycpp/gc_list.h
@@ -39,11 +39,7 @@ class List {
                 "An integral number of items should fit in 32 bytes");
 
  public:
-  List()
-      : GC_CLASS_FIXED(header_, field_mask(), sizeof(List<T>)),
-        len_(0),
-        capacity_(0),
-        slab_(nullptr) {
+  List() : header_(obj_header()), len_(0), capacity_(0), slab_(nullptr) {
   }
 
   // Implements L[i]
@@ -87,6 +83,10 @@ class List {
 
   // Extend this list with multiple elements.
   void extend(List<T>* other);
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(field_mask(), sizeof(List<T>));
+  }
 
   GC_OBJ(header_);
 

--- a/mycpp/gc_mylib.h
+++ b/mycpp/gc_mylib.h
@@ -80,11 +80,15 @@ inline Str* octal(int i) {
 class LineReader {
  public:
   // Abstract type with no fields: unknown size
-  LineReader() : GC_CLASS_FIXED(header_, kZeroMask, kNoObjLen) {
+  LineReader() : header_(obj_header()) {
   }
   virtual Str* readline() = 0;
   virtual bool isatty() = 0;
   virtual void close() = 0;
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(LineReader));
+  }
 
   GC_OBJ(header_);
 };
@@ -143,11 +147,15 @@ LineReader* open(Str* path);
 class Writer {
  public:
   // subclasses mutate the mask (and can set obj_len length for Cheney)
-  Writer() : GC_CLASS_FIXED(header_, kZeroMask, kNoObjLen) {
+  Writer() : header_(obj_header()) {
   }
   virtual void write(Str* s) = 0;
   virtual void flush() = 0;
   virtual bool isatty() = 0;
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(Writer));
+  }
 
   GC_OBJ(header_);
 };

--- a/mycpp/gc_obj.h
+++ b/mycpp/gc_obj.h
@@ -76,6 +76,11 @@ struct ObjHeader {
   static constexpr ObjHeader Slab(uint8_t heap_tag, uint32_t num_pointers) {
     return {kIsHeader, TypeTag::Slab, num_pointers, heap_tag, kUndefinedId};
   }
+
+  static constexpr ObjHeader Tuple(uint16_t field_mask, uint32_t obj_len) {
+    return {kIsHeader, TypeTag::Tuple, field_mask, HeapTag::FixedSize,
+            kUndefinedId};
+  }
 };
 
 // TODO: we could determine the max of all objects statically!

--- a/mycpp/gc_obj.h
+++ b/mycpp/gc_obj.h
@@ -75,6 +75,12 @@ struct ObjHeader {
     return {kIsHeader, TypeTag::OtherClass, field_mask, heap_tag, kUndefinedId};
   }
 
+  // Used by ASDL.
+  static constexpr ObjHeader AsdlClass(uint8_t type_tag,
+                                       uint32_t num_pointers) {
+    return {kIsHeader, type_tag, num_pointers, HeapTag::Scanned, kUndefinedId};
+  }
+
   static constexpr ObjHeader Str() {
     return {kIsHeader, TypeTag::Str, kZeroMask, HeapTag::Opaque, kUndefinedId};
   }

--- a/mycpp/gc_obj.h
+++ b/mycpp/gc_obj.h
@@ -55,6 +55,13 @@ struct ObjHeader {
   unsigned heap_tag : 3;     // Cheney also needs HeapTag::Forwarded
   unsigned obj_len : 29;     // Cheney: number of bytes to copy
 #endif
+
+  // Classes with no inheritance (e.g. used by mycpp)
+  static constexpr ObjHeader ClassScanned(uint32_t num_pointers,
+                                          uint32_t obj_len) {
+    return {kIsHeader, TypeTag::OtherClass, num_pointers, HeapTag::Scanned,
+            kUndefinedId};
+  }
 };
 
 // TODO: we could determine the max of all objects statically!

--- a/mycpp/gc_obj.h
+++ b/mycpp/gc_obj.h
@@ -72,6 +72,10 @@ struct ObjHeader {
   static constexpr ObjHeader Str() {
     return {kIsHeader, TypeTag::Str, kZeroMask, HeapTag::Opaque, kUndefinedId};
   }
+
+  static constexpr ObjHeader Slab(uint8_t heap_tag, uint32_t num_pointers) {
+    return {kIsHeader, TypeTag::Slab, num_pointers, heap_tag, kUndefinedId};
+  }
 };
 
 // TODO: we could determine the max of all objects statically!

--- a/mycpp/gc_obj.h
+++ b/mycpp/gc_obj.h
@@ -56,6 +56,12 @@ struct ObjHeader {
   unsigned obj_len : 29;     // Cheney: number of bytes to copy
 #endif
 
+  // Used by hand-written and generated classes
+  static constexpr ObjHeader ClassFixed(uint16_t field_mask, uint32_t obj_len) {
+    return {kIsHeader, TypeTag::OtherClass, field_mask, HeapTag::FixedSize,
+            kUndefinedId};
+  }
+
   // Classes with no inheritance (e.g. used by mycpp)
   static constexpr ObjHeader ClassScanned(uint32_t num_pointers,
                                           uint32_t obj_len) {

--- a/mycpp/gc_obj.h
+++ b/mycpp/gc_obj.h
@@ -68,6 +68,10 @@ struct ObjHeader {
     return {kIsHeader, TypeTag::OtherClass, num_pointers, HeapTag::Scanned,
             kUndefinedId};
   }
+
+  static constexpr ObjHeader Str() {
+    return {kIsHeader, TypeTag::Str, kZeroMask, HeapTag::Opaque, kUndefinedId};
+  }
 };
 
 // TODO: we could determine the max of all objects statically!

--- a/mycpp/gc_obj.h
+++ b/mycpp/gc_obj.h
@@ -69,6 +69,12 @@ struct ObjHeader {
             kUndefinedId};
   }
 
+  // Used by frontend/flag_gen.py.  TODO: Sort fields and use GC_CLASS_SCANNED
+  static constexpr ObjHeader Class(uint8_t heap_tag, uint16_t field_mask,
+                                   uint32_t obj_len) {
+    return {kIsHeader, TypeTag::OtherClass, field_mask, heap_tag, kUndefinedId};
+  }
+
   static constexpr ObjHeader Str() {
     return {kIsHeader, TypeTag::Str, kZeroMask, HeapTag::Opaque, kUndefinedId};
   }

--- a/mycpp/gc_slab.h
+++ b/mycpp/gc_slab.h
@@ -29,11 +29,14 @@ template <typename T>
 class Slab {
   // Slabs of pointers are scanned; slabs of ints/bools are opaque.
  public:
-  explicit Slab(unsigned num_items)
-      : GC_SLAB(header_,
-                std::is_pointer<T>() ? HeapTag::Scanned : HeapTag::Opaque,
-                num_items) {
+  explicit Slab(unsigned num_items) : header_(obj_header(num_items)) {
   }
+
+  static constexpr ObjHeader obj_header(unsigned num_items) {
+    return ObjHeader::Slab(
+        std::is_pointer<T>() ? HeapTag::Scanned : HeapTag::Opaque, num_items);
+  }
+
   GC_OBJ(header_);
   T items_[1];  // variable length
 

--- a/mycpp/gc_str.h
+++ b/mycpp/gc_str.h
@@ -10,7 +10,7 @@ class List;
 class Str {
  public:
   // Don't call this directly.  Call NewStr() instead, which calls this.
-  Str() : GC_STR(header_) {
+  Str() : header_(obj_header()) {
   }
 
   char* data() {
@@ -68,6 +68,10 @@ class Str {
   // - Intern strings at GARBAGE COLLECTION TIME, with
   //   LayoutForwarded::new_location_?  Is this possible?  Does it introduce
   //   too much coupling between strings, hash tables, and GC?
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::Str();
+  }
 
   GC_OBJ(header_);
   int len_;

--- a/mycpp/gc_tuple.h
+++ b/mycpp/gc_tuple.h
@@ -6,8 +6,7 @@ class Tuple2 {
   typedef Tuple2<A, B> this_type;
 
  public:
-  Tuple2(A a, B b)
-      : GC_TUPLE(header_, field_mask(), sizeof(this_type)), a_(a), b_(b) {
+  Tuple2(A a, B b) : header_(obj_header()), a_(a), b_(b) {
   }
 
   A at0() {
@@ -15,6 +14,10 @@ class Tuple2 {
   }
   B at1() {
     return b_;
+  }
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::Tuple(field_mask(), sizeof(this_type));
   }
 
   static constexpr uint16_t field_mask() {
@@ -34,11 +37,7 @@ class Tuple3 {
   typedef Tuple3<A, B, C> this_type;
 
  public:
-  Tuple3(A a, B b, C c)
-      : GC_TUPLE(header_, field_mask(), sizeof(this_type)),
-        a_(a),
-        b_(b),
-        c_(c) {
+  Tuple3(A a, B b, C c) : header_(obj_header()), a_(a), b_(b), c_(c) {
   }
   A at0() {
     return a_;
@@ -48,6 +47,10 @@ class Tuple3 {
   }
   C at2() {
     return c_;
+  }
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::Tuple(field_mask(), sizeof(this_type));
   }
 
   static constexpr uint16_t field_mask() {
@@ -70,11 +73,7 @@ class Tuple4 {
 
  public:
   Tuple4(A a, B b, C c, D d)
-      : GC_TUPLE(header_, field_mask(), sizeof(this_type)),
-        a_(a),
-        b_(b),
-        c_(c),
-        d_(d) {
+      : header_(obj_header()), a_(a), b_(b), c_(c), d_(d) {
   }
   A at0() {
     return a_;
@@ -87,6 +86,10 @@ class Tuple4 {
   }
   D at3() {
     return d_;
+  }
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::Tuple(field_mask(), sizeof(this_type));
   }
 
   static constexpr uint16_t field_mask() {

--- a/mycpp/mark_sweep_heap_test.cc
+++ b/mycpp/mark_sweep_heap_test.cc
@@ -161,7 +161,11 @@ TEST list_collection_test() {
 
 class Node {
  public:
-  Node() : GC_CLASS_FIXED(header_, field_mask(), sizeof(Node)), next_(nullptr) {
+  Node() : header_(obj_header()), next_(nullptr) {
+  }
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(field_mask(), sizeof(Node));
   }
 
   GC_OBJ(header_);

--- a/mycpp/small_str_test.cc
+++ b/mycpp/small_str_test.cc
@@ -48,7 +48,7 @@ class SmallStr {
 
 class HeapStr {
  public:
-  HeapStr() : GC_STR(header_) {
+  HeapStr() : header_(obj_header()) {
   }
   int Length() {
 #ifdef MARK_SWEEP
@@ -74,6 +74,11 @@ class HeapStr {
     header.obj_len = kStrHeaderSize + len + 1;  // +1 for
 #endif
   }
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::Str();
+  }
+
   ObjHeader header_;
   char data_[1];
 };

--- a/prebuilt/asdl/runtime.mycpp.cc
+++ b/prebuilt/asdl/runtime.mycpp.cc
@@ -216,8 +216,7 @@ format::ColorOutput* DetectConsoleOutput(mylib::Writer* f) {
   }
 }
 
-ColorOutput::ColorOutput(mylib::Writer* f) 
-    : GC_CLASS_FIXED(header_, field_mask(), sizeof(ColorOutput)) {
+ColorOutput::ColorOutput(mylib::Writer* f) : header_(obj_header()) {
   this->f = f;
   this->num_chars = 0;
 }
@@ -385,8 +384,7 @@ void AnsiOutput::PopColor() {
 }
 int INDENT = 2;
 
-_PrettyPrinter::_PrettyPrinter(int max_col) 
-    : GC_CLASS_SCANNED(header_, 0, sizeof(_PrettyPrinter)) {
+_PrettyPrinter::_PrettyPrinter(int max_col) : header_(obj_header()) {
   this->max_col = max_col;
 }
 

--- a/prebuilt/asdl/runtime.mycpp.h
+++ b/prebuilt/asdl/runtime.mycpp.h
@@ -57,6 +57,10 @@ class ColorOutput {
     return maskbit_v(offsetof(ColorOutput, f));
   }
 
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(field_mask(), sizeof(ColorOutput));
+  }
+
   DISALLOW_COPY_AND_ASSIGN(ColorOutput)
 };
 
@@ -66,6 +70,10 @@ class TextOutput : public ColorOutput {
   virtual format::TextOutput* NewTempBuffer();
   virtual void PushColor(hnode_asdl::color_t e_color);
   virtual void PopColor();
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(TextOutput));
+  }
 
   DISALLOW_COPY_AND_ASSIGN(TextOutput)
 };
@@ -80,6 +88,10 @@ class HtmlOutput : public ColorOutput {
   virtual void PopColor();
   virtual void write(Str* s);
 
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(HtmlOutput));
+  }
+
   DISALLOW_COPY_AND_ASSIGN(HtmlOutput)
 };
 
@@ -89,6 +101,10 @@ class AnsiOutput : public ColorOutput {
   virtual format::AnsiOutput* NewTempBuffer();
   virtual void PushColor(hnode_asdl::color_t e_color);
   virtual void PopColor();
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(AnsiOutput));
+  }
 
   DISALLOW_COPY_AND_ASSIGN(AnsiOutput)
 };
@@ -104,6 +120,10 @@ class _PrettyPrinter {
 
   GC_OBJ(header_);
   int max_col;
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassScanned(0, sizeof(_PrettyPrinter));
+  }
 
   DISALLOW_COPY_AND_ASSIGN(_PrettyPrinter)
 };

--- a/prebuilt/core/error.mycpp.cc
+++ b/prebuilt/core/error.mycpp.cc
@@ -61,14 +61,13 @@ namespace error {  // define
 
 int NO_SPID = -1;
 
-Usage::Usage(Str* msg, int span_id) 
-    : GC_CLASS_SCANNED(header_, 1, sizeof(Usage)) {
+Usage::Usage(Str* msg, int span_id) : header_(obj_header()) {
   this->msg = msg;
   this->span_id = span_id;
 }
 
-_ErrorWithLocation::_ErrorWithLocation(Str* msg, syntax_asdl::loc_t* location) 
-    : GC_CLASS_FIXED(header_, field_mask(), sizeof(_ErrorWithLocation)) {
+_ErrorWithLocation::_ErrorWithLocation(Str* msg, syntax_asdl::loc_t* location)
+    : header_(obj_header()) {
   this->msg = msg;
   this->location = location;
 }
@@ -87,8 +86,7 @@ Str* _ErrorWithLocation::UserErrorString() {
   return this->msg;
 }
 
-Runtime::Runtime(Str* msg) 
-    : GC_CLASS_SCANNED(header_, 1, sizeof(Runtime)) {
+Runtime::Runtime(Str* msg) : header_(obj_header()) {
   this->msg = msg;
 }
 

--- a/prebuilt/core/error.mycpp.h
+++ b/prebuilt/core/error.mycpp.h
@@ -38,6 +38,10 @@ class Usage {
   Str* msg;
   int span_id;
 
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassScanned(1, sizeof(Usage));
+  }
+
   DISALLOW_COPY_AND_ASSIGN(Usage)
 };
 
@@ -56,6 +60,10 @@ class _ErrorWithLocation {
          | maskbit(offsetof(_ErrorWithLocation, msg));
   }
 
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(field_mask(), sizeof(_ErrorWithLocation));
+  }
+
   DISALLOW_COPY_AND_ASSIGN(_ErrorWithLocation)
 };
 
@@ -67,12 +75,20 @@ class Runtime {
   GC_OBJ(header_);
   Str* msg;
 
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassScanned(1, sizeof(Runtime));
+  }
+
   DISALLOW_COPY_AND_ASSIGN(Runtime)
 };
 
 class Parse : public _ErrorWithLocation {
  public:
   Parse(Str* msg, syntax_asdl::loc_t* location);
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(Parse));
+  }
 
   DISALLOW_COPY_AND_ASSIGN(Parse)
 };
@@ -81,12 +97,20 @@ class FailGlob : public _ErrorWithLocation {
  public:
   FailGlob(Str* msg, syntax_asdl::loc_t* location);
 
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(FailGlob));
+  }
+
   DISALLOW_COPY_AND_ASSIGN(FailGlob)
 };
 
 class RedirectEval : public _ErrorWithLocation {
  public:
   RedirectEval(Str* msg, syntax_asdl::loc_t* location);
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(RedirectEval));
+  }
 
   DISALLOW_COPY_AND_ASSIGN(RedirectEval)
 };
@@ -98,12 +122,20 @@ class FatalRuntime : public _ErrorWithLocation {
 
   int exit_status;
 
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(FatalRuntime));
+  }
+
   DISALLOW_COPY_AND_ASSIGN(FatalRuntime)
 };
 
 class Strict : public FatalRuntime {
  public:
   Strict(Str* msg, syntax_asdl::loc_t* location);
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(Strict));
+  }
 
   DISALLOW_COPY_AND_ASSIGN(Strict)
 };
@@ -114,12 +146,20 @@ class ErrExit : public FatalRuntime {
 
   bool show_code;
 
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(ErrExit));
+  }
+
   DISALLOW_COPY_AND_ASSIGN(ErrExit)
 };
 
 class Expr : public FatalRuntime {
  public:
   Expr(Str* msg, syntax_asdl::loc_t* location);
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(Expr));
+  }
 
   DISALLOW_COPY_AND_ASSIGN(Expr)
 };

--- a/prebuilt/frontend/args.mycpp.cc
+++ b/prebuilt/frontend/args.mycpp.cc
@@ -245,6 +245,10 @@ class Usage {
   Str* msg;
   int span_id;
 
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassScanned(1, sizeof(Usage));
+  }
+
   DISALLOW_COPY_AND_ASSIGN(Usage)
 };
 
@@ -263,6 +267,10 @@ class _ErrorWithLocation {
          | maskbit(offsetof(_ErrorWithLocation, msg));
   }
 
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(field_mask(), sizeof(_ErrorWithLocation));
+  }
+
   DISALLOW_COPY_AND_ASSIGN(_ErrorWithLocation)
 };
 
@@ -274,12 +282,20 @@ class Runtime {
   GC_OBJ(header_);
   Str* msg;
 
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassScanned(1, sizeof(Runtime));
+  }
+
   DISALLOW_COPY_AND_ASSIGN(Runtime)
 };
 
 class Parse : public _ErrorWithLocation {
  public:
   Parse(Str* msg, syntax_asdl::loc_t* location);
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(Parse));
+  }
 
   DISALLOW_COPY_AND_ASSIGN(Parse)
 };
@@ -288,12 +304,20 @@ class FailGlob : public _ErrorWithLocation {
  public:
   FailGlob(Str* msg, syntax_asdl::loc_t* location);
 
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(FailGlob));
+  }
+
   DISALLOW_COPY_AND_ASSIGN(FailGlob)
 };
 
 class RedirectEval : public _ErrorWithLocation {
  public:
   RedirectEval(Str* msg, syntax_asdl::loc_t* location);
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(RedirectEval));
+  }
 
   DISALLOW_COPY_AND_ASSIGN(RedirectEval)
 };
@@ -305,12 +329,20 @@ class FatalRuntime : public _ErrorWithLocation {
 
   int exit_status;
 
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(FatalRuntime));
+  }
+
   DISALLOW_COPY_AND_ASSIGN(FatalRuntime)
 };
 
 class Strict : public FatalRuntime {
  public:
   Strict(Str* msg, syntax_asdl::loc_t* location);
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(Strict));
+  }
 
   DISALLOW_COPY_AND_ASSIGN(Strict)
 };
@@ -321,12 +353,20 @@ class ErrExit : public FatalRuntime {
 
   bool show_code;
 
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(ErrExit));
+  }
+
   DISALLOW_COPY_AND_ASSIGN(ErrExit)
 };
 
 class Expr : public FatalRuntime {
  public:
   Expr(Str* msg, syntax_asdl::loc_t* location);
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(Expr));
+  }
 
   DISALLOW_COPY_AND_ASSIGN(Expr)
 };
@@ -386,8 +426,7 @@ format::ColorOutput* DetectConsoleOutput(mylib::Writer* f) {
   }
 }
 
-ColorOutput::ColorOutput(mylib::Writer* f) 
-    : GC_CLASS_FIXED(header_, field_mask(), sizeof(ColorOutput)) {
+ColorOutput::ColorOutput(mylib::Writer* f) : header_(obj_header()) {
   this->f = f;
   this->num_chars = 0;
 }
@@ -555,8 +594,7 @@ void AnsiOutput::PopColor() {
 }
 int INDENT = 2;
 
-_PrettyPrinter::_PrettyPrinter(int max_col) 
-    : GC_CLASS_SCANNED(header_, 0, sizeof(_PrettyPrinter)) {
+_PrettyPrinter::_PrettyPrinter(int max_col) : header_(obj_header()) {
   this->max_col = max_col;
 }
 
@@ -1315,14 +1353,13 @@ namespace error {  // define
 
 int NO_SPID = -1;
 
-Usage::Usage(Str* msg, int span_id) 
-    : GC_CLASS_SCANNED(header_, 1, sizeof(Usage)) {
+Usage::Usage(Str* msg, int span_id) : header_(obj_header()) {
   this->msg = msg;
   this->span_id = span_id;
 }
 
-_ErrorWithLocation::_ErrorWithLocation(Str* msg, syntax_asdl::loc_t* location) 
-    : GC_CLASS_FIXED(header_, field_mask(), sizeof(_ErrorWithLocation)) {
+_ErrorWithLocation::_ErrorWithLocation(Str* msg, syntax_asdl::loc_t* location)
+    : header_(obj_header()) {
   this->msg = msg;
   this->location = location;
 }
@@ -1341,8 +1378,7 @@ Str* _ErrorWithLocation::UserErrorString() {
   return this->msg;
 }
 
-Runtime::Runtime(Str* msg) 
-    : GC_CLASS_SCANNED(header_, 1, sizeof(Runtime)) {
+Runtime::Runtime(Str* msg) : header_(obj_header()) {
   this->msg = msg;
 }
 
@@ -1430,8 +1466,8 @@ int Int = 2;
 int Float = 3;
 int Bool = 4;
 
-_Attributes::_Attributes(Dict<Str*, runtime_asdl::value_t*>* defaults) 
-    : GC_CLASS_SCANNED(header_, 4, sizeof(_Attributes)) {
+_Attributes::_Attributes(Dict<Str*, runtime_asdl::value_t*>* defaults)
+    : header_(obj_header()) {
   this->attrs = Alloc<Dict<Str*, runtime_asdl::value_t*>>();
   this->opt_changes = Alloc<List<Tuple2<Str*, bool>*>>();
   this->shopt_changes = Alloc<List<Tuple2<Str*, bool>*>>();
@@ -1458,8 +1494,7 @@ void _Attributes::Set(Str* name, runtime_asdl::value_t* val) {
   this->attrs->set(name, val);
 }
 
-Reader::Reader(List<Str*>* argv, List<int>* spids) 
-    : GC_CLASS_SCANNED(header_, 2, sizeof(Reader)) {
+Reader::Reader(List<Str*>* argv, List<int>* spids) : header_(obj_header()) {
   this->argv = argv;
   this->spids = spids;
   this->n = len(argv);
@@ -1555,8 +1590,7 @@ int Reader::SpanId() {
   }
 }
 
-_Action::_Action() 
-    : GC_CLASS_FIXED(header_, kZeroMask, sizeof(_Action)) {
+_Action::_Action() : header_(obj_header()) {
   ;  // pass
 }
 

--- a/prebuilt/frontend/args.mycpp.h
+++ b/prebuilt/frontend/args.mycpp.h
@@ -83,6 +83,10 @@ class ColorOutput {
     return maskbit_v(offsetof(ColorOutput, f));
   }
 
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(field_mask(), sizeof(ColorOutput));
+  }
+
   DISALLOW_COPY_AND_ASSIGN(ColorOutput)
 };
 
@@ -92,6 +96,10 @@ class TextOutput : public ColorOutput {
   virtual format::TextOutput* NewTempBuffer();
   virtual void PushColor(hnode_asdl::color_t e_color);
   virtual void PopColor();
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(TextOutput));
+  }
 
   DISALLOW_COPY_AND_ASSIGN(TextOutput)
 };
@@ -106,6 +114,10 @@ class HtmlOutput : public ColorOutput {
   virtual void PopColor();
   virtual void write(Str* s);
 
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(HtmlOutput));
+  }
+
   DISALLOW_COPY_AND_ASSIGN(HtmlOutput)
 };
 
@@ -115,6 +127,10 @@ class AnsiOutput : public ColorOutput {
   virtual format::AnsiOutput* NewTempBuffer();
   virtual void PushColor(hnode_asdl::color_t e_color);
   virtual void PopColor();
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(AnsiOutput));
+  }
 
   DISALLOW_COPY_AND_ASSIGN(AnsiOutput)
 };
@@ -130,6 +146,10 @@ class _PrettyPrinter {
 
   GC_OBJ(header_);
   int max_col;
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassScanned(0, sizeof(_PrettyPrinter));
+  }
 
   DISALLOW_COPY_AND_ASSIGN(_PrettyPrinter)
 };
@@ -173,6 +193,10 @@ class _Attributes {
   bool show_options;
   bool saw_double_dash;
 
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassScanned(4, sizeof(_Attributes));
+  }
+
   DISALLOW_COPY_AND_ASSIGN(_Attributes)
 };
 
@@ -196,6 +220,10 @@ class Reader {
   int n;
   int i;
 
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassScanned(2, sizeof(Reader));
+  }
+
   DISALLOW_COPY_AND_ASSIGN(Reader)
 };
 
@@ -205,6 +233,10 @@ class _Action {
   virtual bool OnMatch(Str* attached_arg, args::Reader* arg_r, args::_Attributes* out);
 
   GC_OBJ(header_);
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(_Action));
+  }
 
   DISALLOW_COPY_AND_ASSIGN(_Action)
 };
@@ -224,6 +256,10 @@ class _ArgAction : public _Action {
          | maskbit_v(offsetof(_ArgAction, valid));
   }
 
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(field_mask(), sizeof(_ArgAction));
+  }
+
   DISALLOW_COPY_AND_ASSIGN(_ArgAction)
 };
 
@@ -231,6 +267,10 @@ class SetToInt : public _ArgAction {
  public:
   SetToInt(Str* name);
   virtual runtime_asdl::value_t* _Value(Str* arg, int span_id);
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(SetToInt));
+  }
 
   DISALLOW_COPY_AND_ASSIGN(SetToInt)
 };
@@ -240,6 +280,10 @@ class SetToFloat : public _ArgAction {
   SetToFloat(Str* name);
   virtual runtime_asdl::value_t* _Value(Str* arg, int span_id);
 
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(SetToFloat));
+  }
+
   DISALLOW_COPY_AND_ASSIGN(SetToFloat)
 };
 
@@ -247,6 +291,10 @@ class SetToString : public _ArgAction {
  public:
   SetToString(Str* name, bool quit_parsing_flags, List<Str*>* valid = nullptr);
   virtual runtime_asdl::value_t* _Value(Str* arg, int span_id);
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(SetToString));
+  }
 
   DISALLOW_COPY_AND_ASSIGN(SetToString)
 };
@@ -260,6 +308,10 @@ class SetAttachedBool : public _Action {
   
   static constexpr uint16_t field_mask() {
     return maskbit_v(offsetof(SetAttachedBool, name));
+  }
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(field_mask(), sizeof(SetAttachedBool));
   }
 
   DISALLOW_COPY_AND_ASSIGN(SetAttachedBool)
@@ -276,6 +328,10 @@ class SetToTrue : public _Action {
     return maskbit_v(offsetof(SetToTrue, name));
   }
 
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(field_mask(), sizeof(SetToTrue));
+  }
+
   DISALLOW_COPY_AND_ASSIGN(SetToTrue)
 };
 
@@ -288,6 +344,10 @@ class SetOption : public _Action {
   
   static constexpr uint16_t field_mask() {
     return maskbit_v(offsetof(SetOption, name));
+  }
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(field_mask(), sizeof(SetOption));
   }
 
   DISALLOW_COPY_AND_ASSIGN(SetOption)
@@ -306,6 +366,10 @@ class SetNamedOption : public _Action {
     return maskbit_v(offsetof(SetNamedOption, names));
   }
 
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(field_mask(), sizeof(SetNamedOption));
+  }
+
   DISALLOW_COPY_AND_ASSIGN(SetNamedOption)
 };
 
@@ -318,6 +382,10 @@ class SetAction : public _Action {
   
   static constexpr uint16_t field_mask() {
     return maskbit_v(offsetof(SetAction, name));
+  }
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(field_mask(), sizeof(SetAction));
   }
 
   DISALLOW_COPY_AND_ASSIGN(SetAction)
@@ -333,6 +401,10 @@ class SetNamedAction : public _Action {
   
   static constexpr uint16_t field_mask() {
     return maskbit_v(offsetof(SetNamedAction, names));
+  }
+
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(field_mask(), sizeof(SetNamedAction));
   }
 
   DISALLOW_COPY_AND_ASSIGN(SetNamedAction)

--- a/test/lint.sh
+++ b/test/lint.sh
@@ -29,22 +29,8 @@ cpplint() {
 }
 
 clang-format() {
-  # I like consistent Python-style functions and blocks, e.g. not if (x) return
-  local style='{
-      BasedOnStyle: Google,
-      IndentCaseLabels: false,
-      AllowShortFunctionsOnASingleLine: None,
-      AllowShortBlocksOnASingleLine: false,
-      IndentPPDirectives: BeforeHash,
-
-      # Does not do what I want
-      # TypenameMacros: ["SUM", "VARIANT"]
-      WhitespaceSensitiveMacros: ["SUM", "VARIANT", "SCHEMA"]
-      TypenameMacros: ["SUM_NS", "PROD"]
-    }
-  '
-  # We have a lot of switch statements, and the extra indent doesn't help.
-  $CLANG_DIR/bin/clang-format -style="$style" "$@"
+  # See //.clang-format for the style config.
+  $CLANG_DIR/bin/clang-format --style=file "$@"
 }
 
 readonly -a CPP_FILES=(


### PR DESCRIPTION
Refactor GC objects to each now contain a static `obj_header` function that returns the the ObjHeader it should be initialized with. Now, instead of directly intiializing `header_` via the GC_* macros, we initialize it from obj_header(). This should be no different semantically -- it's step one in the transformation to move the ObjHeader outside of objects and have `Alloc()` initialize them.

@andychu  LMK if this is too hard to review and I can try to split it up for you. The commits are pretty self contained so you can also look at the diff per commit maybe. 