### PR TITLE
[benchmarks] Fix time-helper bug

### DIFF
--- a/benchmarks/time-helper.c
+++ b/benchmarks/time-helper.c
@@ -129,7 +129,7 @@ int main(int argc, char **argv) {
 
   // http://www.gnu.org/software/libc/manual/html_node/Example-of-Getopt.html
   // + means to be strict about flag parsing.
-  char c;
+  int c;
   while ((c = getopt(argc, argv, "+o:ad:vxeUSM")) != -1) {
     switch (c) {
     case 'o':


### PR DESCRIPTION
I debugged this issue while trying to run the benchmarks and noticing they were silently failing! 

time-helper was hitting this "unreachable" abort() on my system because getopt() returns an int but we were assigning it to a char. This breaks when 'char' is 'unsigned char' (because getopt() can return -1).