### PR TITLE
[mycpp/runtime] Don't zero with calloc(), use malloc()

### DIFF
--- a/benchmarks/gc.sh
+++ b/benchmarks/gc.sh
@@ -169,6 +169,10 @@ print-cachegrind-tasks() {
     "bash${TAB}-"
     "_bin/cxx-bumpleak/osh${TAB}mut"
     "_bin/cxx-bumproot/osh${TAB}mut"
+
+    "_bin/cxx-small/osh${TAB}-"
+    "_bin/cxx-big/osh${TAB}-"
+
     "_bin/cxx-opt/osh${TAB}mut+alloc"
     "_bin/cxx-opt/osh${TAB}mut+alloc+free"
     "_bin/cxx-opt/osh${TAB}mut+alloc+free+gc"
@@ -275,7 +279,20 @@ run-tasks() {
 
     case $shell_runtime_opts in 
       -)
-        "${instrumented[@]}" > /dev/null
+        case $sh_path in
+          _bin/cxx-small/osh|_bin/cxx-big/osh)
+
+            log "***"
+            log "Running $sh_path with GC off"
+            log "***"
+
+            OIL_GC_STATS=1 OIL_GC_THRESHOLD=$BIG_THRESHOLD \
+              "${instrumented[@]}" > /dev/null
+            ;;
+          *)
+            "${instrumented[@]}" > /dev/null
+            ;;
+        esac
         ;;
       mut)
         OIL_GC_STATS=1 \
@@ -378,7 +395,7 @@ more-variants() {
 }
 
 build-binaries() {
-  local -a bin=( _bin/cxx-{bumpleak,bumproot,opt}/osh )
+  local -a bin=( _bin/cxx-{bumpleak,bumproot,opt,small,big}/osh )
 
   if test -n "${TCMALLOC:-}"; then
     bin+=( _bin/cxx-tcmalloc/osh )

--- a/benchmarks/gc.sh
+++ b/benchmarks/gc.sh
@@ -170,8 +170,8 @@ print-cachegrind-tasks() {
     "_bin/cxx-bumpleak/osh${TAB}mut"
     "_bin/cxx-bumproot/osh${TAB}mut"
 
-    "_bin/cxx-small/osh${TAB}-"
-    "_bin/cxx-big/osh${TAB}-"
+    "_bin/cxx-small/osh${TAB}mut"
+    "_bin/cxx-big/osh${TAB}mut"
 
     "_bin/cxx-opt/osh${TAB}mut+alloc"
     "_bin/cxx-opt/osh${TAB}mut+alloc+free"
@@ -279,6 +279,9 @@ run-tasks() {
 
     case $shell_runtime_opts in 
       -)
+        "${instrumented[@]}" > /dev/null
+        ;;
+      mut)
         case $sh_path in
           _bin/cxx-small/osh|_bin/cxx-big/osh)
 
@@ -290,13 +293,10 @@ run-tasks() {
               "${instrumented[@]}" > /dev/null
             ;;
           *)
-            "${instrumented[@]}" > /dev/null
+            OIL_GC_STATS=1 \
+              "${instrumented[@]}" > /dev/null
             ;;
         esac
-        ;;
-      mut)
-        OIL_GC_STATS=1 \
-          "${instrumented[@]}" > /dev/null
         ;;
       mut+alloc)
         # disable GC with big threshold

--- a/build/ninja-rules-cpp.sh
+++ b/build/ninja-rules-cpp.sh
@@ -149,6 +149,14 @@ setglobal_compile_flags() {
     (opt32)
       flags="$flags -O2 -g -D OPTIMIZED -m32"
       ;;
+
+    (big)
+      flags="$flags -O2 -g -D OPTIMIZED -D BUMP_ROOT -D TAKE_OVER_BIG"
+      ;;
+    (small)
+      flags="$flags -O2 -g -D OPTIMIZED -D BUMP_ROOT -D TAKE_OVER_SMALL"
+      ;;
+
     (tcmalloc)
       flags="$flags -O2 -g -D TCMALLOC -D OPTIMIZED"
       ;;

--- a/build/ninja_lib.py
+++ b/build/ninja_lib.py
@@ -61,6 +61,10 @@ COMPILERS_VARIANTS = [
 GC_PERF_VARIANTS = [
     ('cxx', 'bumpleak'),
     ('cxx', 'bumproot'),
+
+    ('cxx', 'big'),
+    ('cxx', 'small'),
+
     ('cxx', 'tcmalloc'),
 
     # TODO: should be binary with different files

--- a/mycpp/bump_leak_heap.cc
+++ b/mycpp/bump_leak_heap.cc
@@ -12,7 +12,7 @@
 
 // We need this #ifdef because we don't want the global var in other binaries
 
-#ifdef BUMP_LEAK
+#if defined(BUMP_LEAK) || defined(TAKE_OVER_SMALL) || defined(TAKE_OVER_BIG)
 
 // some benchmarks take more than 1 GiB
 // but cachegrind can't work with static data of 2 GiB (get mmap() error)
@@ -74,6 +74,8 @@ void BumpLeakHeap::CleanProcessExit() {
 void BumpLeakHeap::FastProcessExit() {
   PrintStats(STDERR_FILENO);
 }
+#endif
 
+#ifdef BUMP_LEAK
 BumpLeakHeap gHeap;
 #endif

--- a/mycpp/mark_sweep_heap.cc
+++ b/mycpp/mark_sweep_heap.cc
@@ -56,9 +56,28 @@ int MarkSweepHeap::MaybeCollect() {
   return result;
 }
 
+#if defined(TAKE_OVER_SMALL) || defined(TAKE_OVER_BIG)
+#include "mycpp/bump_leak_heap.h"
+
+BumpLeakHeap gBumpLeak;
+#endif
+
 // Allocate and update stats
 void* MarkSweepHeap::Allocate(size_t num_bytes) {
   // log("Allocate %d", num_bytes);
+
+  // These only work with GC off -- OIL_GC_THRESHOLD=[big]
+  #ifdef TAKE_OVER_SMALL
+  if (num_bytes <= 32) {
+    return gBumpLeak.Allocate(num_bytes);
+  }
+  #endif
+
+  #ifdef TAKE_OVER_BIG
+  if (num_bytes > 32) {
+    return gBumpLeak.Allocate(num_bytes);
+  }
+  #endif
 
   if (to_free_.empty()) {
     // Use higher object IDs


### PR DESCRIPTION
calloc() is showing up hot in our profiles

Instead, just NUL terminate strings, and zero Slab<T*> which is HeapTag::Scanned.