### PR TITLE
spec: Don't use ## for non-metadata comments.

### DIFF
--- a/spec/append.test.sh
+++ b/spec/append.test.sh
@@ -34,7 +34,7 @@ t=foofoo
 
 #### Append to array to undefined variable
 
-## TODO: strict_array could get rid of this?
+# TODO: strict_array could get rid of this?
 y+=(c d)
 argv.py "${y[@]}"
 ## STDOUT:

--- a/spec/bugs.test.sh
+++ b/spec/bugs.test.sh
@@ -128,7 +128,7 @@ echo x=${x@P}
 x=\D{%H:%M
 ## END
 
-## bash just ignores the missing }
+# bash just ignores the missing }
 ## BUG bash stdout-json: ""
 
 # These shells don't understand @P

--- a/spec/if_.test.sh
+++ b/spec/if_.test.sh
@@ -42,7 +42,7 @@ fi
 
 #### if break corner case
 
-## This is analogous to the 'while' case in spec/loop
+# This is analogous to the 'while' case in spec/loop
 f() {
   if break; then
     echo hi


### PR DESCRIPTION
I noticed that there are some non-metadata comments starting with `##` when writing my own parser of Oil's spec tests [1]. There are just a few of them, so I assume the use of `##` is accidental; changing them to `#` makes the spec files just a little bit easier to parse.

There is another place that is slightly weird (not changed in this PR):

https://github.com/oilshell/oil/blob/ed3f591537ffd754dc5770a8ad310544147cd683/spec/arith.test.sh#L362

This is the only metadata line that starts directly with a shell name, without `OK` / `BUG` / `N-I`. Reading the comment for this test case, 9 is the expected output on all shells, so presumably the `osh` part can just be removed?

[1] It's in https://github.com/elves/posixsh/blob/master/pkg/spec/oil_specs_test.go if you're interested; the project name `posixsh` is a lie since you can't implement a fully POSIX-compliant shell in Go, it's just my experiment to see _how_ compliant I can get.