### PR TITLE
Add a .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# [mycpp cleanup] Reformat code with yapf auto-formatter
+c2d68ec41ae1d6a5f9f40645c9bc3152e95d8afc


### PR DESCRIPTION
And initialize it with a python code formatting change.

To configure git locally:

    git config blame.ignoreRevsFile .git-blame-ignore-revs

For more info see:
https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view