### PR TITLE
Move object headers outside of objects

### DIFF
--- a/asdl/gen_cpp.py
+++ b/asdl/gen_cpp.py
@@ -349,7 +349,7 @@ class ClassDefVisitor(visitor.AsdlVisitor):
     Emit(' public:')
     Emit('  int tag_() const {')
     # There's no inheritance relationship, so we have to reinterpret_cast.
-    Emit('    return ObjHeader::FromObject(this).type_tag;')
+    Emit('    return ObjHeader::FromObject(this)->type_tag;')
     Emit('  }')
 
     if self.pretty_print_methods:

--- a/asdl/gen_cpp.py
+++ b/asdl/gen_cpp.py
@@ -3,7 +3,7 @@ gen_cpp.py - Generate C++ classes from an ASDL schema.
 
 TODO:
 
-- Integrate some of the lessons here:  
+- Integrate some of the lessons here:
   - https://github.com/oilshell/blog-code/tree/master/asdl
   - And maybe mycpp/target_lang.cc
 
@@ -349,7 +349,7 @@ class ClassDefVisitor(visitor.AsdlVisitor):
     Emit(' public:')
     Emit('  int tag_() const {')
     # There's no inheritance relationship, so we have to reinterpret_cast.
-    Emit('    return reinterpret_cast<const ObjHeader*>(this)->type_tag;')
+    Emit('    return ObjHeader::FromObject(this).type_tag;')
     Emit('  }')
 
     if self.pretty_print_methods:
@@ -406,18 +406,15 @@ class ClassDefVisitor(visitor.AsdlVisitor):
       # reflow doesn't work well here, so do it manually
       return ',\n        '.join(strs)
 
-    params = []
-    # All product types and variants have a tag
-    header_init = 'header_(obj_header())'
-    inits = [header_init]
-
     # Ensure that the constructor params are listed in the same order as the
     # equivalent python constructors for compatibility in translated code.
+    params = []
     for f in ast_node.fields:
       params.append('%s %s' % (_GetCppType(f.typ), f.name))
 
     # Member initializers are in the same order as the member variables to
     # avoid compiler warnings (the order doesn't affect the semantics).
+    inits = []
     for f in all_fields:
       if f in attributes:
         # spids are initialized separately
@@ -428,8 +425,11 @@ class ClassDefVisitor(visitor.AsdlVisitor):
 
     # Define constructor with N args
     self.Emit('  %s(%s)' % (class_name, ', '.join(params)), depth)
-    self.Emit('      : %s {' % FieldInitJoin(inits), depth, reflow=False)
-    self.Emit('  }')
+    if len(inits):
+      self.Emit('      : %s {' % FieldInitJoin(inits), depth, reflow=False)
+      self.Emit('  }')
+    else:
+      self.Emit('{ }')
     self.Emit('')
 
     # Define static constructor with ZERO args.  Don't emit for types with no
@@ -462,7 +462,6 @@ class ClassDefVisitor(visitor.AsdlVisitor):
     #
     # Members
     #
-    self.Emit('  GC_OBJ(header_);')
     for field in all_fields:
       self.Emit("  %s %s;" % (_GetCppType(field.typ), field.name))
 

--- a/asdl/gen_cpp_test.cc
+++ b/asdl/gen_cpp_test.cc
@@ -179,11 +179,11 @@ using typed_demo_asdl::flag_type;
 using typed_demo_asdl::SetToArg_;
 
 // TODO: We should always use these, rather than 'new flag_type::Bool()'
-flag_type::Bool g_ft = {};
+InlineGcObj<flag_type::Bool> g_ft = {flag_type::Bool::obj_header()};
 
 // Use __ style
 using typed_demo_asdl::cflow__Return;
-cflow__Return g_ret = {5};
+InlineGcObj<cflow__Return> g_ret = {cflow__Return::obj_header(), {5}};
 
 int i0 = 7;
 
@@ -197,15 +197,15 @@ List<int>* g_list = NewList<int>({i0, 8, 9});
 TEST literal_test() {
   // Interesting, initializer list part of the constructor "runs".  Otherwise
   // this doesn't work.
-  log("g_ft.tag_() = %d", g_ft.tag_());
+  log("g_ft.tag_() = %d", g_ft.obj.tag_());
   auto ft = Alloc<flag_type::Bool>();
-  ASSERT_EQ(g_ft.tag_(), ft->tag_());
+  ASSERT_EQ(g_ft.obj.tag_(), ft->tag_());
 
-  log("g_ret.tag_() = %d", g_ret.tag_());
-  log("g_ret.status = %d", g_ret.status);
+  log("g_ret.tag_() = %d", g_ret.obj.tag_());
+  log("g_ret.status = %d", g_ret.obj.status);
   auto ret = Alloc<cflow__Return>(5);
-  ASSERT_EQ(g_ret.tag_(), ret->tag_());
-  ASSERT_EQ(g_ret.status, ret->status);
+  ASSERT_EQ(g_ret.obj.tag_(), ret->tag_());
+  ASSERT_EQ(g_ret.obj.status, ret->status);
 
 #if 0
   // Wow this works too?  Is it the the constexpr interpreter, or is this code

--- a/asdl/gen_cpp_test.cc
+++ b/asdl/gen_cpp_test.cc
@@ -178,12 +178,17 @@ TEST dicts_test() {
 using typed_demo_asdl::flag_type;
 using typed_demo_asdl::SetToArg_;
 
+ObjHeader make_global(ObjHeader header) {
+  header.heap_tag = HeapTag::Global;
+  return header;
+}
+
 // TODO: We should always use these, rather than 'new flag_type::Bool()'
-InlineGcObj<flag_type::Bool> g_ft = {flag_type::Bool::obj_header()};
+GcGlobal<flag_type::Bool> g_ft = {make_global(flag_type::Bool::obj_header())};
 
 // Use __ style
 using typed_demo_asdl::cflow__Return;
-InlineGcObj<cflow__Return> g_ret = {cflow__Return::obj_header(), {5}};
+GcGlobal<cflow__Return> g_ret = {make_global(cflow__Return::obj_header()), {5}};
 
 int i0 = 7;
 

--- a/core/optview_gen.py
+++ b/core/optview_gen.py
@@ -33,8 +33,7 @@ using option_asdl::option_i;
 class _View {
  public:
   _View(List<bool>* opt0_array, List<List<bool>*>* opt_stacks)
-      : header_(obj_header()),
-        opt0_array(opt0_array), opt_stacks(opt_stacks) {
+      : opt0_array(opt0_array), opt_stacks(opt_stacks) {
   }
 
   bool _Get(int opt_num) {
@@ -50,7 +49,6 @@ class _View {
     return ObjHeader::ClassFixed(field_mask(), sizeof(_View));
   }
 
-  GC_OBJ(header_);
   List<bool>* opt0_array;
   List<List<bool>*>* opt_stacks;
 

--- a/cpp/core.h
+++ b/cpp/core.h
@@ -46,22 +46,20 @@ Str* GetHomeDir(Str* user_name);
 
 class ReadError {
  public:
-  explicit ReadError(int err_num_) : header_(obj_header()), err_num(err_num_) {
+  explicit ReadError(int err_num_) : err_num(err_num_) {
   }
 
   static constexpr ObjHeader obj_header() {
     return ObjHeader::ClassFixed(kZeroMask, sizeof(ReadError));
   }
 
-  GC_OBJ(header_);
   int err_num;
 };
 
 class PasswdEntry {
  public:
   explicit PasswdEntry(const passwd* entry)
-      : header_(obj_header()),
-        pw_name(StrFromC(entry->pw_name)),
+      : pw_name(StrFromC(entry->pw_name)),
         pw_uid(entry->pw_uid),
         pw_gid(entry->pw_gid) {
   }
@@ -70,7 +68,6 @@ class PasswdEntry {
     return ObjHeader::ClassFixed(field_mask(), sizeof(PasswdEntry));
   }
 
-  GC_OBJ(header_);
   Str* pw_name;
   int pw_uid;
   int pw_gid;
@@ -105,6 +102,9 @@ class TermState {
   void Restore() {
     assert(0);
   }
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(TermState));
+  }
 };
 
 // Make the signal queue slab 4096 bytes, including the GC header.  See
@@ -115,8 +115,7 @@ class SignalSafe {
   // State that is shared between the main thread and signal handlers.
  public:
   SignalSafe()
-      : header_(obj_header()),
-        pending_signals_(AllocSignalList()),
+      : pending_signals_(AllocSignalList()),
         empty_list_(AllocSignalList()),  // to avoid repeated allocation
         last_sig_num_(0),
         received_sigint_(false),
@@ -211,7 +210,6 @@ class SignalSafe {
     return ObjHeader::ClassFixed(field_mask(), sizeof(SignalSafe));
   }
 
-  GC_OBJ(header_);
   List<int>* pending_signals_;  // public for testing
   List<int>* empty_list_;
 
@@ -258,7 +256,7 @@ Str* ChArrayToString(List<int>* ch_array);
 
 class _ResourceLoader {
  public:
-  _ResourceLoader() : header_(obj_header()) {
+  _ResourceLoader() {
   }
 
   virtual Str* Get(Str* path);
@@ -266,8 +264,6 @@ class _ResourceLoader {
   static constexpr ObjHeader obj_header() {
     return ObjHeader::ClassFixed(kZeroMask, sizeof(_ResourceLoader));
   }
-
-  GC_OBJ(header_);
 };
 
 _ResourceLoader* GetResourceLoader();

--- a/cpp/frontend_flag_spec.h
+++ b/cpp/frontend_flag_spec.h
@@ -85,8 +85,7 @@ namespace flag_spec {
 class _FlagSpec {
  public:
   _FlagSpec()
-      : header_(obj_header()),
-        arity0(nullptr),
+      : arity0(nullptr),
         arity1(nullptr),
         plus_flags(nullptr),
         actions_long(nullptr),
@@ -97,7 +96,6 @@ class _FlagSpec {
     return ObjHeader::ClassFixed(field_mask(), sizeof(_FlagSpec));
   }
 
-  GC_OBJ(header_);
   List<Str*>* arity0;
   Dict<Str*, args::_Action*>* arity1;
   List<Str*>* plus_flags;
@@ -116,8 +114,7 @@ class _FlagSpec {
 class _FlagSpecAndMore {
  public:
   _FlagSpecAndMore()
-      : header_(obj_header()),
-        actions_long(nullptr),
+      : actions_long(nullptr),
         actions_short(nullptr),
         plus_flags(nullptr),
         defaults(nullptr) {
@@ -127,7 +124,6 @@ class _FlagSpecAndMore {
     return ObjHeader::ClassFixed(field_mask(), sizeof(_FlagSpecAndMore));
   }
 
-  GC_OBJ(header_);
   Dict<Str*, args::_Action*>* actions_long;
   Dict<Str*, args::_Action*>* actions_short;
   List<Str*>* plus_flags;

--- a/cpp/frontend_match.h
+++ b/cpp/frontend_match.h
@@ -24,7 +24,7 @@ typedef void (*MatchFunc)(const unsigned char* line, int line_len,
 class SimpleLexer {
  public:
   SimpleLexer(MatchFunc match_func, Str* s)
-      : header_(obj_header()), match_func_(match_func), s_(s), pos_(0) {
+      : match_func_(match_func), s_(s), pos_(0) {
   }
 
   Tuple2<Id_t, Str*> Next();
@@ -39,7 +39,6 @@ class SimpleLexer {
   }
 
  private:
-  GC_OBJ(header_);
   MatchFunc match_func_;
   Str* s_;
   int pos_;

--- a/cpp/frontend_pyreadline.cc
+++ b/cpp/frontend_pyreadline.cc
@@ -65,8 +65,7 @@ static void display_matches_hook(char** matches, int num_matches,
 #endif
 
 Readline::Readline()
-    : header_(obj_header()),
-      begidx_(),
+    : begidx_(),
       endidx_(),
       completer_delims_(StrFromC(" \t\n`~!@#$%^&*()-=+[{]}\\|;:'\",<>/?")),
       completer_(),

--- a/cpp/frontend_pyreadline.h
+++ b/cpp/frontend_pyreadline.h
@@ -49,8 +49,6 @@ class Readline {
     return ObjHeader::ClassFixed(field_mask(), sizeof(Readline));
   }
 
-  GC_OBJ(header_);
-
   int begidx_;
   int endidx_;
   Str* completer_delims_;

--- a/cpp/osh.cc
+++ b/cpp/osh.cc
@@ -16,7 +16,8 @@ using syntax_asdl::loc;
 
 namespace arith_parse {
 
-InlineGcObj<tdop::ParserSpec> kArithSpec_ = {tdop::ParserSpec::obj_header().SetIsGlobal()};
+GcGlobal<tdop::ParserSpec> kArithSpec_ = {
+    kIsHeader, TypeTag::OtherClass, kZeroMask, HeapTag::Global, kIsGlobal};
 tdop::ParserSpec* kArithSpec = &kArithSpec_.obj;
 
 }  // namespace arith_parse

--- a/cpp/osh.cc
+++ b/cpp/osh.cc
@@ -16,7 +16,8 @@ using syntax_asdl::loc;
 
 namespace arith_parse {
 
-tdop::ParserSpec kArithSpec;
+InlineGcObj<tdop::ParserSpec> kArithSpec_ = {tdop::ParserSpec::obj_header().SetIsGlobal()};
+tdop::ParserSpec* kArithSpec = &kArithSpec_.obj;
 
 }  // namespace arith_parse
 

--- a/cpp/osh.h
+++ b/cpp/osh.h
@@ -9,10 +9,10 @@
 
 namespace arith_parse {
 
-extern tdop::ParserSpec kArithSpec;
+extern tdop::ParserSpec* kArithSpec;
 
 inline tdop::ParserSpec* Spec() {
-  return &kArithSpec;
+  return kArithSpec;
 }
 
 // Generated tables in _devbuild/gen-cpp/

--- a/cpp/osh_tdop.h
+++ b/cpp/osh_tdop.h
@@ -35,7 +35,7 @@ struct NullInfo {
 class ParserSpec {
  public:
   // No fields
-  ParserSpec() : header_(obj_header()) {
+  ParserSpec() {
   }
   LeftInfo* LookupLed(Id_t id);
   NullInfo* LookupNud(Id_t id);
@@ -45,8 +45,6 @@ class ParserSpec {
   static constexpr ObjHeader obj_header() {
     return ObjHeader::ClassFixed(kZeroMask, sizeof(ParserSpec));
   }
-
-  GC_OBJ(header_);
 };
 
 }  // namespace tdop

--- a/cpp/osh_tdop.h
+++ b/cpp/osh_tdop.h
@@ -40,11 +40,11 @@ class ParserSpec {
   LeftInfo* LookupLed(Id_t id);
   NullInfo* LookupNud(Id_t id);
 
-  DISALLOW_COPY_AND_ASSIGN(ParserSpec)
-
   static constexpr ObjHeader obj_header() {
     return ObjHeader::ClassFixed(kZeroMask, sizeof(ParserSpec));
   }
+
+  DISALLOW_COPY_AND_ASSIGN(ParserSpec)
 };
 
 }  // namespace tdop

--- a/cpp/pgen2.h
+++ b/cpp/pgen2.h
@@ -21,8 +21,7 @@ namespace parse {
 
 class ParseError {
  public:
-  ParseError(Str* msg, int type_, syntax_asdl::Token* tok)
-      : header_(obj_header()) {
+  ParseError(Str* msg, int type_, syntax_asdl::Token* tok) {
   }
 
   static constexpr ObjHeader obj_header() {
@@ -34,7 +33,6 @@ class ParseError {
            maskbit(offsetof(ParseError, tok));
   }
 
-  GC_OBJ(header_);
   Str* msg;
   syntax_asdl::Token* tok;
   int type;
@@ -45,7 +43,7 @@ class Parser {
   // In C, the grammar is a constant, so the grammar arg is ignored.  (We can't
   // get easily rid of it because the call site has to type check and run in
   // Python.)
-  explicit Parser(grammar::Grammar* grammar) : header_(obj_header()) {
+  explicit Parser(grammar::Grammar* grammar) {
   }
   void setup(int start);
   bool addtoken(int typ, syntax_asdl::Token* opaque, int ilabel);
@@ -62,8 +60,6 @@ class Parser {
   // void shift(int typ, syntax_asdl::Token* opaque, int newstate);
   // void push(int typ, syntax_asdl::Token* opaque, Tuple2<List<List<Tuple2<int,
   // int>*>*>*, Dict<int, int>*>* newdfa, int newstate);  void pop();
-
-  GC_OBJ(header_);
 
   // grammar::Grammar* grammar;
   pnode::PNode* rootnode;

--- a/frontend/flag_gen.py
+++ b/frontend/flag_gen.py
@@ -259,19 +259,18 @@ attrs->index_(StrFromC("%s"))->tag_() == value_e::Undef
     header_f.write("""
 class %s {
  public:
-  %s(Dict<Str*, runtime_asdl::value_t*>* attrs)
-      : header_(obj_header()),
-""" % (spec_name, spec_name))
+  %s(Dict<Str*, runtime_asdl::value_t*>* attrs)""" % (spec_name, spec_name))
 
-    for i, field_name in enumerate(field_names):
-      if i != 0:
-        header_f.write(',\n')
-      header_f.write('        %s(%s)' % (field_name, init_vals[i]))
+    if field_names:
+      header_f.write('\n      : ')
+      for i, field_name in enumerate(field_names):
+        if i != 0:
+          header_f.write(',\n        ')
+        header_f.write('%s(%s)' % (field_name, init_vals[i]))
     header_f.write(' {\n')
     header_f.write('  }\n')
     header_f.write('\n')
 
-    header_f.write('  GC_OBJ(header_);\n')
     for decl in field_decls:
       header_f.write('  %s\n' % decl)
 

--- a/mycpp/cheney_heap.cc
+++ b/mycpp/cheney_heap.cc
@@ -124,7 +124,7 @@ void CheneyHeap::Collect(int to_space_size) {
   #endif
 
     if (root) {  // could be nullptr
-      auto header = FindObjHeader(root);
+      auto header = &ObjHeader::FromObject(root);
 
       // This updates the underlying Str/List/Dict with a forwarding pointer,
       // i.e. for other objects that are pointing to it
@@ -159,18 +159,18 @@ void CheneyHeap::Collect(int to_space_size) {
 
   while (scan < free_) {
     auto obj = reinterpret_cast<RawObject*>(scan);
-    auto header = FindObjHeader(obj);
+    auto header = &ObjHeader::FromObject(obj);
 
     switch (header->heap_tag) {
     case HeapTag::FixedSize: {
-      auto fixed = reinterpret_cast<LayoutFixed*>(header);
-      int mask = fixed->header_.field_mask;
+      auto fixed = reinterpret_cast<LayoutFixed*>(obj);
+      int mask = ObjHeader::FromObject(obj).field_mask;
       for (int i = 0; i < 16; ++i) {
         if (mask & (1 << i)) {
           RawObject* child = fixed->children_[i];
           // log("i = %d, p = %p, heap_tag = %d", i, child, child->heap_tag);
           if (child) {
-            auto child_header = FindObjHeader(child);
+            auto child_header = &ObjHeader::FromObject(child);
             // log("  fixed: child %d from %p", i, child);
             fixed->children_[i] = Relocate(child, child_header);
             // log("  to %p", fixed->children_[i]);
@@ -180,15 +180,13 @@ void CheneyHeap::Collect(int to_space_size) {
       break;
     }
     case HeapTag::Scanned: {
-      // no vtable
-      assert(reinterpret_cast<void*>(header) == reinterpret_cast<void*>(obj));
-
-      auto slab = reinterpret_cast<Slab<void*>*>(header);
-      int n = (slab->header_.obj_len - kSlabHeaderSize) / sizeof(void*);
+      auto slab = reinterpret_cast<Slab<void*>*>(obj);
+      auto& header = ObjHeader::FromObject(obj);
+      int n = (header.obj_len - kSlabHeaderSize) / sizeof(void*);
       for (int i = 0; i < n; ++i) {
         RawObject* child = reinterpret_cast<RawObject*>(slab->items_[i]);
         if (child) {  // note: List<> may have nullptr; Dict is sparse
-          auto child_header = FindObjHeader(child);
+          auto child_header = &ObjHeader::FromObject(child);
           slab->items_[i] = Relocate(child, child_header);
         }
       }

--- a/mycpp/cppgen_pass.py
+++ b/mycpp/cppgen_pass.py
@@ -2262,7 +2262,8 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
             else:
                 # Has inheritance
 
-                # The field mask of a derived class extends that of its base.
+                # The field mask of a derived class is unioned with its base's
+                # field mask.
                 if base_class_name:
                     mask_bits.append('%s::field_mask()' % base_class_name)
 

--- a/mycpp/cppgen_pass.py
+++ b/mycpp/cppgen_pass.py
@@ -60,7 +60,7 @@ def _GetCTypeForCast(type_expr):
 
 def _GetCastKind(module_path, cast_to_type):
     """Translate MyPy cast to C++ cast.
-  
+
   Prefer static_cast, but sometimes we need reinterpret_cast.
   """
 
@@ -2262,26 +2262,25 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
             else:
                 # Has inheritance
 
+                # The field mask of a derived class extends that of its base.
+                if base_class_name:
+                    mask_bits.append('%s::field_mask()' % base_class_name)
+
                 for name in sorted(self.member_vars):
                     c_type = GetCType(self.member_vars[name])
                     if CTypeIsManaged(c_type):
                         mask_bits.append('%s(offsetof(%s, %s))' %
                                          (mask_func_name, o.name, name))
 
-                if len(mask_bits) == 0:
-                    # Bug fix: even if the base class has no mask_bits, it can't be
-                    # HeapTag::Opaque, because that would mess up derived classes.
-                    self.field_gc[o] = ('HeapTag::FixedSize', 'kZeroMask')
-                else:
-                    self.field_gc[o] = ('HeapTag::FixedSize', 'field_mask()')
+                # A base class with no fields has kZeroMask.
+                if not base_class_name and not mask_bits:
+                    mask_bits.append('kZeroMask')
 
                 sorted_member_names = sorted(self.member_vars)
 
-            # Write member variables
+                self.field_gc[o] = ('HeapTag::FixedSize', 'field_mask()')
 
-            if not base_class_name:
-                self.decl_write('\n')  # separate from functions
-                self.decl_write_ind('GC_OBJ(header_);\n')
+            # Write member variables
 
             #log('MEMBERS for %s: %s', o.name, list(self.member_vars.keys()))
             if self.member_vars:
@@ -2298,7 +2297,6 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
                 self.decl_write_ind('\n')
                 self.decl_write_ind(
                     'static constexpr uint32_t field_mask() {\n')
-
                 self.decl_write_ind('  return ')
                 for i, b in enumerate(mask_bits):
                     if i != 0:
@@ -2347,12 +2345,7 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
                     self.write('\n')
                     self.write('%s::%s(', o.name, o.name)
                     self._WriteFuncParams(stmt.type.arg_types, stmt.arguments)
-                    self.write(') ')
-
-                    # Base class must initialize the header.
-                    if not base_class_name:
-                        self.write('\n')
-                        self.write('    : header_(obj_header())')
+                    self.write(')')
 
                     # Check for Base.__init__(self, ...) and move that to the initializer list.
 
@@ -2377,7 +2370,7 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
                                 MemberExpr) and callee.name == '__init__':
                             base_constructor_args = expr.args
                             #log('ARGS %s', base_constructor_args)
-                            self.write(': %s(', base_class_name)
+                            self.write(' : %s(', base_class_name)
                             for i, arg in enumerate(base_constructor_args):
                                 if i == 0:
                                     continue  # Skip 'this'
@@ -2392,14 +2385,6 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
 
                     # Debug Tag!
                     # self.write('  type_tag_ = kMycppDebugType;\n')
-
-                    # Derived classes MUTATE the mask
-                    if base_class_name:
-                        obj_tag, obj_arg = self.field_gc[o]
-                        if obj_tag == 'HeapTag::FixedSize' and obj_arg != 'kZeroMask':
-                            self.write(
-                                '  FIELD_MASK(header_) |= %s::field_mask();\n'
-                                % o.name)
 
                     # Now visit the rest of the statements
                     self.indent += 1

--- a/mycpp/demo/gc_header.cc
+++ b/mycpp/demo/gc_header.cc
@@ -149,18 +149,18 @@ TEST endian_test() {
   log("sizeof(Node) = %d", sizeof(Node));
   log("sizeof(Derived) = %d", sizeof(Derived));
 
-  ObjHeader& header = ObjHeader::FromObject(derived);
-  log("Derived is GC object? %d", header.type_tag & 0x1);
+  ObjHeader* header = ObjHeader::FromObject(derived);
+  log("Derived is GC object? %d", header->type_tag & 0x1);
 
   NoVirtual* n2 = Alloc<NoVirtual>();
-  ObjHeader& header2 = ObjHeader::FromObject(n2);
-  log("NoVirtual is GC object? %d", header2.type_tag & 0x1);
+  ObjHeader* header2 = ObjHeader::FromObject(n2);
+  log("NoVirtual is GC object? %d", header2->type_tag & 0x1);
 
   Node* n = Alloc<Node>();
-  ObjHeader& h = ObjHeader::FromObject(n);
-  FIELD_MASK(h) = 0b11;
-  log("field mask %d", FIELD_MASK(h));
-  log("num pointers %d", NUM_POINTERS(h));
+  ObjHeader* h = ObjHeader::FromObject(n);
+  FIELD_MASK(*h) = 0b11;
+  log("field mask %d", FIELD_MASK(*h));
+  log("num pointers %d", NUM_POINTERS(*h));
 
   PASS();
 }
@@ -351,13 +351,6 @@ TEST union_test() {
   PASS();
 }
 
-TEST my_test() {
-  log("offset of x in Derived: %d", offsetof(Derived, x));
-  log("offset of x in Node: %d", offsetof(Node, x));
-  log("offset of i in NoVirtual: %x", offsetof(NoVirtual, i));
-  PASS();
-}
-
 }  // namespace demo
 
 GREATEST_MAIN_DEFS();
@@ -370,7 +363,6 @@ int main(int argc, char** argv) {
   RUN_TEST(demo::gc_header_test);
   RUN_TEST(demo::endian_test);
   RUN_TEST(demo::union_test);
-  RUN_TEST(demo::my_test);
 
   // gHeap.CleanProcessExit();
 

--- a/mycpp/demo/target_lang.cc
+++ b/mycpp/demo/target_lang.cc
@@ -558,7 +558,7 @@ class Derived : public Base {
  public:
   Derived(int i, int j) : Base(i), j(j) {
     // annoying: should be in initializer list
-    FIELD_MASK(ObjHeader::FromObject(this)) |= 0x5;
+    FIELD_MASK(*ObjHeader::FromObject(this)) |= 0x5;
   }
   int j;
   Node* three;

--- a/mycpp/demo/target_lang.cc
+++ b/mycpp/demo/target_lang.cc
@@ -544,12 +544,11 @@ TEST field_mask_demo() {
 
 class Base {
  public:
-  Base(int i) : header_(obj_header()), i(i) {
+  Base(int i) : i(i) {
   }
   static constexpr ObjHeader obj_header() {
     return ObjHeader::ClassFixed(kZeroMask, sizeof(Base));
   }
-  GC_OBJ(header_);
   int i;
   Node* left;
   Node* right;
@@ -559,7 +558,7 @@ class Derived : public Base {
  public:
   Derived(int i, int j) : Base(i), j(j) {
     // annoying: should be in initializer list
-    FIELD_MASK(header_) |= 0x5;
+    FIELD_MASK(ObjHeader::FromObject(this)) |= 0x5;
   }
   int j;
   Node* three;

--- a/mycpp/gc_alloc.h
+++ b/mycpp/gc_alloc.h
@@ -41,7 +41,7 @@ class StackRoots {
 #if VALIDATE_ROOTS
       RawObject* obj = *(reinterpret_cast<RawObject**>(root));
       if (obj) {
-        RawObject* header = FindObjHeader(obj);
+        RawObject* header = ObjHeader::FromObject(obj);
         log("obj %p header %p", obj, header);
 
         switch (header->heap_tag) {
@@ -85,23 +85,17 @@ class StackRoots {
 // https://eli.thegreenplace.net/2014/variadic-templates-in-c/
 template <typename T, typename... Args>
 T* Alloc(Args&&... args) {
+  // The objects are placed directly after the headers (i.e., at an address
+  // with alignment = sizeof(ObjHeader)).
+  static_assert(alignof(T) <= sizeof(ObjHeader));
   DCHECK(gHeap.is_initialized_);
 
-  void* place = gHeap.Allocate(sizeof(T));
+  void* place = gHeap.Allocate(sizeof(ObjHeader) + sizeof(T));
+  ObjHeader* header = new (place) ObjHeader(T::obj_header());
 #if MARK_SWEEP
-  // IMPORTANT: save the object ID before calling placement new, which can
-  // invoke Allocate() again!
-  int obj_id = gHeap.UnusedObjectId();
+  header->obj_id = gHeap.UnusedObjectId();
 #endif
-
-  T* obj = new (place) T(std::forward<Args>(args)...);
-
-#if MARK_SWEEP
-  // Hack for now: find the header
-  ObjHeader* header = FindObjHeader(reinterpret_cast<RawObject*>(obj));
-  header->obj_id = obj_id;
-#endif
-  return obj;
+  return new (header->ObjectAddress()) T(std::forward<Args>(args)...);
 }
 
 //
@@ -115,21 +109,21 @@ inline Str* NewStr(int len) {
     return kEmptyString;
   }
 
-  int obj_len = kStrHeaderSize + len + 1;
+  int obj_len = kStrHeaderSize + len + 1;  // NUL terminator
 
-  // only allocation is unconditionally returned
-  void* place = gHeap.Allocate(obj_len);
+  void* place = gHeap.Allocate(sizeof(ObjHeader) + obj_len);
+  ObjHeader* header = new (place) ObjHeader(Str::obj_header());
 
-  auto s = new (place) Str();
+  auto s = new (header->ObjectAddress()) Str();
 #if defined(MARK_SWEEP) || defined(BUMP_LEAK)
   s->len_ = len;
 #else
   // reversed in len() to derive string length
-  s->header_.obj_len = kStrHeaderSize + len + 1;
+  header->obj_len = kStrHeaderSize + len + 1;
 #endif
 
 #if MARK_SWEEP
-  s->header_.obj_id = gHeap.UnusedObjectId();
+  header->obj_id = gHeap.UnusedObjectId();
 #endif
   return s;
 }
@@ -139,10 +133,11 @@ inline Str* NewStr(int len) {
 // s->MaybeShrink() afterward!
 inline Str* OverAllocatedStr(int len) {
   int obj_len = kStrHeaderSize + len + 1;  // NUL terminator
-  void* place = gHeap.Allocate(obj_len);
-  auto s = new (place) Str();
+  void* place = gHeap.Allocate(sizeof(ObjHeader) + obj_len);
+  ObjHeader* header = new (place) ObjHeader(Str::obj_header());
+  auto s = new (header->ObjectAddress()) Str();
 #if MARK_SWEEP
-  s->header_.obj_id = gHeap.UnusedObjectId();
+  header->obj_id = gHeap.UnusedObjectId();
 #endif
   return s;
 }
@@ -170,10 +165,11 @@ inline Str* StrFromC(const char* data) {
 template <typename T>
 inline Slab<T>* NewSlab(int len) {
   int obj_len = RoundUp(kSlabHeaderSize + len * sizeof(T));
-  void* place = gHeap.Allocate(obj_len);
-  auto slab = new (place) Slab<T>(len);  // placement new
+  void* place = gHeap.Allocate(sizeof(ObjHeader) + obj_len);
+  ObjHeader* header = new (place) ObjHeader(Slab<T>::obj_header(len));
+  auto slab = new (header->ObjectAddress()) Slab<T>(len);
 #if MARK_SWEEP
-  slab->header_.obj_id = gHeap.UnusedObjectId();
+  header->obj_id = gHeap.UnusedObjectId();
 #endif
   return slab;
 }

--- a/mycpp/gc_builtins.h
+++ b/mycpp/gc_builtins.h
@@ -14,13 +14,11 @@ class Str;
 
 class _ExceptionOpaque {
  public:
-  _ExceptionOpaque() : header_(obj_header()) {
+  _ExceptionOpaque() {
   }
   static constexpr ObjHeader obj_header() {
     return ObjHeader::ClassFixed(kZeroMask, sizeof(_ExceptionOpaque));
   }
-
-  GC_OBJ(header_);
 };
 
 // mycpp removes constructor arguments
@@ -38,16 +36,15 @@ class StopIteration : public _ExceptionOpaque {};
 
 class ValueError {
  public:
-  ValueError() : header_(obj_header()), message(nullptr) {
+  ValueError() : message(nullptr) {
   }
-  explicit ValueError(Str* message) : header_(obj_header()), message(message) {
+  explicit ValueError(Str* message) : message(message) {
   }
 
   static constexpr ObjHeader obj_header() {
     return ObjHeader::ClassFixed(field_mask(), sizeof(ValueError));
   }
 
-  GC_OBJ(header_);
   Str* message;
 
   static constexpr uint32_t field_mask() {
@@ -62,15 +59,13 @@ class ValueError {
 // libc::regex_match and other bindings raise RuntimeError
 class RuntimeError {
  public:
-  explicit RuntimeError(Str* message)
-      : header_(obj_header()), message(message) {
+  explicit RuntimeError(Str* message) : message(message) {
   }
 
   static constexpr ObjHeader obj_header() {
     return ObjHeader::ClassFixed(field_mask(), sizeof(RuntimeError));
   }
 
-  GC_OBJ(header_);
   Str* message;
 
   static constexpr uint32_t field_mask() {

--- a/mycpp/gc_builtins_test.cc
+++ b/mycpp/gc_builtins_test.cc
@@ -221,10 +221,10 @@ TEST comparators_test() {
 
 TEST exceptions_test() {
   auto v1 = Alloc<ValueError>();
-  ASSERT_EQ(HeapTag::FixedSize, v1->header_.heap_tag);
+  ASSERT_EQ(HeapTag::FixedSize, ObjHeader::FromObject(v1).heap_tag);
 
   auto v2 = Alloc<ValueError>(kEmptyString);
-  ASSERT_EQ(HeapTag::FixedSize, v2->header_.heap_tag);
+  ASSERT_EQ(HeapTag::FixedSize, ObjHeader::FromObject(v2).heap_tag);
 
   IndexError* other;
   bool caught = false;

--- a/mycpp/gc_builtins_test.cc
+++ b/mycpp/gc_builtins_test.cc
@@ -221,10 +221,10 @@ TEST comparators_test() {
 
 TEST exceptions_test() {
   auto v1 = Alloc<ValueError>();
-  ASSERT_EQ(HeapTag::FixedSize, ObjHeader::FromObject(v1).heap_tag);
+  ASSERT_EQ(HeapTag::FixedSize, ObjHeader::FromObject(v1)->heap_tag);
 
   auto v2 = Alloc<ValueError>(kEmptyString);
-  ASSERT_EQ(HeapTag::FixedSize, ObjHeader::FromObject(v2).heap_tag);
+  ASSERT_EQ(HeapTag::FixedSize, ObjHeader::FromObject(v2)->heap_tag);
 
   IndexError* other;
   bool caught = false;

--- a/mycpp/gc_dict.h
+++ b/mycpp/gc_dict.h
@@ -44,8 +44,7 @@ class Dict {
 
  public:
   Dict()
-      : header_(obj_header()),
-        len_(0),
+      : len_(0),
         capacity_(0),
         entry_(nullptr),
         keys_(nullptr),
@@ -53,8 +52,7 @@ class Dict {
   }
 
   Dict(std::initializer_list<K> keys, std::initializer_list<V> values)
-      : header_(obj_header()),
-        len_(0),
+      : len_(0),
         capacity_(0),
         entry_(nullptr),
         keys_(nullptr),
@@ -112,7 +110,6 @@ class Dict {
     return ObjHeader::ClassFixed(field_mask(), sizeof(Dict));
   }
 
-  GC_OBJ(header_);
   int len_;       // number of entries (keys and values, almost dense)
   int capacity_;  // number of entries before resizing
 

--- a/mycpp/gc_dict_test.cc
+++ b/mycpp/gc_dict_test.cc
@@ -131,8 +131,10 @@ TEST test_dict_internals() {
   ASSERT_EQ(0, len(dict1));
   ASSERT_EQ(0, len(dict2));
 
-  ASSERT_EQ_FMT(HeapTag::FixedSize, dict1->header_.heap_tag, "%d");
-  ASSERT_EQ_FMT(HeapTag::FixedSize, dict1->header_.heap_tag, "%d");
+  ASSERT_EQ_FMT(HeapTag::FixedSize, ObjHeader::FromObject(dict1).heap_tag,
+                "%d");
+  ASSERT_EQ_FMT(HeapTag::FixedSize, ObjHeader::FromObject(dict1).heap_tag,
+                "%d");
 
   ASSERT_EQ_FMT(0, dict1->capacity_, "%d");
   ASSERT_EQ_FMT(0, dict2->capacity_, "%d");
@@ -157,9 +159,9 @@ TEST test_dict_internals() {
 #endif
 
 #if 0
-  ASSERT_EQ_FMT(32, dict1->entry_->header_.obj_len, "%d");
-  ASSERT_EQ_FMT(32, dict1->keys_->header_.obj_len, "%d");
-  ASSERT_EQ_FMT(32, dict1->values_->header_.obj_len, "%d");
+  ASSERT_EQ_FMT(32, ObjHeader::FromObject(dict1->entry_).obj_len, "%d");
+  ASSERT_EQ_FMT(32, ObjHeader::FromObject(dict1->keys_).obj_len, "%d");
+  ASSERT_EQ_FMT(32, ObjHeader::FromObject(dict1->values_).obj_len, "%d");
 #endif
 
   dict1->set(42, 99);
@@ -196,9 +198,9 @@ TEST test_dict_internals() {
   ASSERT(str_equals(bar, dict2->index_(foo)));
 
 #if 0
-  ASSERT_EQ_FMT(32, dict2->entry_->header_.obj_len, "%d");
-  ASSERT_EQ_FMT(64, dict2->keys_->header_.obj_len, "%d");
-  ASSERT_EQ_FMT(64, dict2->values_->header_.obj_len, "%d");
+  ASSERT_EQ_FMT(32, ObjHeader::FromObject(dict2->entry_).obj_len, "%d");
+  ASSERT_EQ_FMT(64, ObjHeader::FromObject(dict2->keys_).obj_len, "%d");
+  ASSERT_EQ_FMT(64, ObjHeader::FromObject(dict2->values_).obj_len, "%d");
 #endif
 
   auto dict_si = NewDict<Str*, int>();
@@ -207,9 +209,9 @@ TEST test_dict_internals() {
   ASSERT_EQ(1, len(dict_si));
 
 #if 0
-  ASSERT_EQ_FMT(32, dict_si->entry_->header_.obj_len, "%d");
-  ASSERT_EQ_FMT(64, dict_si->keys_->header_.obj_len, "%d");
-  ASSERT_EQ_FMT(32, dict_si->values_->header_.obj_len, "%d");
+  ASSERT_EQ_FMT(32, ObjHeader::FromObject(dict_si->entry_).obj_len, "%d");
+  ASSERT_EQ_FMT(64, ObjHeader::FromObject(dict_si->keys_).obj_len, "%d");
+  ASSERT_EQ_FMT(32, ObjHeader::FromObject(dict_si->values_).obj_len, "%d");
 #endif
 
   auto dict_is = NewDict<int, Str*>();
@@ -220,9 +222,9 @@ TEST test_dict_internals() {
   ASSERT_EQ(1, len(dict_is));
 
 #if 0
-  ASSERT_EQ_FMT(32, dict_is->entry_->header_.obj_len, "%d");
-  ASSERT_EQ_FMT(32, dict_is->keys_->header_.obj_len, "%d");
-  ASSERT_EQ_FMT(64, dict_is->values_->header_.obj_len, "%d");
+  ASSERT_EQ_FMT(32, ObjHeader::FromObject(dict_is->entry_).obj_len, "%d");
+  ASSERT_EQ_FMT(32, ObjHeader::FromObject(dict_is->keys_).obj_len, "%d");
+  ASSERT_EQ_FMT(64, ObjHeader::FromObject(dict_is->values_).obj_len, "%d");
 #endif
 
   auto two = StrFromC("two");

--- a/mycpp/gc_dict_test.cc
+++ b/mycpp/gc_dict_test.cc
@@ -131,9 +131,9 @@ TEST test_dict_internals() {
   ASSERT_EQ(0, len(dict1));
   ASSERT_EQ(0, len(dict2));
 
-  ASSERT_EQ_FMT(HeapTag::FixedSize, ObjHeader::FromObject(dict1).heap_tag,
+  ASSERT_EQ_FMT(HeapTag::FixedSize, ObjHeader::FromObject(dict1)->heap_tag,
                 "%d");
-  ASSERT_EQ_FMT(HeapTag::FixedSize, ObjHeader::FromObject(dict1).heap_tag,
+  ASSERT_EQ_FMT(HeapTag::FixedSize, ObjHeader::FromObject(dict1)->heap_tag,
                 "%d");
 
   ASSERT_EQ_FMT(0, dict1->capacity_, "%d");
@@ -159,9 +159,9 @@ TEST test_dict_internals() {
 #endif
 
 #if 0
-  ASSERT_EQ_FMT(32, ObjHeader::FromObject(dict1->entry_).obj_len, "%d");
-  ASSERT_EQ_FMT(32, ObjHeader::FromObject(dict1->keys_).obj_len, "%d");
-  ASSERT_EQ_FMT(32, ObjHeader::FromObject(dict1->values_).obj_len, "%d");
+  ASSERT_EQ_FMT(32, ObjHeader::FromObject(dict1->entry_)->obj_len, "%d");
+  ASSERT_EQ_FMT(32, ObjHeader::FromObject(dict1->keys_)->obj_len, "%d");
+  ASSERT_EQ_FMT(32, ObjHeader::FromObject(dict1->values_)->obj_len, "%d");
 #endif
 
   dict1->set(42, 99);
@@ -198,9 +198,9 @@ TEST test_dict_internals() {
   ASSERT(str_equals(bar, dict2->index_(foo)));
 
 #if 0
-  ASSERT_EQ_FMT(32, ObjHeader::FromObject(dict2->entry_).obj_len, "%d");
-  ASSERT_EQ_FMT(64, ObjHeader::FromObject(dict2->keys_).obj_len, "%d");
-  ASSERT_EQ_FMT(64, ObjHeader::FromObject(dict2->values_).obj_len, "%d");
+  ASSERT_EQ_FMT(32, ObjHeader::FromObject(dict2->entry_)->obj_len, "%d");
+  ASSERT_EQ_FMT(64, ObjHeader::FromObject(dict2->keys_)->obj_len, "%d");
+  ASSERT_EQ_FMT(64, ObjHeader::FromObject(dict2->values_)->obj_len, "%d");
 #endif
 
   auto dict_si = NewDict<Str*, int>();
@@ -209,9 +209,9 @@ TEST test_dict_internals() {
   ASSERT_EQ(1, len(dict_si));
 
 #if 0
-  ASSERT_EQ_FMT(32, ObjHeader::FromObject(dict_si->entry_).obj_len, "%d");
-  ASSERT_EQ_FMT(64, ObjHeader::FromObject(dict_si->keys_).obj_len, "%d");
-  ASSERT_EQ_FMT(32, ObjHeader::FromObject(dict_si->values_).obj_len, "%d");
+  ASSERT_EQ_FMT(32, ObjHeader::FromObject(dict_si->entry_)->obj_len, "%d");
+  ASSERT_EQ_FMT(64, ObjHeader::FromObject(dict_si->keys_)->obj_len, "%d");
+  ASSERT_EQ_FMT(32, ObjHeader::FromObject(dict_si->values_)->obj_len, "%d");
 #endif
 
   auto dict_is = NewDict<int, Str*>();
@@ -222,9 +222,9 @@ TEST test_dict_internals() {
   ASSERT_EQ(1, len(dict_is));
 
 #if 0
-  ASSERT_EQ_FMT(32, ObjHeader::FromObject(dict_is->entry_).obj_len, "%d");
-  ASSERT_EQ_FMT(32, ObjHeader::FromObject(dict_is->keys_).obj_len, "%d");
-  ASSERT_EQ_FMT(64, ObjHeader::FromObject(dict_is->values_).obj_len, "%d");
+  ASSERT_EQ_FMT(32, ObjHeader::FromObject(dict_is->entry_)->obj_len, "%d");
+  ASSERT_EQ_FMT(32, ObjHeader::FromObject(dict_is->keys_)->obj_len, "%d");
+  ASSERT_EQ_FMT(64, ObjHeader::FromObject(dict_is->values_)->obj_len, "%d");
 #endif
 
   auto two = StrFromC("two");

--- a/mycpp/gc_heap_test.cc
+++ b/mycpp/gc_heap_test.cc
@@ -24,13 +24,13 @@ static_assert(offsetof(List<int>, slab_) ==
 
 void ShowSlab(void* obj) {
   auto slab = reinterpret_cast<Slab<void*>*>(obj);
-  auto& header = ObjHeader::FromObject(obj);
-  assert(header.heap_tag == HeapTag::Scanned);
+  auto* header = ObjHeader::FromObject(obj);
+  assert(header->heap_tag == HeapTag::Scanned);
 
-  int n = NUM_POINTERS(header);
+  int n = NUM_POINTERS(*header);
 #if 0
   int n = (slab->header_.obj_len - kSlabHeaderSize) / sizeof(void*);
-  log("slab len = %d, n = %d", ObjHeader::FromObject(slab).obj_len, n);
+  log("slab len = %d, n = %d", ObjHeader::FromObject(slab)->obj_len, n);
 #endif
   for (int i = 0; i < n; ++i) {
     void* p = slab->items_[i];
@@ -48,7 +48,7 @@ TEST field_masks_test() {
   StackRoots _roots({&L});
 
   L->append(1);
-  log("List mask = %d", FIELD_MASK(ObjHeader::FromObject(L)));
+  log("List mask = %d", FIELD_MASK(*ObjHeader::FromObject(L)));
 
   auto d = Alloc<Dict<Str*, int>>();
   StackRoots _roots2({&d});
@@ -61,7 +61,7 @@ TEST field_masks_test() {
   // expression!  Gah!
   // d->set(StrFromC("foo"), 3);
 
-  log("Dict mask = %d", FIELD_MASK(ObjHeader::FromObject(d)));
+  log("Dict mask = %d", FIELD_MASK(*ObjHeader::FromObject(d)));
 
 #if 0
   ShowFixedChildren(L);

--- a/mycpp/gc_heap_test.cc
+++ b/mycpp/gc_heap_test.cc
@@ -18,21 +18,19 @@ static_assert(offsetof(Slab<int>, items_) ==
                   offsetof(GlobalSlab<int COMMA 1>, items_),
               "Slab and GlobalSlab should be consistent");
 
-static_assert(kSlabHeaderSize == offsetof(GlobalSlab<int COMMA 1>, items_),
-              "kSlabHeaderSize and GlobalSlab should be consistent");
-
 static_assert(offsetof(List<int>, slab_) ==
                   offsetof(GlobalList<int COMMA 1>, slab_),
               "List and GlobalList should be consistent");
 
 void ShowSlab(void* obj) {
   auto slab = reinterpret_cast<Slab<void*>*>(obj);
-  assert(slab->header_.heap_tag == HeapTag::Scanned);
+  auto& header = ObjHeader::FromObject(obj);
+  assert(header.heap_tag == HeapTag::Scanned);
 
-  int n = NUM_POINTERS(slab->header_);
+  int n = NUM_POINTERS(header);
 #if 0
   int n = (slab->header_.obj_len - kSlabHeaderSize) / sizeof(void*);
-  log("slab len = %d, n = %d", slab->header_.obj_len, n);
+  log("slab len = %d, n = %d", ObjHeader::FromObject(slab).obj_len, n);
 #endif
   for (int i = 0; i < n; ++i) {
     void* p = slab->items_[i];
@@ -50,7 +48,7 @@ TEST field_masks_test() {
   StackRoots _roots({&L});
 
   L->append(1);
-  log("List mask = %d", FIELD_MASK(L->header_));
+  log("List mask = %d", FIELD_MASK(ObjHeader::FromObject(L)));
 
   auto d = Alloc<Dict<Str*, int>>();
   StackRoots _roots2({&d});
@@ -63,7 +61,7 @@ TEST field_masks_test() {
   // expression!  Gah!
   // d->set(StrFromC("foo"), 3);
 
-  log("Dict mask = %d", FIELD_MASK(d->header_));
+  log("Dict mask = %d", FIELD_MASK(ObjHeader::FromObject(d)));
 
 #if 0
   ShowFixedChildren(L);
@@ -92,9 +90,9 @@ TEST offsets_test() {
   unsigned list_mask = List<int>::field_mask();
   ASSERT_EQ_FMT(0x0002, list_mask, "0x%x");
 
-  // in binary: 0b 0000 0000 0000 01110
+  // in binary: 0b 0000 0000 0000 1110
   unsigned dict_mask = Dict<int COMMA int>::field_mask();
-  ASSERT_EQ_FMT(0x000E, dict_mask, "0x%x");
+  ASSERT_EQ_FMT(0x0000e, dict_mask, "0x%x");
 
   PASS();
 }
@@ -115,7 +113,7 @@ TEST roundup_test() {
 
 class Point {
  public:
-  Point(int x, int y) : header_(obj_header()), x_(x), y_(y) {
+  Point(int x, int y) : x_(x), y_(y) {
   }
   int size() {
     return x_ + y_;
@@ -125,7 +123,6 @@ class Point {
     return ObjHeader::ClassFixed(kZeroMask, sizeof(Point));
   }
 
-  GC_OBJ(header_);
   int x_;
   int y_;
 };
@@ -134,14 +131,13 @@ const int kLineMask = 0x3;  // 0b0011
 
 class Line {
  public:
-  Line() : header_(obj_header()), begin_(nullptr), end_(nullptr) {
+  Line() : begin_(nullptr), end_(nullptr) {
   }
 
   static constexpr ObjHeader obj_header() {
     return ObjHeader::ClassFixed(kLineMask, sizeof(Line));
   }
 
-  GC_OBJ(header_);
   Point* begin_;
   Point* end_;
 };
@@ -288,7 +284,7 @@ TEST global_trace_test() {
 // 8 byte vtable, 8 byte ObjHeader, then member_
 class BaseObj {
  public:
-  explicit BaseObj(uint32_t obj_len) : header_(obj_header(obj_len)) {
+  explicit BaseObj(uint32_t obj_len) {
   }
   BaseObj() : BaseObj(sizeof(BaseObj)) {
   }
@@ -297,11 +293,10 @@ class BaseObj {
     return 3;
   }
 
-  static constexpr ObjHeader obj_header(uint32_t obj_len) {
-    return ObjHeader::ClassFixed(kZeroMask, obj_len);
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(BaseObj));
   }
 
-  GC_OBJ(header_);
   int member_ = 254;
 };
 
@@ -314,6 +309,10 @@ class DerivedObj : public BaseObj {
     return 4;
   }
 
+  static constexpr ObjHeader obj_header() {
+    return ObjHeader::ClassFixed(kZeroMask, sizeof(DerivedObj));
+  }
+
   int derived_member_ = 253;
   int derived_member2_ = 252;
 };
@@ -323,54 +322,6 @@ void ShowObj(ObjHeader* obj) {
 #if 0
   log("obj->obj_len %d", obj->obj_len);
 #endif
-}
-
-TEST vtable_test() {
-  DerivedObj d3;
-  BaseObj* b3 = &d3;
-  log("method = %d", b3->Method());
-
-  BaseObj base3;
-
-#if 0
-  log("BaseObj obj_len = %d", base3.header_.obj_len);
-  log("derived b3->obj_len = %d", b3->header_.obj_len);  // derived length
-#endif
-  log("sizeof(d3) = %d", sizeof(d3));
-
-  unsigned char* c3 = reinterpret_cast<unsigned char*>(b3);
-  log("c3[0] = %x", c3[0]);
-  log("c3[1] = %x", c3[1]);
-  log("c3[2] = %x", c3[2]);
-  log("c3[8] = %x", c3[8]);  // this is the ObjHeader
-
-  log("c3[12] = %x", c3[12]);  // this is padding?   gah.
-
-  log("c3[16] = %x", c3[16]);  // 0xfe is member_
-  log("c3[20] = %x", c3[20]);  // 0xfd is derived_member_
-
-  // Note: if static casting, then it doesn't include the vtable pointer!  Must
-  // reinterpret_cast!
-  ObjHeader* obj = reinterpret_cast<ObjHeader*>(b3);
-
-  ShowObj(obj);
-  if (obj->is_header) {
-    ASSERT(false);  // shouldn't get here
-  } else {          // vtable pointer, NOT A TAG!
-    ObjHeader* header = reinterpret_cast<ObjHeader*>(
-        reinterpret_cast<char*>(obj) + sizeof(void*));
-    // Now we have the right GC info.
-    ShowObj(header);
-
-    ASSERT_EQ_FMT(HeapTag::FixedSize, header->heap_tag, "%d");
-    ASSERT_EQ_FMT(0, FIELD_MASK(*header), "%d");
-#if 0
-    // casts get rid of warning
-    ASSERT_EQ_FMT((int)sizeof(DerivedObj), (int)header->obj_len, "%d");
-#endif
-  }
-
-  PASS();
 }
 
 TEST inheritance_test() {
@@ -431,7 +382,6 @@ int main(int argc, char** argv) {
   RUN_TEST(slab_trace_test);
   RUN_TEST(global_trace_test);
 
-  RUN_TEST(vtable_test);
   RUN_TEST(inheritance_test);
 
   RUN_TEST(stack_roots_test);

--- a/mycpp/gc_list.h
+++ b/mycpp/gc_list.h
@@ -414,9 +414,9 @@ List<T>* list(List<T>* other) {
 }
 
 #define GLOBAL_LIST(T, N, name, array)                               \
-  InlineGcObj<GlobalSlab<T, N>> _slab_##name = {                     \
+  GcGlobal<GlobalSlab<T, N>> _slab_##name = {                        \
       {kIsHeader, 0, kZeroMask, HeapTag::Global, kIsGlobal}, array}; \
-  InlineGcObj<GlobalList<T, N>> _list_##name = {                     \
+  GcGlobal<GlobalList<T, N>> _list_##name = {                        \
       {kIsHeader, 0, kZeroMask, HeapTag::Global, kIsGlobal},         \
       {N, N, &_slab_##name.obj}};                                    \
   List<T>* name = reinterpret_cast<List<T>*>(&_list_##name.obj);

--- a/mycpp/gc_list.h
+++ b/mycpp/gc_list.h
@@ -17,7 +17,6 @@
 template <typename T, int N>
 class GlobalList {
  public:
-  ObjHeader header_;
   int len_;
   int capacity_;
   GlobalSlab<T, N>* slab_;
@@ -39,7 +38,7 @@ class List {
                 "An integral number of items should fit in 32 bytes");
 
  public:
-  List() : header_(obj_header()), len_(0), capacity_(0), slab_(nullptr) {
+  List() : len_(0), capacity_(0), slab_(nullptr) {
   }
 
   // Implements L[i]
@@ -87,8 +86,6 @@ class List {
   static constexpr ObjHeader obj_header() {
     return ObjHeader::ClassFixed(field_mask(), sizeof(List<T>));
   }
-
-  GC_OBJ(header_);
 
   int len_;       // number of entries
   int capacity_;  // max entries before resizing
@@ -417,14 +414,12 @@ List<T>* list(List<T>* other) {
 }
 
 #define GLOBAL_LIST(T, N, name, array)                               \
-  GlobalSlab<T, N> _slab_##name = {                                  \
+  InlineGcObj<GlobalSlab<T, N>> _slab_##name = {                     \
       {kIsHeader, 0, kZeroMask, HeapTag::Global, kIsGlobal}, array}; \
-  GlobalList<T, N> _list_##name = {                                  \
+  InlineGcObj<GlobalList<T, N>> _list_##name = {                     \
       {kIsHeader, 0, kZeroMask, HeapTag::Global, kIsGlobal},         \
-      N,                                                             \
-      N,                                                             \
-      &_slab_##name};                                                \
-  List<T>* name = reinterpret_cast<List<T>*>(&_list_##name);
+      {N, N, &_slab_##name.obj}};                                    \
+  List<T>* name = reinterpret_cast<List<T>*>(&_list_##name.obj);
 
 template <class T>
 class ListIter {

--- a/mycpp/gc_list_test.cc
+++ b/mycpp/gc_list_test.cc
@@ -40,13 +40,15 @@ TEST test_list_gc_header() {
   ASSERT_EQ_FMT(0, list1->capacity_, "%d");
   ASSERT_EQ_FMT(0, list2->capacity_, "%d");
 
-  ASSERT_EQ_FMT(HeapTag::FixedSize, list1->header_.heap_tag, "%d");
-  ASSERT_EQ_FMT(HeapTag::FixedSize, list2->header_.heap_tag, "%d");
+  ASSERT_EQ_FMT(HeapTag::FixedSize, ObjHeader::FromObject(list1).heap_tag,
+                "%d");
+  ASSERT_EQ_FMT(HeapTag::FixedSize, ObjHeader::FromObject(list2).heap_tag,
+                "%d");
 
 #if 0
   // 8 byte obj header + 2 integers + pointer
-  ASSERT_EQ_FMT(24, list1->header_.obj_len, "%d");
-  ASSERT_EQ_FMT(24, list2->header_.obj_len, "%d");
+  ASSERT_EQ_FMT(24, ObjHeader::FromObject(list1).obj_len, "%d");
+  ASSERT_EQ_FMT(24, ObjHeader::FromObject(list2).obj_len, "%d");
 #endif
 
   // Make sure they're on the heap
@@ -64,11 +66,12 @@ TEST test_list_gc_header() {
 
   // 32 byte block - 8 byte header = 24 bytes, 6 elements
   ASSERT_EQ_FMT(6, list1->capacity_, "%d");
-  ASSERT_EQ_FMT(HeapTag::Opaque, list1->slab_->header_.heap_tag, "%d");
+  ASSERT_EQ_FMT(HeapTag::Opaque, ObjHeader::FromObject(list1->slab_).heap_tag,
+                "%d");
 
 #if 0
   // 8 byte header + 3*4 == 8 + 12 == 20, rounded up to power of 2
-  ASSERT_EQ_FMT(32, list1->slab_->header_.obj_len, "%d");
+  ASSERT_EQ_FMT(32, ObjHeader::FromObject(list1->slab_).obj_len, "%d");
 #endif
 
   ASSERT_EQ_FMT(11, list1->index_(0), "%d");
@@ -86,7 +89,7 @@ TEST test_list_gc_header() {
 
 #if 0
   // 8 bytes header + 7*4 == 8 + 28 == 36, rounded up to power of 2
-  ASSERT_EQ_FMT(64, list1->slab_->header_.obj_len, "%d");
+  ASSERT_EQ_FMT(64, ObjHeader::FromObject(list1->slab_).obj_len, "%d");
 #endif
 
   ASSERT_EQ_FMT(11, list1->index_(0), "%d");
@@ -126,14 +129,14 @@ TEST test_list_gc_header() {
 }
 
 // Manual initialization.  This helped me write the GLOBAL_LIST() macro.
-GlobalSlab<int, 3> _gSlab = {
+InlineGcObj<GlobalSlab<int, 3>> _gSlab = {
     {kIsHeader, 0, kZeroMask, HeapTag::Global, kUndefinedId}, {5, 6, 7}};
-GlobalList<int, 3> _gList = {
+InlineGcObj<GlobalList<int, 3>> _gList = {
     {kIsHeader, 0, kZeroMask, HeapTag::Global, kUndefinedId},
-    3,  // len
-    3,  // capacity
-    &_gSlab};
-List<int>* gList = reinterpret_cast<List<int>*>(&_gList);
+    {3,  // len
+     3,  // capacity
+     &_gSlab.obj}};
+List<int>* gList = reinterpret_cast<List<int>*>(&_gList.obj);
 
 GLOBAL_LIST(int, 4, gList2, {5 COMMA 4 COMMA 3 COMMA 2});
 

--- a/mycpp/gc_list_test.cc
+++ b/mycpp/gc_list_test.cc
@@ -40,15 +40,15 @@ TEST test_list_gc_header() {
   ASSERT_EQ_FMT(0, list1->capacity_, "%d");
   ASSERT_EQ_FMT(0, list2->capacity_, "%d");
 
-  ASSERT_EQ_FMT(HeapTag::FixedSize, ObjHeader::FromObject(list1).heap_tag,
+  ASSERT_EQ_FMT(HeapTag::FixedSize, ObjHeader::FromObject(list1)->heap_tag,
                 "%d");
-  ASSERT_EQ_FMT(HeapTag::FixedSize, ObjHeader::FromObject(list2).heap_tag,
+  ASSERT_EQ_FMT(HeapTag::FixedSize, ObjHeader::FromObject(list2)->heap_tag,
                 "%d");
 
 #if 0
   // 8 byte obj header + 2 integers + pointer
-  ASSERT_EQ_FMT(24, ObjHeader::FromObject(list1).obj_len, "%d");
-  ASSERT_EQ_FMT(24, ObjHeader::FromObject(list2).obj_len, "%d");
+  ASSERT_EQ_FMT(24, ObjHeader::FromObject(list1)->obj_len, "%d");
+  ASSERT_EQ_FMT(24, ObjHeader::FromObject(list2)->obj_len, "%d");
 #endif
 
   // Make sure they're on the heap
@@ -66,12 +66,12 @@ TEST test_list_gc_header() {
 
   // 32 byte block - 8 byte header = 24 bytes, 6 elements
   ASSERT_EQ_FMT(6, list1->capacity_, "%d");
-  ASSERT_EQ_FMT(HeapTag::Opaque, ObjHeader::FromObject(list1->slab_).heap_tag,
+  ASSERT_EQ_FMT(HeapTag::Opaque, ObjHeader::FromObject(list1->slab_)->heap_tag,
                 "%d");
 
 #if 0
   // 8 byte header + 3*4 == 8 + 12 == 20, rounded up to power of 2
-  ASSERT_EQ_FMT(32, ObjHeader::FromObject(list1->slab_).obj_len, "%d");
+  ASSERT_EQ_FMT(32, ObjHeader::FromObject(list1->slab_)->obj_len, "%d");
 #endif
 
   ASSERT_EQ_FMT(11, list1->index_(0), "%d");
@@ -89,7 +89,7 @@ TEST test_list_gc_header() {
 
 #if 0
   // 8 bytes header + 7*4 == 8 + 28 == 36, rounded up to power of 2
-  ASSERT_EQ_FMT(64, ObjHeader::FromObject(list1->slab_).obj_len, "%d");
+  ASSERT_EQ_FMT(64, ObjHeader::FromObject(list1->slab_)->obj_len, "%d");
 #endif
 
   ASSERT_EQ_FMT(11, list1->index_(0), "%d");
@@ -129,9 +129,9 @@ TEST test_list_gc_header() {
 }
 
 // Manual initialization.  This helped me write the GLOBAL_LIST() macro.
-InlineGcObj<GlobalSlab<int, 3>> _gSlab = {
+GcGlobal<GlobalSlab<int, 3>> _gSlab = {
     {kIsHeader, 0, kZeroMask, HeapTag::Global, kUndefinedId}, {5, 6, 7}};
-InlineGcObj<GlobalList<int, 3>> _gList = {
+GcGlobal<GlobalList<int, 3>> _gList = {
     {kIsHeader, 0, kZeroMask, HeapTag::Global, kUndefinedId},
     {3,  // len
      3,  // capacity

--- a/mycpp/gc_obj.h
+++ b/mycpp/gc_obj.h
@@ -71,6 +71,11 @@ struct ObjHeader {
         static_cast<char*>(const_cast<void*>(obj)) - sizeof(ObjHeader));
   }
 
+  ObjHeader& SetIsGlobal() {
+    heap_tag = HeapTag::Global;
+    return *this;
+  }
+
   // Used by hand-written and generated classes
   static constexpr ObjHeader ClassFixed(uint32_t field_mask, uint32_t obj_len) {
     return {kIsHeader, TypeTag::OtherClass, field_mask, HeapTag::FixedSize,

--- a/mycpp/gc_slab.h
+++ b/mycpp/gc_slab.h
@@ -4,7 +4,7 @@
 #include <utility>  // std::is_pointer
 
 #include "mycpp/common.h"  // DISALLOW_COPY_AND_ASSIGN
-#include "mycpp/gc_obj.h"  // GC_OBJ
+#include "mycpp/gc_obj.h"
 
 // Return the size of a resizeable allocation.  Just round up to the nearest
 // power of 2.  (CPython has an interesting policy in listobject.c.)
@@ -29,7 +29,7 @@ template <typename T>
 class Slab {
   // Slabs of pointers are scanned; slabs of ints/bools are opaque.
  public:
-  explicit Slab(unsigned num_items) : header_(obj_header(num_items)) {
+  explicit Slab(unsigned num_items) {
   }
 
   static constexpr ObjHeader obj_header(unsigned num_items) {
@@ -37,7 +37,6 @@ class Slab {
         std::is_pointer<T>() ? HeapTag::Scanned : HeapTag::Opaque, num_items);
   }
 
-  GC_OBJ(header_);
   T items_[1];  // variable length
 
   DISALLOW_COPY_AND_ASSIGN(Slab);
@@ -48,13 +47,12 @@ class GlobalSlab {
   // A template type with the same layout as Slab of length N.  For
   // initializing global constant List.
  public:
-  ObjHeader header_;
   T items_[N];
 
   DISALLOW_COPY_AND_ASSIGN(GlobalSlab)
 };
 
-// The first field is items_
-const int kSlabHeaderSize = offsetof(Slab<int>, items_);
+// XXX(watk): Does this make sense?
+const int kSlabHeaderSize = sizeof(ObjHeader);
 
 #endif  // GC_SLAB_H

--- a/mycpp/gc_str.cc
+++ b/mycpp/gc_str.cc
@@ -525,7 +525,7 @@ static inline Str* _StrFormat(const char* fmt, int fmt_len, va_list args) {
     case 's': {
       Str* s = va_arg(args, Str*);
       // Check type unconditionally because mycpp doesn't always check it
-      CHECK(s->header_.type_tag == TypeTag::Str);
+      CHECK(ObjHeader::FromObject(s).type_tag == TypeTag::Str);
 
       str_to_add = s->data();
       add_len = len(s);
@@ -535,7 +535,7 @@ static inline Str* _StrFormat(const char* fmt, int fmt_len, va_list args) {
     case 'r': {
       Str* s = va_arg(args, Str*);
       // Check type unconditionally because mycpp doesn't always check it
-      CHECK(s->header_.type_tag == TypeTag::Str);
+      CHECK(ObjHeader::FromObject(s).type_tag == TypeTag::Str);
 
       s = repr(s);
       str_to_add = s->data();

--- a/mycpp/gc_str.cc
+++ b/mycpp/gc_str.cc
@@ -525,7 +525,7 @@ static inline Str* _StrFormat(const char* fmt, int fmt_len, va_list args) {
     case 's': {
       Str* s = va_arg(args, Str*);
       // Check type unconditionally because mycpp doesn't always check it
-      CHECK(ObjHeader::FromObject(s).type_tag == TypeTag::Str);
+      CHECK(ObjHeader::FromObject(s)->type_tag == TypeTag::Str);
 
       str_to_add = s->data();
       add_len = len(s);
@@ -535,7 +535,7 @@ static inline Str* _StrFormat(const char* fmt, int fmt_len, va_list args) {
     case 'r': {
       Str* s = va_arg(args, Str*);
       // Check type unconditionally because mycpp doesn't always check it
-      CHECK(ObjHeader::FromObject(s).type_tag == TypeTag::Str);
+      CHECK(ObjHeader::FromObject(s)->type_tag == TypeTag::Str);
 
       s = repr(s);
       str_to_add = s->data();

--- a/mycpp/gc_str.h
+++ b/mycpp/gc_str.h
@@ -159,7 +159,7 @@ class GlobalStr {
 // https://stackoverflow.com/questions/10422487/how-can-i-initialize-char-arrays-in-a-constructor
 
 #define GLOBAL_STR(name, val)                                           \
-  InlineGcObj<GlobalStr<sizeof(val)>> _##name = {                       \
+  GcGlobal<GlobalStr<sizeof(val)>> _##name = {                          \
       {kIsHeader, TypeTag::Str, kZeroMask, HeapTag::Global, kIsGlobal}, \
       {sizeof(val) - 1, val}};                                          \
   Str* name = reinterpret_cast<Str*>(&_##name.obj);

--- a/mycpp/gc_str.h
+++ b/mycpp/gc_str.h
@@ -10,7 +10,7 @@ class List;
 class Str {
  public:
   // Don't call this directly.  Call NewStr() instead, which calls this.
-  Str() : header_(obj_header()) {
+  Str() {
   }
 
   char* data() {
@@ -73,7 +73,6 @@ class Str {
     return ObjHeader::Str();
   }
 
-  GC_OBJ(header_);
   int len_;
   char data_[1];  // flexible array
 
@@ -145,7 +144,6 @@ class GlobalStr {
   // A template type with the same layout as Str with length N-1 (which needs a
   // buffer of size N).  For initializing global constant instances.
  public:
-  ObjHeader header_;
   int hash_value_;
   const char data_[N];
 
@@ -161,10 +159,9 @@ class GlobalStr {
 // https://stackoverflow.com/questions/10422487/how-can-i-initialize-char-arrays-in-a-constructor
 
 #define GLOBAL_STR(name, val)                                           \
-  GlobalStr<sizeof(val)> _##name = {                                    \
+  InlineGcObj<GlobalStr<sizeof(val)>> _##name = {                       \
       {kIsHeader, TypeTag::Str, kZeroMask, HeapTag::Global, kIsGlobal}, \
-      sizeof(val) - 1,                                                  \
-      val};                                                             \
-  Str* name = reinterpret_cast<Str*>(&_##name);
+      {sizeof(val) - 1, val}};                                          \
+  Str* name = reinterpret_cast<Str*>(&_##name.obj);
 
 #endif  // MYCPP_GC_STR_H

--- a/mycpp/gc_str_test.cc
+++ b/mycpp/gc_str_test.cc
@@ -44,7 +44,7 @@ TEST test_str_gc_header() {
   str1 = StrFromC("");
   str2 = StrFromC("one\0two", 7);
 
-  ASSERT_EQ_FMT(HeapTag::Opaque, ObjHeader::FromObject(str2).heap_tag, "%d");
+  ASSERT_EQ_FMT(HeapTag::Opaque, ObjHeader::FromObject(str2)->heap_tag, "%d");
   // ASSERT_EQ_FMT(kStrHeaderSize + 1, str1->header_.obj_len, "%d");
   // ASSERT_EQ_FMT(kStrHeaderSize + 7 + 1, str2->header_.obj_len, "%d");
 
@@ -65,7 +65,7 @@ TEST test_str_gc_header() {
   ASSERT_EQ('g', str4->data_[1]);
   ASSERT_EQ('g', str4->data_[2]);
   ASSERT_EQ('\0', str4->data_[3]);
-  ASSERT_EQ(HeapTag::Global, ObjHeader::FromObject(str4).heap_tag);
+  ASSERT_EQ(HeapTag::Global, ObjHeader::FromObject(str4)->heap_tag);
   // ASSERT_EQ(16, str4->header_.obj_len);
   ASSERT_EQ(3, len(str4));
 

--- a/mycpp/gc_str_test.cc
+++ b/mycpp/gc_str_test.cc
@@ -44,7 +44,7 @@ TEST test_str_gc_header() {
   str1 = StrFromC("");
   str2 = StrFromC("one\0two", 7);
 
-  ASSERT_EQ_FMT(HeapTag::Opaque, str2->header_.heap_tag, "%d");
+  ASSERT_EQ_FMT(HeapTag::Opaque, ObjHeader::FromObject(str2).heap_tag, "%d");
   // ASSERT_EQ_FMT(kStrHeaderSize + 1, str1->header_.obj_len, "%d");
   // ASSERT_EQ_FMT(kStrHeaderSize + 7 + 1, str2->header_.obj_len, "%d");
 
@@ -65,7 +65,7 @@ TEST test_str_gc_header() {
   ASSERT_EQ('g', str4->data_[1]);
   ASSERT_EQ('g', str4->data_[2]);
   ASSERT_EQ('\0', str4->data_[3]);
-  ASSERT_EQ(HeapTag::Global, str4->header_.heap_tag);
+  ASSERT_EQ(HeapTag::Global, ObjHeader::FromObject(str4).heap_tag);
   // ASSERT_EQ(16, str4->header_.obj_len);
   ASSERT_EQ(3, len(str4));
 

--- a/mycpp/gc_tuple.h
+++ b/mycpp/gc_tuple.h
@@ -6,7 +6,7 @@ class Tuple2 {
   typedef Tuple2<A, B> this_type;
 
  public:
-  Tuple2(A a, B b) : header_(obj_header()), a_(a), b_(b) {
+  Tuple2(A a, B b) : a_(a), b_(b) {
   }
 
   A at0() {
@@ -25,8 +25,6 @@ class Tuple2 {
            (std::is_pointer<B>() ? maskbit(offsetof(this_type, b_)) : 0);
   }
 
-  GC_OBJ(header_);
-
  private:
   A a_;
   B b_;
@@ -37,7 +35,7 @@ class Tuple3 {
   typedef Tuple3<A, B, C> this_type;
 
  public:
-  Tuple3(A a, B b, C c) : header_(obj_header()), a_(a), b_(b), c_(c) {
+  Tuple3(A a, B b, C c) : a_(a), b_(b), c_(c) {
   }
   A at0() {
     return a_;
@@ -59,8 +57,6 @@ class Tuple3 {
            (std::is_pointer<C>() ? maskbit(offsetof(this_type, c_)) : 0);
   }
 
-  GC_OBJ(header_);
-
  private:
   A a_;
   B b_;
@@ -72,8 +68,7 @@ class Tuple4 {
   typedef Tuple4<A, B, C, D> this_type;
 
  public:
-  Tuple4(A a, B b, C c, D d)
-      : header_(obj_header()), a_(a), b_(b), c_(c), d_(d) {
+  Tuple4(A a, B b, C c, D d) : a_(a), b_(b), c_(c), d_(d) {
   }
   A at0() {
     return a_;
@@ -98,8 +93,6 @@ class Tuple4 {
            (std::is_pointer<C>() ? maskbit(offsetof(this_type, c_)) : 0) |
            (std::is_pointer<D>() ? maskbit(offsetof(this_type, d_)) : 0);
   }
-
-  GC_OBJ(header_);
 
  private:
   A a_;

--- a/mycpp/gc_tuple_test.cc
+++ b/mycpp/gc_tuple_test.cc
@@ -2,26 +2,26 @@
 #include "vendor/greatest.h"
 
 TEST tuple_field_masks_test() {
-  Tuple2<Str *, Str *> ss(nullptr, nullptr);
-  ASSERT_EQ_FMT(0b11, FIELD_MASK(ss.header_), "%d");
+  auto ss = Tuple2<Str *, Str *>::obj_header();
+  ASSERT_EQ_FMT(0b11, FIELD_MASK(ss), "%d");
 
   // 8 + 4 on 64 bit
-  Tuple2<Str *, int> si(nullptr, 42);
-  ASSERT_EQ_FMT(0b01, FIELD_MASK(si.header_), "%d");
+  auto si = Tuple2<Str *, int>::obj_header();
+  ASSERT_EQ_FMT(0b01, FIELD_MASK(si), "%d");
 
   // 4 + 8 on 64 bit
-  Tuple2<int, Str *> is(42, nullptr);
-  ASSERT_EQ_FMT(0b10, FIELD_MASK(is.header_), "%d");
+  auto is = Tuple2<int, Str *>::obj_header();
+  ASSERT_EQ_FMT(0b10, FIELD_MASK(is), "%d");
 
-  Tuple3<Str *, Str *, Str *> sss(nullptr, nullptr, nullptr);
-  ASSERT_EQ_FMT(0b111, FIELD_MASK(sss.header_), "%d");
+  auto sss = Tuple3<Str *, Str *, Str *>::obj_header();
+  ASSERT_EQ_FMT(0b111, FIELD_MASK(sss), "%d");
 
-  Tuple3<int, Str *, Str *> iss(42, nullptr, nullptr);
-  ASSERT_EQ_FMT(0b110, FIELD_MASK(iss.header_), "%d");
+  auto iss = Tuple3<int, Str *, Str *>::obj_header();
+  ASSERT_EQ_FMT(0b110, FIELD_MASK(iss), "%d");
 
   // 4 + 4 + 8 + 8, so it's 0b110 not 0b1100
-  Tuple4<int, int, Str *, Str *> iiss(42, 42, nullptr, nullptr);
-  ASSERT_EQ_FMT(0b110, FIELD_MASK(iiss.header_), "%d");
+  auto iiss = Tuple4<int, int, Str *, Str *>::obj_header();
+  ASSERT_EQ_FMT(0b110, FIELD_MASK(iiss), "%d");
 
   PASS();
 }

--- a/mycpp/mark_sweep_heap_test.cc
+++ b/mycpp/mark_sweep_heap_test.cc
@@ -161,14 +161,13 @@ TEST list_collection_test() {
 
 class Node {
  public:
-  Node() : header_(obj_header()), next_(nullptr) {
+  Node() : next_(nullptr) {
   }
 
   static constexpr ObjHeader obj_header() {
     return ObjHeader::ClassFixed(field_mask(), sizeof(Node));
   }
 
-  GC_OBJ(header_);
   Node *next_;
 
   static constexpr uint32_t field_mask() {

--- a/mycpp/small_str_test.cc
+++ b/mycpp/small_str_test.cc
@@ -48,7 +48,7 @@ class SmallStr {
 
 class HeapStr {
  public:
-  HeapStr() : header_(obj_header()) {
+  HeapStr() {
   }
   int Length() {
 #ifdef MARK_SWEEP

--- a/prebuilt/asdl/runtime.mycpp.cc
+++ b/prebuilt/asdl/runtime.mycpp.cc
@@ -216,7 +216,7 @@ format::ColorOutput* DetectConsoleOutput(mylib::Writer* f) {
   }
 }
 
-ColorOutput::ColorOutput(mylib::Writer* f) : header_(obj_header()) {
+ColorOutput::ColorOutput(mylib::Writer* f) {
   this->f = f;
   this->num_chars = 0;
 }
@@ -384,7 +384,7 @@ void AnsiOutput::PopColor() {
 }
 int INDENT = 2;
 
-_PrettyPrinter::_PrettyPrinter(int max_col) : header_(obj_header()) {
+_PrettyPrinter::_PrettyPrinter(int max_col) {
   this->max_col = max_col;
 }
 

--- a/prebuilt/asdl/runtime.mycpp.h
+++ b/prebuilt/asdl/runtime.mycpp.h
@@ -48,8 +48,6 @@ class ColorOutput {
   void WriteRaw(Tuple2<Str*, int>* raw);
   int NumChars();
   Tuple2<Str*, int> GetRaw();
-
-  GC_OBJ(header_);
   mylib::Writer* f;
   int num_chars;
   
@@ -70,9 +68,13 @@ class TextOutput : public ColorOutput {
   virtual format::TextOutput* NewTempBuffer();
   virtual void PushColor(hnode_asdl::color_t e_color);
   virtual void PopColor();
+  
+  static constexpr uint32_t field_mask() {
+    return ColorOutput::field_mask();
+  }
 
   static constexpr ObjHeader obj_header() {
-    return ObjHeader::ClassFixed(kZeroMask, sizeof(TextOutput));
+    return ObjHeader::ClassFixed(field_mask(), sizeof(TextOutput));
   }
 
   DISALLOW_COPY_AND_ASSIGN(TextOutput)
@@ -87,9 +89,13 @@ class HtmlOutput : public ColorOutput {
   virtual void PushColor(hnode_asdl::color_t e_color);
   virtual void PopColor();
   virtual void write(Str* s);
+  
+  static constexpr uint32_t field_mask() {
+    return ColorOutput::field_mask();
+  }
 
   static constexpr ObjHeader obj_header() {
-    return ObjHeader::ClassFixed(kZeroMask, sizeof(HtmlOutput));
+    return ObjHeader::ClassFixed(field_mask(), sizeof(HtmlOutput));
   }
 
   DISALLOW_COPY_AND_ASSIGN(HtmlOutput)
@@ -101,9 +107,13 @@ class AnsiOutput : public ColorOutput {
   virtual format::AnsiOutput* NewTempBuffer();
   virtual void PushColor(hnode_asdl::color_t e_color);
   virtual void PopColor();
+  
+  static constexpr uint32_t field_mask() {
+    return ColorOutput::field_mask();
+  }
 
   static constexpr ObjHeader obj_header() {
-    return ObjHeader::ClassFixed(kZeroMask, sizeof(AnsiOutput));
+    return ObjHeader::ClassFixed(field_mask(), sizeof(AnsiOutput));
   }
 
   DISALLOW_COPY_AND_ASSIGN(AnsiOutput)
@@ -117,8 +127,6 @@ class _PrettyPrinter {
   bool _PrintWholeArray(List<hnode_asdl::hnode_t*>* array, int prefix_len, format::ColorOutput* f, int indent);
   void _PrintRecord(hnode_asdl::hnode__Record* node, format::ColorOutput* f, int indent);
   void PrintNode(hnode_asdl::hnode_t* node, format::ColorOutput* f, int indent);
-
-  GC_OBJ(header_);
   int max_col;
 
   static constexpr ObjHeader obj_header() {

--- a/prebuilt/core/error.mycpp.cc
+++ b/prebuilt/core/error.mycpp.cc
@@ -61,13 +61,12 @@ namespace error {  // define
 
 int NO_SPID = -1;
 
-Usage::Usage(Str* msg, int span_id) : header_(obj_header()) {
+Usage::Usage(Str* msg, int span_id) {
   this->msg = msg;
   this->span_id = span_id;
 }
 
-_ErrorWithLocation::_ErrorWithLocation(Str* msg, syntax_asdl::loc_t* location)
-    : header_(obj_header()) {
+_ErrorWithLocation::_ErrorWithLocation(Str* msg, syntax_asdl::loc_t* location) {
   this->msg = msg;
   this->location = location;
 }
@@ -86,7 +85,7 @@ Str* _ErrorWithLocation::UserErrorString() {
   return this->msg;
 }
 
-Runtime::Runtime(Str* msg) : header_(obj_header()) {
+Runtime::Runtime(Str* msg) {
   this->msg = msg;
 }
 

--- a/prebuilt/core/error.mycpp.h
+++ b/prebuilt/core/error.mycpp.h
@@ -33,8 +33,6 @@ extern int NO_SPID;
 class Usage {
  public:
   Usage(Str* msg, int span_id = NO_SPID);
-
-  GC_OBJ(header_);
   Str* msg;
   int span_id;
 
@@ -50,8 +48,6 @@ class _ErrorWithLocation {
   _ErrorWithLocation(Str* msg, syntax_asdl::loc_t* location);
   bool HasLocation();
   Str* UserErrorString();
-
-  GC_OBJ(header_);
   syntax_asdl::loc_t* location;
   Str* msg;
   
@@ -71,8 +67,6 @@ class Runtime {
  public:
   Runtime(Str* msg);
   Str* UserErrorString();
-
-  GC_OBJ(header_);
   Str* msg;
 
   static constexpr ObjHeader obj_header() {
@@ -85,9 +79,13 @@ class Runtime {
 class Parse : public _ErrorWithLocation {
  public:
   Parse(Str* msg, syntax_asdl::loc_t* location);
+  
+  static constexpr uint32_t field_mask() {
+    return _ErrorWithLocation::field_mask();
+  }
 
   static constexpr ObjHeader obj_header() {
-    return ObjHeader::ClassFixed(kZeroMask, sizeof(Parse));
+    return ObjHeader::ClassFixed(field_mask(), sizeof(Parse));
   }
 
   DISALLOW_COPY_AND_ASSIGN(Parse)
@@ -96,9 +94,13 @@ class Parse : public _ErrorWithLocation {
 class FailGlob : public _ErrorWithLocation {
  public:
   FailGlob(Str* msg, syntax_asdl::loc_t* location);
+  
+  static constexpr uint32_t field_mask() {
+    return _ErrorWithLocation::field_mask();
+  }
 
   static constexpr ObjHeader obj_header() {
-    return ObjHeader::ClassFixed(kZeroMask, sizeof(FailGlob));
+    return ObjHeader::ClassFixed(field_mask(), sizeof(FailGlob));
   }
 
   DISALLOW_COPY_AND_ASSIGN(FailGlob)
@@ -107,9 +109,13 @@ class FailGlob : public _ErrorWithLocation {
 class RedirectEval : public _ErrorWithLocation {
  public:
   RedirectEval(Str* msg, syntax_asdl::loc_t* location);
+  
+  static constexpr uint32_t field_mask() {
+    return _ErrorWithLocation::field_mask();
+  }
 
   static constexpr ObjHeader obj_header() {
-    return ObjHeader::ClassFixed(kZeroMask, sizeof(RedirectEval));
+    return ObjHeader::ClassFixed(field_mask(), sizeof(RedirectEval));
   }
 
   DISALLOW_COPY_AND_ASSIGN(RedirectEval)
@@ -121,9 +127,13 @@ class FatalRuntime : public _ErrorWithLocation {
   int ExitStatus();
 
   int exit_status;
+  
+  static constexpr uint32_t field_mask() {
+    return _ErrorWithLocation::field_mask();
+  }
 
   static constexpr ObjHeader obj_header() {
-    return ObjHeader::ClassFixed(kZeroMask, sizeof(FatalRuntime));
+    return ObjHeader::ClassFixed(field_mask(), sizeof(FatalRuntime));
   }
 
   DISALLOW_COPY_AND_ASSIGN(FatalRuntime)
@@ -132,9 +142,13 @@ class FatalRuntime : public _ErrorWithLocation {
 class Strict : public FatalRuntime {
  public:
   Strict(Str* msg, syntax_asdl::loc_t* location);
+  
+  static constexpr uint32_t field_mask() {
+    return FatalRuntime::field_mask();
+  }
 
   static constexpr ObjHeader obj_header() {
-    return ObjHeader::ClassFixed(kZeroMask, sizeof(Strict));
+    return ObjHeader::ClassFixed(field_mask(), sizeof(Strict));
   }
 
   DISALLOW_COPY_AND_ASSIGN(Strict)
@@ -145,9 +159,13 @@ class ErrExit : public FatalRuntime {
   ErrExit(int exit_status, Str* msg, syntax_asdl::loc_t* location, bool show_code = false);
 
   bool show_code;
+  
+  static constexpr uint32_t field_mask() {
+    return FatalRuntime::field_mask();
+  }
 
   static constexpr ObjHeader obj_header() {
-    return ObjHeader::ClassFixed(kZeroMask, sizeof(ErrExit));
+    return ObjHeader::ClassFixed(field_mask(), sizeof(ErrExit));
   }
 
   DISALLOW_COPY_AND_ASSIGN(ErrExit)
@@ -156,9 +174,13 @@ class ErrExit : public FatalRuntime {
 class Expr : public FatalRuntime {
  public:
   Expr(Str* msg, syntax_asdl::loc_t* location);
+  
+  static constexpr uint32_t field_mask() {
+    return FatalRuntime::field_mask();
+  }
 
   static constexpr ObjHeader obj_header() {
-    return ObjHeader::ClassFixed(kZeroMask, sizeof(Expr));
+    return ObjHeader::ClassFixed(field_mask(), sizeof(Expr));
   }
 
   DISALLOW_COPY_AND_ASSIGN(Expr)

--- a/prebuilt/frontend/args.mycpp.cc
+++ b/prebuilt/frontend/args.mycpp.cc
@@ -240,8 +240,6 @@ extern int NO_SPID;
 class Usage {
  public:
   Usage(Str* msg, int span_id = NO_SPID);
-
-  GC_OBJ(header_);
   Str* msg;
   int span_id;
 
@@ -257,8 +255,6 @@ class _ErrorWithLocation {
   _ErrorWithLocation(Str* msg, syntax_asdl::loc_t* location);
   bool HasLocation();
   Str* UserErrorString();
-
-  GC_OBJ(header_);
   syntax_asdl::loc_t* location;
   Str* msg;
   
@@ -278,8 +274,6 @@ class Runtime {
  public:
   Runtime(Str* msg);
   Str* UserErrorString();
-
-  GC_OBJ(header_);
   Str* msg;
 
   static constexpr ObjHeader obj_header() {
@@ -292,9 +286,13 @@ class Runtime {
 class Parse : public _ErrorWithLocation {
  public:
   Parse(Str* msg, syntax_asdl::loc_t* location);
+  
+  static constexpr uint32_t field_mask() {
+    return _ErrorWithLocation::field_mask();
+  }
 
   static constexpr ObjHeader obj_header() {
-    return ObjHeader::ClassFixed(kZeroMask, sizeof(Parse));
+    return ObjHeader::ClassFixed(field_mask(), sizeof(Parse));
   }
 
   DISALLOW_COPY_AND_ASSIGN(Parse)
@@ -303,9 +301,13 @@ class Parse : public _ErrorWithLocation {
 class FailGlob : public _ErrorWithLocation {
  public:
   FailGlob(Str* msg, syntax_asdl::loc_t* location);
+  
+  static constexpr uint32_t field_mask() {
+    return _ErrorWithLocation::field_mask();
+  }
 
   static constexpr ObjHeader obj_header() {
-    return ObjHeader::ClassFixed(kZeroMask, sizeof(FailGlob));
+    return ObjHeader::ClassFixed(field_mask(), sizeof(FailGlob));
   }
 
   DISALLOW_COPY_AND_ASSIGN(FailGlob)
@@ -314,9 +316,13 @@ class FailGlob : public _ErrorWithLocation {
 class RedirectEval : public _ErrorWithLocation {
  public:
   RedirectEval(Str* msg, syntax_asdl::loc_t* location);
+  
+  static constexpr uint32_t field_mask() {
+    return _ErrorWithLocation::field_mask();
+  }
 
   static constexpr ObjHeader obj_header() {
-    return ObjHeader::ClassFixed(kZeroMask, sizeof(RedirectEval));
+    return ObjHeader::ClassFixed(field_mask(), sizeof(RedirectEval));
   }
 
   DISALLOW_COPY_AND_ASSIGN(RedirectEval)
@@ -328,9 +334,13 @@ class FatalRuntime : public _ErrorWithLocation {
   int ExitStatus();
 
   int exit_status;
+  
+  static constexpr uint32_t field_mask() {
+    return _ErrorWithLocation::field_mask();
+  }
 
   static constexpr ObjHeader obj_header() {
-    return ObjHeader::ClassFixed(kZeroMask, sizeof(FatalRuntime));
+    return ObjHeader::ClassFixed(field_mask(), sizeof(FatalRuntime));
   }
 
   DISALLOW_COPY_AND_ASSIGN(FatalRuntime)
@@ -339,9 +349,13 @@ class FatalRuntime : public _ErrorWithLocation {
 class Strict : public FatalRuntime {
  public:
   Strict(Str* msg, syntax_asdl::loc_t* location);
+  
+  static constexpr uint32_t field_mask() {
+    return FatalRuntime::field_mask();
+  }
 
   static constexpr ObjHeader obj_header() {
-    return ObjHeader::ClassFixed(kZeroMask, sizeof(Strict));
+    return ObjHeader::ClassFixed(field_mask(), sizeof(Strict));
   }
 
   DISALLOW_COPY_AND_ASSIGN(Strict)
@@ -352,9 +366,13 @@ class ErrExit : public FatalRuntime {
   ErrExit(int exit_status, Str* msg, syntax_asdl::loc_t* location, bool show_code = false);
 
   bool show_code;
+  
+  static constexpr uint32_t field_mask() {
+    return FatalRuntime::field_mask();
+  }
 
   static constexpr ObjHeader obj_header() {
-    return ObjHeader::ClassFixed(kZeroMask, sizeof(ErrExit));
+    return ObjHeader::ClassFixed(field_mask(), sizeof(ErrExit));
   }
 
   DISALLOW_COPY_AND_ASSIGN(ErrExit)
@@ -363,9 +381,13 @@ class ErrExit : public FatalRuntime {
 class Expr : public FatalRuntime {
  public:
   Expr(Str* msg, syntax_asdl::loc_t* location);
+  
+  static constexpr uint32_t field_mask() {
+    return FatalRuntime::field_mask();
+  }
 
   static constexpr ObjHeader obj_header() {
-    return ObjHeader::ClassFixed(kZeroMask, sizeof(Expr));
+    return ObjHeader::ClassFixed(field_mask(), sizeof(Expr));
   }
 
   DISALLOW_COPY_AND_ASSIGN(Expr)
@@ -426,7 +448,7 @@ format::ColorOutput* DetectConsoleOutput(mylib::Writer* f) {
   }
 }
 
-ColorOutput::ColorOutput(mylib::Writer* f) : header_(obj_header()) {
+ColorOutput::ColorOutput(mylib::Writer* f) {
   this->f = f;
   this->num_chars = 0;
 }
@@ -594,7 +616,7 @@ void AnsiOutput::PopColor() {
 }
 int INDENT = 2;
 
-_PrettyPrinter::_PrettyPrinter(int max_col) : header_(obj_header()) {
+_PrettyPrinter::_PrettyPrinter(int max_col) {
   this->max_col = max_col;
 }
 
@@ -1353,13 +1375,12 @@ namespace error {  // define
 
 int NO_SPID = -1;
 
-Usage::Usage(Str* msg, int span_id) : header_(obj_header()) {
+Usage::Usage(Str* msg, int span_id) {
   this->msg = msg;
   this->span_id = span_id;
 }
 
-_ErrorWithLocation::_ErrorWithLocation(Str* msg, syntax_asdl::loc_t* location)
-    : header_(obj_header()) {
+_ErrorWithLocation::_ErrorWithLocation(Str* msg, syntax_asdl::loc_t* location) {
   this->msg = msg;
   this->location = location;
 }
@@ -1378,7 +1399,7 @@ Str* _ErrorWithLocation::UserErrorString() {
   return this->msg;
 }
 
-Runtime::Runtime(Str* msg) : header_(obj_header()) {
+Runtime::Runtime(Str* msg) {
   this->msg = msg;
 }
 
@@ -1466,8 +1487,7 @@ int Int = 2;
 int Float = 3;
 int Bool = 4;
 
-_Attributes::_Attributes(Dict<Str*, runtime_asdl::value_t*>* defaults)
-    : header_(obj_header()) {
+_Attributes::_Attributes(Dict<Str*, runtime_asdl::value_t*>* defaults) {
   this->attrs = Alloc<Dict<Str*, runtime_asdl::value_t*>>();
   this->opt_changes = Alloc<List<Tuple2<Str*, bool>*>>();
   this->shopt_changes = Alloc<List<Tuple2<Str*, bool>*>>();
@@ -1494,7 +1514,7 @@ void _Attributes::Set(Str* name, runtime_asdl::value_t* val) {
   this->attrs->set(name, val);
 }
 
-Reader::Reader(List<Str*>* argv, List<int>* spids) : header_(obj_header()) {
+Reader::Reader(List<Str*>* argv, List<int>* spids) {
   this->argv = argv;
   this->spids = spids;
   this->n = len(argv);
@@ -1590,7 +1610,7 @@ int Reader::SpanId() {
   }
 }
 
-_Action::_Action() : header_(obj_header()) {
+_Action::_Action() {
   ;  // pass
 }
 
@@ -1600,8 +1620,7 @@ bool _Action::OnMatch(Str* attached_arg, args::Reader* arg_r, args::_Attributes*
   FAIL(kNotImplemented);  // Python NotImplementedError
 }
 
-_ArgAction::_ArgAction(Str* name, bool quit_parsing_flags, List<Str*>* valid)  {
-  FIELD_MASK(header_) |= _ArgAction::field_mask();
+_ArgAction::_ArgAction(Str* name, bool quit_parsing_flags, List<Str*>* valid) {
   this->name = name;
   this->quit_parsing_flags = quit_parsing_flags;
   this->valid = valid;
@@ -1683,8 +1702,7 @@ runtime_asdl::value_t* SetToString::_Value(Str* arg, int span_id) {
   return Alloc<value::Str>(arg);
 }
 
-SetAttachedBool::SetAttachedBool(Str* name)  {
-  FIELD_MASK(header_) |= SetAttachedBool::field_mask();
+SetAttachedBool::SetAttachedBool(Str* name) {
   this->name = name;
 }
 
@@ -1712,8 +1730,7 @@ bool SetAttachedBool::OnMatch(Str* attached_arg, args::Reader* arg_r, args::_Att
   return false;
 }
 
-SetToTrue::SetToTrue(Str* name)  {
-  FIELD_MASK(header_) |= SetToTrue::field_mask();
+SetToTrue::SetToTrue(Str* name) {
   this->name = name;
 }
 
@@ -1724,8 +1741,7 @@ bool SetToTrue::OnMatch(Str* attached_arg, args::Reader* arg_r, args::_Attribute
   return false;
 }
 
-SetOption::SetOption(Str* name)  {
-  FIELD_MASK(header_) |= SetOption::field_mask();
+SetOption::SetOption(Str* name) {
   this->name = name;
 }
 
@@ -1738,8 +1754,7 @@ bool SetOption::OnMatch(Str* attached_arg, args::Reader* arg_r, args::_Attribute
   return false;
 }
 
-SetNamedOption::SetNamedOption(bool shopt)  {
-  FIELD_MASK(header_) |= SetNamedOption::field_mask();
+SetNamedOption::SetNamedOption(bool shopt) {
   this->names = Alloc<List<Str*>>();
   this->shopt = shopt;
 }
@@ -1773,8 +1788,7 @@ bool SetNamedOption::OnMatch(Str* attached_arg, args::Reader* arg_r, args::_Attr
   return false;
 }
 
-SetAction::SetAction(Str* name)  {
-  FIELD_MASK(header_) |= SetAction::field_mask();
+SetAction::SetAction(Str* name) {
   this->name = name;
 }
 
@@ -1785,8 +1799,7 @@ bool SetAction::OnMatch(Str* attached_arg, args::Reader* arg_r, args::_Attribute
   return false;
 }
 
-SetNamedAction::SetNamedAction()  {
-  FIELD_MASK(header_) |= SetNamedAction::field_mask();
+SetNamedAction::SetNamedAction() {
   this->names = Alloc<List<Str*>>();
 }
 

--- a/prebuilt/frontend/args.mycpp.h
+++ b/prebuilt/frontend/args.mycpp.h
@@ -74,8 +74,6 @@ class ColorOutput {
   void WriteRaw(Tuple2<Str*, int>* raw);
   int NumChars();
   Tuple2<Str*, int> GetRaw();
-
-  GC_OBJ(header_);
   mylib::Writer* f;
   int num_chars;
   
@@ -96,9 +94,13 @@ class TextOutput : public ColorOutput {
   virtual format::TextOutput* NewTempBuffer();
   virtual void PushColor(hnode_asdl::color_t e_color);
   virtual void PopColor();
+  
+  static constexpr uint32_t field_mask() {
+    return ColorOutput::field_mask();
+  }
 
   static constexpr ObjHeader obj_header() {
-    return ObjHeader::ClassFixed(kZeroMask, sizeof(TextOutput));
+    return ObjHeader::ClassFixed(field_mask(), sizeof(TextOutput));
   }
 
   DISALLOW_COPY_AND_ASSIGN(TextOutput)
@@ -113,9 +115,13 @@ class HtmlOutput : public ColorOutput {
   virtual void PushColor(hnode_asdl::color_t e_color);
   virtual void PopColor();
   virtual void write(Str* s);
+  
+  static constexpr uint32_t field_mask() {
+    return ColorOutput::field_mask();
+  }
 
   static constexpr ObjHeader obj_header() {
-    return ObjHeader::ClassFixed(kZeroMask, sizeof(HtmlOutput));
+    return ObjHeader::ClassFixed(field_mask(), sizeof(HtmlOutput));
   }
 
   DISALLOW_COPY_AND_ASSIGN(HtmlOutput)
@@ -127,9 +133,13 @@ class AnsiOutput : public ColorOutput {
   virtual format::AnsiOutput* NewTempBuffer();
   virtual void PushColor(hnode_asdl::color_t e_color);
   virtual void PopColor();
+  
+  static constexpr uint32_t field_mask() {
+    return ColorOutput::field_mask();
+  }
 
   static constexpr ObjHeader obj_header() {
-    return ObjHeader::ClassFixed(kZeroMask, sizeof(AnsiOutput));
+    return ObjHeader::ClassFixed(field_mask(), sizeof(AnsiOutput));
   }
 
   DISALLOW_COPY_AND_ASSIGN(AnsiOutput)
@@ -143,8 +153,6 @@ class _PrettyPrinter {
   bool _PrintWholeArray(List<hnode_asdl::hnode_t*>* array, int prefix_len, format::ColorOutput* f, int indent);
   void _PrintRecord(hnode_asdl::hnode__Record* node, format::ColorOutput* f, int indent);
   void PrintNode(hnode_asdl::hnode_t* node, format::ColorOutput* f, int indent);
-
-  GC_OBJ(header_);
   int max_col;
 
   static constexpr ObjHeader obj_header() {
@@ -184,8 +192,6 @@ class _Attributes {
   _Attributes(Dict<Str*, runtime_asdl::value_t*>* defaults);
   void SetTrue(Str* name);
   void Set(Str* name, runtime_asdl::value_t* val);
-
-  GC_OBJ(header_);
   Dict<Str*, runtime_asdl::value_t*>* attrs;
   List<Tuple2<Str*, bool>*>* opt_changes;
   List<Tuple2<Str*, bool>*>* shopt_changes;
@@ -213,8 +219,6 @@ class Reader {
   bool AtEnd();
   int _FirstSpanId();
   int SpanId();
-
-  GC_OBJ(header_);
   List<Str*>* argv;
   List<int>* spids;
   int n;
@@ -231,11 +235,13 @@ class _Action {
  public:
   _Action();
   virtual bool OnMatch(Str* attached_arg, args::Reader* arg_r, args::_Attributes* out);
-
-  GC_OBJ(header_);
+  
+  static constexpr uint32_t field_mask() {
+    return kZeroMask;
+  }
 
   static constexpr ObjHeader obj_header() {
-    return ObjHeader::ClassFixed(kZeroMask, sizeof(_Action));
+    return ObjHeader::ClassFixed(field_mask(), sizeof(_Action));
   }
 
   DISALLOW_COPY_AND_ASSIGN(_Action)
@@ -252,7 +258,8 @@ class _ArgAction : public _Action {
   List<Str*>* valid;
   
   static constexpr uint32_t field_mask() {
-    return maskbit_v(offsetof(_ArgAction, name))
+    return _Action::field_mask()
+         | maskbit_v(offsetof(_ArgAction, name))
          | maskbit_v(offsetof(_ArgAction, valid));
   }
 
@@ -267,9 +274,13 @@ class SetToInt : public _ArgAction {
  public:
   SetToInt(Str* name);
   virtual runtime_asdl::value_t* _Value(Str* arg, int span_id);
+  
+  static constexpr uint32_t field_mask() {
+    return _ArgAction::field_mask();
+  }
 
   static constexpr ObjHeader obj_header() {
-    return ObjHeader::ClassFixed(kZeroMask, sizeof(SetToInt));
+    return ObjHeader::ClassFixed(field_mask(), sizeof(SetToInt));
   }
 
   DISALLOW_COPY_AND_ASSIGN(SetToInt)
@@ -279,9 +290,13 @@ class SetToFloat : public _ArgAction {
  public:
   SetToFloat(Str* name);
   virtual runtime_asdl::value_t* _Value(Str* arg, int span_id);
+  
+  static constexpr uint32_t field_mask() {
+    return _ArgAction::field_mask();
+  }
 
   static constexpr ObjHeader obj_header() {
-    return ObjHeader::ClassFixed(kZeroMask, sizeof(SetToFloat));
+    return ObjHeader::ClassFixed(field_mask(), sizeof(SetToFloat));
   }
 
   DISALLOW_COPY_AND_ASSIGN(SetToFloat)
@@ -291,9 +306,13 @@ class SetToString : public _ArgAction {
  public:
   SetToString(Str* name, bool quit_parsing_flags, List<Str*>* valid = nullptr);
   virtual runtime_asdl::value_t* _Value(Str* arg, int span_id);
+  
+  static constexpr uint32_t field_mask() {
+    return _ArgAction::field_mask();
+  }
 
   static constexpr ObjHeader obj_header() {
-    return ObjHeader::ClassFixed(kZeroMask, sizeof(SetToString));
+    return ObjHeader::ClassFixed(field_mask(), sizeof(SetToString));
   }
 
   DISALLOW_COPY_AND_ASSIGN(SetToString)
@@ -307,7 +326,8 @@ class SetAttachedBool : public _Action {
   Str* name;
   
   static constexpr uint32_t field_mask() {
-    return maskbit_v(offsetof(SetAttachedBool, name));
+    return _Action::field_mask()
+         | maskbit_v(offsetof(SetAttachedBool, name));
   }
 
   static constexpr ObjHeader obj_header() {
@@ -325,7 +345,8 @@ class SetToTrue : public _Action {
   Str* name;
   
   static constexpr uint32_t field_mask() {
-    return maskbit_v(offsetof(SetToTrue, name));
+    return _Action::field_mask()
+         | maskbit_v(offsetof(SetToTrue, name));
   }
 
   static constexpr ObjHeader obj_header() {
@@ -343,7 +364,8 @@ class SetOption : public _Action {
   Str* name;
   
   static constexpr uint32_t field_mask() {
-    return maskbit_v(offsetof(SetOption, name));
+    return _Action::field_mask()
+         | maskbit_v(offsetof(SetOption, name));
   }
 
   static constexpr ObjHeader obj_header() {
@@ -363,7 +385,8 @@ class SetNamedOption : public _Action {
   bool shopt;
   
   static constexpr uint32_t field_mask() {
-    return maskbit_v(offsetof(SetNamedOption, names));
+    return _Action::field_mask()
+         | maskbit_v(offsetof(SetNamedOption, names));
   }
 
   static constexpr ObjHeader obj_header() {
@@ -381,7 +404,8 @@ class SetAction : public _Action {
   Str* name;
   
   static constexpr uint32_t field_mask() {
-    return maskbit_v(offsetof(SetAction, name));
+    return _Action::field_mask()
+         | maskbit_v(offsetof(SetAction, name));
   }
 
   static constexpr ObjHeader obj_header() {
@@ -400,7 +424,8 @@ class SetNamedAction : public _Action {
   List<Str*>* names;
   
   static constexpr uint32_t field_mask() {
-    return maskbit_v(offsetof(SetNamedAction, names));
+    return _Action::field_mask()
+         | maskbit_v(offsetof(SetNamedAction, names));
   }
 
   static constexpr ObjHeader obj_header() {


### PR DESCRIPTION
This refactors GC managed objects so that their headers are external objects
instead of member variables. The headers are placed directly before their GC
objects in memory, so it's trivial to jump between them. The physical layout is
maintained by Alloc<T>() (and related allocation functions) and the GcGlobal<T>
wrapper class. Alloc<T>(), NewSlab(), etc, now allocate space for the headers
and initialize them directly with T::obj_header(). And global GC objects are
wrapped in GcGlobal which has an embedded header.

Notable changes:
 * FindObjHeader() is gone: Use ObjHeader::FromObject(obj) and
   header->ObjectAddress() to get between header and object.
 * Derived classes no longer modify the mutate their field mask in the
   constructor. Now each class in a hierarchy is required to have a
   field_mask() function that returns the union of its base's field_mask() (if
   any) and its own.

Followup changes to be done:
 * Minor optimization: Change MarkSweepHeap to keep lists of ObjHeader* instead
   of RawObject* to reduce calls to ObjHeader::FromObj()l.
 * s/maskbit_v/maskbit/: maskbit_v does nothing now
 * Remove ObjHeader::is_header: it's no longer necessary