### PR TITLE
[build] Make the link step respect OIL_NINJA_VERBOSE

### DIFF
--- a/build/ninja-rules-cpp.sh
+++ b/build/ninja-rules-cpp.sh
@@ -287,13 +287,12 @@ link() {
     prefix="benchmarks/time_.py --tsv --out $TIME_TSV_OUT --append --rusage --field link --field $out --"
   fi
 
+  if test -n "${OIL_NINJA_VERBOSE:-}"; then
+    echo "__ $prefix $cxx -o $out $@ $link_flags" >&2
+  fi
   # IMPORTANT: Flags like -ltcmalloc have to come AFTER objects!  Weird but
   # true.
-  local cmdline=($prefix "$cxx" -o "$out" "$@" $link_flags)
-  if test -n "${OIL_NINJA_VERBOSE:-}"; then
-    echo "__ ${cmdline[@]}" >&2
-  fi
-  "${cmdline[@]}"
+  $prefix "$cxx" -o "$out" "$@" $link_flags
 }
 
 compile_and_link() {

--- a/build/ninja-rules-cpp.sh
+++ b/build/ninja-rules-cpp.sh
@@ -289,7 +289,11 @@ link() {
 
   # IMPORTANT: Flags like -ltcmalloc have to come AFTER objects!  Weird but
   # true.
-  $prefix "$cxx" -o "$out" "$@" $link_flags
+  local cmdline=($prefix "$cxx" -o "$out" "$@" $link_flags)
+  if test -n "${OIL_NINJA_VERBOSE:-}"; then
+    echo "__ ${cmdline[@]}" >&2
+  fi
+  "${cmdline[@]}"
 }
 
 compile_and_link() {


### PR DESCRIPTION
Just wanted this while doing something else.

Tested by running both:
```
TIME_TSV_OUT=/tmp/t OIL_NINJA_VERBOSE=1 ninja
OIL_NINJA_VERBOSE=1 ninja
```
and verifying the command line output and timing output file look as expected