### PR TITLE
[scripts] Give common scripts usage errors on no args

### DIFF
--- a/build/deps.sh
+++ b/build/deps.sh
@@ -34,7 +34,8 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-source deps/from-apt.sh   # PY3_BUILD_DEPS
+source deps/from-apt.sh    # PY3_BUILD_DEPS
+source devtools/common.sh  # main
 
 # Also in build/dev-shell.sh
 USER_WEDGE_DIR=~/wedge/oils-for-unix.org
@@ -309,4 +310,4 @@ container-wedges() {
   #deps/wedge.sh build deps/source.medo/R-libs/
 }
 
-"$@"
+main "$@"

--- a/build/py.sh
+++ b/build/py.sh
@@ -14,7 +14,8 @@ shopt -s strict:all 2>/dev/null || true  # dogfood for OSH
 REPO_ROOT=$(cd "$(dirname $0)/.."; pwd)
 readonly REPO_ROOT
 
-source build/common.sh  # for log, $CLANGXX
+source build/common.sh     # log, $CLANGXX
+source devtools/common.sh  # main
 # TODO: We could have the user run deps/from-apt.sh directly
 
 if test -z "${IN_NIX_SHELL:-}"; then
@@ -478,9 +479,4 @@ gitpod-minimal() {
   bin/osh -c 'echo hi'
 }
 
-if [ $# -eq 0 ]; then
-  echo "usage: $0 <function name>"
-  exit 1
-fi
-
-"$@"
+main "$@"

--- a/devtools/common.sh
+++ b/devtools/common.sh
@@ -34,6 +34,15 @@ typecheck() {
   MYPYPATH='.:pyext' PYTHONPATH='.' mypy_ --py2 "$@"
 }
 
+main() {
+  if [ $# -eq 0 ]; then
+    echo "usage: $0 <function name>"
+    exit 1
+  fi
+
+  "$@"
+}
+
 readonly MYPY_FLAGS='--strict --no-strict-optional'
 readonly COMMENT_RE='^[ ]*#'
 

--- a/devtools/refactor.sh
+++ b/devtools/refactor.sh
@@ -7,6 +7,8 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
+source devtools/common.sh
+
 change-kind() {
   local kind=$1
   local kind2=${2:-$kind}
@@ -190,4 +192,4 @@ asdl-create() {
   fgrep -n 'CreateNull(alloc' */*.py */*/*.py | egrep -v '_devbuild|_test.py' | tee _tmp/asdl
 }
 
-"$@"
+main "$@"

--- a/devtools/types.sh
+++ b/devtools/types.sh
@@ -7,7 +7,7 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-source devtools/common.sh
+source devtools/common.sh  # main, typecheck, mypy_
 
 typecheck-files() {
   # The --follow-imports=silent option allows adding type annotations
@@ -55,4 +55,4 @@ soil-run() {
   check-all
 }
 
-"$@"
+main "$@"

--- a/prebuilt/translate.sh
+++ b/prebuilt/translate.sh
@@ -11,7 +11,8 @@ set -o errexit
 
 REPO_ROOT=$(cd "$(dirname $0)/.."; pwd)
 
-source mycpp/common.sh  # MYPY_REPO
+source mycpp/common.sh     # MYPY_REPO
+source devtools/common.sh  # main
 source build/ninja-rules-cpp.sh
 
 readonly TEMP_DIR=_build/tmp
@@ -118,4 +119,4 @@ frontend-args() {
     frontend/args.py
 }
 
-"$@"
+main "$@"


### PR DESCRIPTION
Previously invoking scripts like `devtools/types.sh` with no args would silently do nothing. I remember being caught a few times trying to figure out why the script wasn't giving me any output.

I've only changed the scripts I've used. I know some scripts are sourced by others and are expected to do "nothing" when run and didn't want to break those. I figure that just these more common scripts should be enough to have the most impact.