### PR TITLE
[cpp] Use uint32_t to represent field masks

### DIFF
--- a/core/optview_gen.py
+++ b/core/optview_gen.py
@@ -54,7 +54,7 @@ class _View {
   List<bool>* opt0_array;
   List<List<bool>*>* opt_stacks;
 
-  static constexpr uint16_t field_mask() {
+  static constexpr uint32_t field_mask() {
     return
       maskbit(offsetof(_View, opt0_array))
     | maskbit(offsetof(_View, opt_stacks));

--- a/cpp/core.h
+++ b/cpp/core.h
@@ -75,7 +75,7 @@ class PasswdEntry {
   int pw_uid;
   int pw_gid;
 
-  static constexpr uint16_t field_mask() {
+  static constexpr uint32_t field_mask() {
     return maskbit(offsetof(PasswdEntry, pw_name));
   }
 };
@@ -202,7 +202,7 @@ class SignalSafe {
     return result;
   }
 
-  static constexpr uint16_t field_mask() {
+  static constexpr uint32_t field_mask() {
     return maskbit(offsetof(SignalSafe, pending_signals_)) |
            maskbit(offsetof(SignalSafe, empty_list_));
   }

--- a/cpp/frontend_flag_spec.h
+++ b/cpp/frontend_flag_spec.h
@@ -104,7 +104,7 @@ class _FlagSpec {
   Dict<Str*, args::_Action*>* actions_long;
   Dict<Str*, runtime_asdl::value_t*>* defaults;
 
-  static constexpr uint16_t field_mask() {
+  static constexpr uint32_t field_mask() {
     return maskbit(offsetof(_FlagSpec, arity0)) |
            maskbit(offsetof(_FlagSpec, arity1)) |
            maskbit(offsetof(_FlagSpec, plus_flags)) |
@@ -133,7 +133,7 @@ class _FlagSpecAndMore {
   List<Str*>* plus_flags;
   Dict<Str*, runtime_asdl::value_t*>* defaults;
 
-  static constexpr uint16_t field_mask() {
+  static constexpr uint32_t field_mask() {
     return maskbit(offsetof(_FlagSpecAndMore, actions_long)) |
            maskbit(offsetof(_FlagSpecAndMore, actions_short)) |
            maskbit(offsetof(_FlagSpecAndMore, plus_flags)) |

--- a/cpp/frontend_match.h
+++ b/cpp/frontend_match.h
@@ -34,7 +34,7 @@ class SimpleLexer {
     return ObjHeader::ClassFixed(field_mask(), sizeof(SimpleLexer));
   }
 
-  static constexpr uint16_t field_mask() {
+  static constexpr uint32_t field_mask() {
     return maskbit(offsetof(SimpleLexer, s_));
   }
 

--- a/cpp/frontend_pyreadline.h
+++ b/cpp/frontend_pyreadline.h
@@ -39,7 +39,7 @@ class Readline {
   int get_current_history_length();
   void resize_terminal();
 
-  static constexpr uint16_t field_mask() {
+  static constexpr uint32_t field_mask() {
     return maskbit(offsetof(Readline, completer_delims_)) |
            maskbit(offsetof(Readline, completer_)) |
            maskbit(offsetof(Readline, display_));

--- a/cpp/pgen2.h
+++ b/cpp/pgen2.h
@@ -29,7 +29,7 @@ class ParseError {
     return ObjHeader::ClassFixed(field_mask(), sizeof(ParseError));
   }
 
-  static constexpr uint16_t field_mask() {
+  static constexpr uint32_t field_mask() {
     return maskbit(offsetof(ParseError, msg)) |
            maskbit(offsetof(ParseError, tok));
   }
@@ -54,7 +54,7 @@ class Parser {
     return ObjHeader::ClassFixed(field_mask(), sizeof(Parser));
   }
 
-  static constexpr uint16_t field_mask() {
+  static constexpr uint32_t field_mask() {
     return maskbit(offsetof(Parser, rootnode));
   }
 

--- a/frontend/flag_gen.py
+++ b/frontend/flag_gen.py
@@ -282,7 +282,7 @@ class %s {
 
     if bits:
       header_f.write('\n')
-      header_f.write('  static constexpr uint16_t field_mask() {\n')
+      header_f.write('  static constexpr uint32_t field_mask() {\n')
       header_f.write('    return\n')
       header_f.write('      ')
       header_f.write('\n    | '.join(bits))

--- a/mycpp/cppgen_pass.py
+++ b/mycpp/cppgen_pass.py
@@ -2297,7 +2297,7 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
             if mask_bits:
                 self.decl_write_ind('\n')
                 self.decl_write_ind(
-                    'static constexpr uint16_t field_mask() {\n')
+                    'static constexpr uint32_t field_mask() {\n')
 
                 self.decl_write_ind('  return ')
                 for i, b in enumerate(mask_bits):

--- a/mycpp/gc_builtins.h
+++ b/mycpp/gc_builtins.h
@@ -50,7 +50,7 @@ class ValueError {
   GC_OBJ(header_);
   Str* message;
 
-  static constexpr uint16_t field_mask() {
+  static constexpr uint32_t field_mask() {
     return maskbit(offsetof(ValueError, message));
   }
 };
@@ -73,7 +73,7 @@ class RuntimeError {
   GC_OBJ(header_);
   Str* message;
 
-  static constexpr uint16_t field_mask() {
+  static constexpr uint32_t field_mask() {
     return maskbit(offsetof(RuntimeError, message));
   }
 };

--- a/mycpp/gc_dict.h
+++ b/mycpp/gc_dict.h
@@ -124,7 +124,7 @@ class Dict {
   Slab<V>* values_;   // Dict<K, int>
 
   // A dict has 3 pointers the GC needs to follow.
-  static constexpr uint16_t field_mask() {
+  static constexpr uint32_t field_mask() {
     return maskbit(offsetof(Dict, entry_)) | maskbit(offsetof(Dict, keys_)) |
            maskbit(offsetof(Dict, values_));
   }

--- a/mycpp/gc_list.h
+++ b/mycpp/gc_list.h
@@ -97,7 +97,7 @@ class List {
   Slab<T>* slab_;
 
   // A list has one Slab pointer which we need to follow.
-  static constexpr uint16_t field_mask() {
+  static constexpr uint32_t field_mask() {
     return maskbit(offsetof(List, slab_));
   }
 

--- a/mycpp/gc_obj.h
+++ b/mycpp/gc_obj.h
@@ -57,7 +57,7 @@ struct ObjHeader {
 #endif
 
   // Used by hand-written and generated classes
-  static constexpr ObjHeader ClassFixed(uint16_t field_mask, uint32_t obj_len) {
+  static constexpr ObjHeader ClassFixed(uint32_t field_mask, uint32_t obj_len) {
     return {kIsHeader, TypeTag::OtherClass, field_mask, HeapTag::FixedSize,
             kUndefinedId};
   }
@@ -70,7 +70,7 @@ struct ObjHeader {
   }
 
   // Used by frontend/flag_gen.py.  TODO: Sort fields and use GC_CLASS_SCANNED
-  static constexpr ObjHeader Class(uint8_t heap_tag, uint16_t field_mask,
+  static constexpr ObjHeader Class(uint8_t heap_tag, uint32_t field_mask,
                                    uint32_t obj_len) {
     return {kIsHeader, TypeTag::OtherClass, field_mask, heap_tag, kUndefinedId};
   }
@@ -89,14 +89,14 @@ struct ObjHeader {
     return {kIsHeader, TypeTag::Slab, num_pointers, heap_tag, kUndefinedId};
   }
 
-  static constexpr ObjHeader Tuple(uint16_t field_mask, uint32_t obj_len) {
+  static constexpr ObjHeader Tuple(uint32_t field_mask, uint32_t obj_len) {
     return {kIsHeader, TypeTag::Tuple, field_mask, HeapTag::FixedSize,
             kUndefinedId};
   }
 };
 
 // TODO: we could determine the max of all objects statically!
-const int kFieldMaskBits = 16;
+const int kFieldMaskBits = 24;
 
 #if defined(MARK_SWEEP) || defined(BUMP_LEAK)
   #define FIELD_MASK(header) (header).u_mask_npointers

--- a/mycpp/gc_tuple.h
+++ b/mycpp/gc_tuple.h
@@ -20,7 +20,7 @@ class Tuple2 {
     return ObjHeader::Tuple(field_mask(), sizeof(this_type));
   }
 
-  static constexpr uint16_t field_mask() {
+  static constexpr uint32_t field_mask() {
     return (std::is_pointer<A>() ? maskbit(offsetof(this_type, a_)) : 0) |
            (std::is_pointer<B>() ? maskbit(offsetof(this_type, b_)) : 0);
   }
@@ -53,7 +53,7 @@ class Tuple3 {
     return ObjHeader::Tuple(field_mask(), sizeof(this_type));
   }
 
-  static constexpr uint16_t field_mask() {
+  static constexpr uint32_t field_mask() {
     return (std::is_pointer<A>() ? maskbit(offsetof(this_type, a_)) : 0) |
            (std::is_pointer<B>() ? maskbit(offsetof(this_type, b_)) : 0) |
            (std::is_pointer<C>() ? maskbit(offsetof(this_type, c_)) : 0);
@@ -92,7 +92,7 @@ class Tuple4 {
     return ObjHeader::Tuple(field_mask(), sizeof(this_type));
   }
 
-  static constexpr uint16_t field_mask() {
+  static constexpr uint32_t field_mask() {
     return (std::is_pointer<A>() ? maskbit(offsetof(this_type, a_)) : 0) |
            (std::is_pointer<B>() ? maskbit(offsetof(this_type, b_)) : 0) |
            (std::is_pointer<C>() ? maskbit(offsetof(this_type, c_)) : 0) |

--- a/mycpp/mark_sweep_heap_test.cc
+++ b/mycpp/mark_sweep_heap_test.cc
@@ -171,7 +171,7 @@ class Node {
   GC_OBJ(header_);
   Node *next_;
 
-  static constexpr uint16_t field_mask() {
+  static constexpr uint32_t field_mask() {
     return maskbit(offsetof(Node, next_));
   }
 };

--- a/prebuilt/asdl/runtime.mycpp.h
+++ b/prebuilt/asdl/runtime.mycpp.h
@@ -53,7 +53,7 @@ class ColorOutput {
   mylib::Writer* f;
   int num_chars;
   
-  static constexpr uint16_t field_mask() {
+  static constexpr uint32_t field_mask() {
     return maskbit_v(offsetof(ColorOutput, f));
   }
 

--- a/prebuilt/core/error.mycpp.h
+++ b/prebuilt/core/error.mycpp.h
@@ -55,7 +55,7 @@ class _ErrorWithLocation {
   syntax_asdl::loc_t* location;
   Str* msg;
   
-  static constexpr uint16_t field_mask() {
+  static constexpr uint32_t field_mask() {
     return maskbit(offsetof(_ErrorWithLocation, location))
          | maskbit(offsetof(_ErrorWithLocation, msg));
   }

--- a/prebuilt/frontend/args.mycpp.cc
+++ b/prebuilt/frontend/args.mycpp.cc
@@ -262,7 +262,7 @@ class _ErrorWithLocation {
   syntax_asdl::loc_t* location;
   Str* msg;
   
-  static constexpr uint16_t field_mask() {
+  static constexpr uint32_t field_mask() {
     return maskbit(offsetof(_ErrorWithLocation, location))
          | maskbit(offsetof(_ErrorWithLocation, msg));
   }

--- a/prebuilt/frontend/args.mycpp.h
+++ b/prebuilt/frontend/args.mycpp.h
@@ -79,7 +79,7 @@ class ColorOutput {
   mylib::Writer* f;
   int num_chars;
   
-  static constexpr uint16_t field_mask() {
+  static constexpr uint32_t field_mask() {
     return maskbit_v(offsetof(ColorOutput, f));
   }
 
@@ -251,7 +251,7 @@ class _ArgAction : public _Action {
   bool quit_parsing_flags;
   List<Str*>* valid;
   
-  static constexpr uint16_t field_mask() {
+  static constexpr uint32_t field_mask() {
     return maskbit_v(offsetof(_ArgAction, name))
          | maskbit_v(offsetof(_ArgAction, valid));
   }
@@ -306,7 +306,7 @@ class SetAttachedBool : public _Action {
 
   Str* name;
   
-  static constexpr uint16_t field_mask() {
+  static constexpr uint32_t field_mask() {
     return maskbit_v(offsetof(SetAttachedBool, name));
   }
 
@@ -324,7 +324,7 @@ class SetToTrue : public _Action {
 
   Str* name;
   
-  static constexpr uint16_t field_mask() {
+  static constexpr uint32_t field_mask() {
     return maskbit_v(offsetof(SetToTrue, name));
   }
 
@@ -342,7 +342,7 @@ class SetOption : public _Action {
 
   Str* name;
   
-  static constexpr uint16_t field_mask() {
+  static constexpr uint32_t field_mask() {
     return maskbit_v(offsetof(SetOption, name));
   }
 
@@ -362,7 +362,7 @@ class SetNamedOption : public _Action {
   List<Str*>* names;
   bool shopt;
   
-  static constexpr uint16_t field_mask() {
+  static constexpr uint32_t field_mask() {
     return maskbit_v(offsetof(SetNamedOption, names));
   }
 
@@ -380,7 +380,7 @@ class SetAction : public _Action {
 
   Str* name;
   
-  static constexpr uint16_t field_mask() {
+  static constexpr uint32_t field_mask() {
     return maskbit_v(offsetof(SetAction, name));
   }
 
@@ -399,7 +399,7 @@ class SetNamedAction : public _Action {
 
   List<Str*>* names;
   
-  static constexpr uint16_t field_mask() {
+  static constexpr uint32_t field_mask() {
     return maskbit_v(offsetof(SetNamedAction, names));
   }
 


### PR DESCRIPTION
In various places (mainly the field_mask() functions) we previously represented field masks with uint16_t's even though the ObjHeader allocates 24 bits for them. Now we use uint32_t instead.

I'm motivated to do this now because my upcoming change to move the object header outside of objects results in one type requiring 17 bits for its field mask (the field masks get one bit longer).

Note: The only manual change here was increasing `kFieldMaskBits` to 24. The rest is: `s/uint16_t field_mask/uint32_t field_mask/`