### PR TITLE
[cpp] Remove ObjHeader::is_header

### DIFF
--- a/cpp/osh.cc
+++ b/cpp/osh.cc
@@ -17,7 +17,7 @@ using syntax_asdl::loc;
 namespace arith_parse {
 
 GcGlobal<tdop::ParserSpec> kArithSpec_ = {
-    {kIsHeader, TypeTag::OtherClass, kZeroMask, HeapTag::Global, kIsGlobal}};
+    {TypeTag::OtherClass, kZeroMask, HeapTag::Global, kIsGlobal}};
 tdop::ParserSpec* kArithSpec = &kArithSpec_.obj;
 
 }  // namespace arith_parse

--- a/mycpp/demo/gc_header.cc
+++ b/mycpp/demo/gc_header.cc
@@ -40,7 +40,7 @@ class Point {
 
   static constexpr ObjHeader obj_header() {
     // type_tag is 42
-    return ObjHeader{kIsHeader, 42};
+    return ObjHeader{42};
   }
 };
 

--- a/mycpp/gc_list.h
+++ b/mycpp/gc_list.h
@@ -413,12 +413,11 @@ List<T>* list(List<T>* other) {
   return result;
 }
 
-#define GLOBAL_LIST(T, N, name, array)                               \
-  GcGlobal<GlobalSlab<T, N>> _slab_##name = {                        \
-      {kIsHeader, 0, kZeroMask, HeapTag::Global, kIsGlobal}, array}; \
-  GcGlobal<GlobalList<T, N>> _list_##name = {                        \
-      {kIsHeader, 0, kZeroMask, HeapTag::Global, kIsGlobal},         \
-      {N, N, &_slab_##name.obj}};                                    \
+#define GLOBAL_LIST(T, N, name, array)                                        \
+  GcGlobal<GlobalSlab<T, N>> _slab_##name = {                                 \
+      {0, kZeroMask, HeapTag::Global, kIsGlobal}, array};                     \
+  GcGlobal<GlobalList<T, N>> _list_##name = {                                 \
+      {0, kZeroMask, HeapTag::Global, kIsGlobal}, {N, N, &_slab_##name.obj}}; \
   List<T>* name = reinterpret_cast<List<T>*>(&_list_##name.obj);
 
 template <class T>

--- a/mycpp/gc_list_test.cc
+++ b/mycpp/gc_list_test.cc
@@ -130,9 +130,9 @@ TEST test_list_gc_header() {
 
 // Manual initialization.  This helped me write the GLOBAL_LIST() macro.
 GcGlobal<GlobalSlab<int, 3>> _gSlab = {
-    {kIsHeader, 0, kZeroMask, HeapTag::Global, kUndefinedId}, {5, 6, 7}};
+    {0, kZeroMask, HeapTag::Global, kUndefinedId}, {5, 6, 7}};
 GcGlobal<GlobalList<int, 3>> _gList = {
-    {kIsHeader, 0, kZeroMask, HeapTag::Global, kUndefinedId},
+    {0, kZeroMask, HeapTag::Global, kUndefinedId},
     {3,  // len
      3,  // capacity
      &_gSlab.obj}};

--- a/mycpp/gc_obj.h
+++ b/mycpp/gc_obj.h
@@ -28,8 +28,6 @@ const int Slab = 125;
 const int Tuple = 124;
 };  // namespace TypeTag
 
-const int kIsHeader = 1;  // for is_header bit
-
 const unsigned kZeroMask = 0;  // for types with no pointers
 
 const int kMaxObjId = (1 << 30) - 1;  // 30 bit object ID
@@ -41,9 +39,8 @@ const int kUndefinedId = 0;  // Unitialized object ID
 // TODO: ./configure could detect endian-ness, and reorder the fields in
 // ObjHeader.  See mycpp/demo/gc_header.cc.
 struct ObjHeader {
-  unsigned is_header : 1;  // To distinguish from vtable pointer
-                           // Overlaps with RawObject::points_to_header
-  unsigned type_tag : 7;   // TypeTag, ASDL variant / shared variant
+  unsigned unused : 1;
+  unsigned type_tag : 7;  // TypeTag, ASDL variant / shared variant
 #if defined(MARK_SWEEP) || defined(BUMP_LEAK)
   // Depending on heap_tag, up to 24 fields or 2**24 = 16 Mi pointers to scan
   unsigned u_mask_npointers : 24;
@@ -77,40 +74,37 @@ struct ObjHeader {
 
   // Used by hand-written and generated classes
   static constexpr ObjHeader ClassFixed(uint32_t field_mask, uint32_t obj_len) {
-    return {kIsHeader, TypeTag::OtherClass, field_mask, HeapTag::FixedSize,
-            kUndefinedId};
+    return {TypeTag::OtherClass, field_mask, HeapTag::FixedSize, kUndefinedId};
   }
 
   // Classes with no inheritance (e.g. used by mycpp)
   static constexpr ObjHeader ClassScanned(uint32_t num_pointers,
                                           uint32_t obj_len) {
-    return {kIsHeader, TypeTag::OtherClass, num_pointers, HeapTag::Scanned,
-            kUndefinedId};
+    return {TypeTag::OtherClass, num_pointers, HeapTag::Scanned, kUndefinedId};
   }
 
   // Used by frontend/flag_gen.py.  TODO: Sort fields and use GC_CLASS_SCANNED
   static constexpr ObjHeader Class(uint8_t heap_tag, uint32_t field_mask,
                                    uint32_t obj_len) {
-    return {kIsHeader, TypeTag::OtherClass, field_mask, heap_tag, kUndefinedId};
+    return {TypeTag::OtherClass, field_mask, heap_tag, kUndefinedId};
   }
 
   // Used by ASDL.
   static constexpr ObjHeader AsdlClass(uint8_t type_tag,
                                        uint32_t num_pointers) {
-    return {kIsHeader, type_tag, num_pointers, HeapTag::Scanned, kUndefinedId};
+    return {type_tag, num_pointers, HeapTag::Scanned, kUndefinedId};
   }
 
   static constexpr ObjHeader Str() {
-    return {kIsHeader, TypeTag::Str, kZeroMask, HeapTag::Opaque, kUndefinedId};
+    return {TypeTag::Str, kZeroMask, HeapTag::Opaque, kUndefinedId};
   }
 
   static constexpr ObjHeader Slab(uint8_t heap_tag, uint32_t num_pointers) {
-    return {kIsHeader, TypeTag::Slab, num_pointers, heap_tag, kUndefinedId};
+    return {TypeTag::Slab, num_pointers, heap_tag, kUndefinedId};
   }
 
   static constexpr ObjHeader Tuple(uint32_t field_mask, uint32_t obj_len) {
-    return {kIsHeader, TypeTag::Tuple, field_mask, HeapTag::FixedSize,
-            kUndefinedId};
+    return {TypeTag::Tuple, field_mask, HeapTag::FixedSize, kUndefinedId};
   }
 };
 

--- a/mycpp/gc_obj.h
+++ b/mycpp/gc_obj.h
@@ -39,8 +39,7 @@ const int kUndefinedId = 0;  // Unitialized object ID
 // TODO: ./configure could detect endian-ness, and reorder the fields in
 // ObjHeader.  See mycpp/demo/gc_header.cc.
 struct ObjHeader {
-  unsigned unused : 1;
-  unsigned type_tag : 7;  // TypeTag, ASDL variant / shared variant
+  unsigned type_tag : 8;  // TypeTag, ASDL variant / shared variant
 #if defined(MARK_SWEEP) || defined(BUMP_LEAK)
   // Depending on heap_tag, up to 24 fields or 2**24 = 16 Mi pointers to scan
   unsigned u_mask_npointers : 24;

--- a/mycpp/gc_str.h
+++ b/mycpp/gc_str.h
@@ -158,10 +158,10 @@ class GlobalStr {
 // https://old.reddit.com/r/cpp_questions/comments/j0khh6/how_to_constexpr_initialize_class_member_thats/
 // https://stackoverflow.com/questions/10422487/how-can-i-initialize-char-arrays-in-a-constructor
 
-#define GLOBAL_STR(name, val)                                           \
-  GcGlobal<GlobalStr<sizeof(val)>> _##name = {                          \
-      {kIsHeader, TypeTag::Str, kZeroMask, HeapTag::Global, kIsGlobal}, \
-      {sizeof(val) - 1, val}};                                          \
+#define GLOBAL_STR(name, val)                                \
+  GcGlobal<GlobalStr<sizeof(val)>> _##name = {               \
+      {TypeTag::Str, kZeroMask, HeapTag::Global, kIsGlobal}, \
+      {sizeof(val) - 1, val}};                               \
   Str* name = reinterpret_cast<Str*>(&_##name.obj);
 
 #endif  // MYCPP_GC_STR_H


### PR DESCRIPTION
is_header no longer used so remove it. We now have a spare bit!