### PR TITLE
[builtin/history] Add support for '-a' (append) flag

### DIFF
--- a/core/shell.py
+++ b/core/shell.py
@@ -9,6 +9,7 @@ import time
 from _devbuild.gen import arg_types
 from _devbuild.gen.option_asdl import option_i, builtin_i
 from _devbuild.gen.syntax_asdl import loc, source, source_t, IntParamBox
+from _devbuild.gen.runtime_asdl import value, scope_e
 
 from asdl import runtime
 
@@ -36,6 +37,7 @@ _ = flag_def
 from frontend import flag_spec
 from frontend import reader
 from frontend import parse_lib
+from frontend import location
 
 from oil_lang import expr_eval
 from oil_lang import builtin_json
@@ -383,7 +385,9 @@ def Main(lang, arg_r, environ, login_shell, loader, readline):
   home_dir = pyos.GetMyHomeDir()
   assert home_dir is not None
 
+  # init the HISTFILE variable to our default history file
   history_filename = os_path.join(home_dir, '.config/oil/history_%s' % lang)
+  mem.SetValue(location.LName('HISTFILE'), value.Str(history_filename), scope_e.GlobalOnly)
 
   #
   # Initialize builtins that don't depend on evaluators

--- a/core/shell.py
+++ b/core/shell.py
@@ -407,7 +407,7 @@ def Main(lang, arg_r, environ, login_shell, loader, readline):
 
   # Interactive, depend on readline
   builtins[builtin_i.bind] = builtin_lib.Bind(readline, errfmt)
-  builtins[builtin_i.history] = builtin_lib.History(readline, history_filename, mylib.Stdout())
+  builtins[builtin_i.history] = builtin_lib.History(readline, mem, mylib.Stdout())
 
   #
   # Initialize Evaluators

--- a/core/shell.py
+++ b/core/shell.py
@@ -9,7 +9,6 @@ import time
 from _devbuild.gen import arg_types
 from _devbuild.gen.option_asdl import option_i, builtin_i
 from _devbuild.gen.syntax_asdl import loc, source, source_t, IntParamBox
-from _devbuild.gen.runtime_asdl import value, scope_e
 
 from asdl import runtime
 

--- a/core/shell.py
+++ b/core/shell.py
@@ -36,7 +36,6 @@ unused2 = flag_def
 from frontend import flag_spec
 from frontend import reader
 from frontend import parse_lib
-from frontend import location
 
 from oil_lang import expr_eval
 from oil_lang import builtin_json

--- a/core/shell.py
+++ b/core/shell.py
@@ -378,6 +378,13 @@ def Main(lang, arg_r, environ, login_shell, loader, readline):
 
   dir_stack = state.DirStack()
 
+  # Find common directories, these are consumed by some builtins and then much
+  # later used while setting up an interactive shell.
+  home_dir = pyos.GetMyHomeDir()
+  assert home_dir is not None
+
+  history_filename = os_path.join(home_dir, '.config/oil/history_%s' % lang)
+
   #
   # Initialize builtins that don't depend on evaluators
   #
@@ -400,7 +407,7 @@ def Main(lang, arg_r, environ, login_shell, loader, readline):
 
   # Interactive, depend on readline
   builtins[builtin_i.bind] = builtin_lib.Bind(readline, errfmt)
-  builtins[builtin_i.history] = builtin_lib.History(readline, mylib.Stdout())
+  builtins[builtin_i.history] = builtin_lib.History(readline, history_filename, mylib.Stdout())
 
   #
   # Initialize Evaluators
@@ -544,9 +551,6 @@ def Main(lang, arg_r, environ, login_shell, loader, readline):
 
   # https://unix.stackexchange.com/questions/24347/why-do-some-applications-use-config-appname-for-their-config-data-while-other
 
-  home_dir = pyos.GetMyHomeDir()
-  assert home_dir is not None
-
   rc_paths = []  # type: List[str]
 
   if not flag.norc:
@@ -602,7 +606,6 @@ def Main(lang, arg_r, environ, login_shell, loader, readline):
 
     return status
 
-  history_filename = os_path.join(home_dir, '.config/oil/history_%s' % lang)
   if exec_opts.interactive():
     state.InitInteractive(mem)
     # bash: 'set -o emacs' is the default only in the interactive shell

--- a/core/shell.py
+++ b/core/shell.py
@@ -387,7 +387,7 @@ def Main(lang, arg_r, environ, login_shell, loader, readline):
 
   # init the HISTFILE variable to our default history file
   history_filename = os_path.join(home_dir, '.config/oil/history_%s' % lang)
-  mem.SetValue(location.LName('HISTFILE'), value.Str(history_filename), scope_e.GlobalOnly)
+  state.SetGlobalString(mem, 'HISTFILE', history_filename)
 
   #
   # Initialize builtins that don't depend on evaluators

--- a/core/test_lib.py
+++ b/core/test_lib.py
@@ -208,7 +208,7 @@ def InitCommandEvaluator(
 
       builtin_i.history: builtin_lib.History(
         readline,
-        "_tmp/builtin_test_history.txt",
+        mem,
         mylib.Stdout(),
       ),
 

--- a/core/test_lib.py
+++ b/core/test_lib.py
@@ -206,7 +206,11 @@ def InitCommandEvaluator(
       builtin_i.echo: builtin_pure.Echo(exec_opts),
       builtin_i.shift: builtin_assign.Shift(mem),
 
-      builtin_i.history: builtin_lib.History(readline, mylib.Stdout()),
+      builtin_i.history: builtin_lib.History(
+        readline,
+        "_tmp/builtin_test_history.txt",
+        mylib.Stdout(),
+      ),
 
       builtin_i.compopt: builtin_comp.CompOpt(compopt_state, errfmt),
       builtin_i.compadjust: builtin_comp.CompAdjust(mem),

--- a/frontend/flag_def.py
+++ b/frontend/flag_def.py
@@ -162,6 +162,7 @@ HELP_SPEC = FlagSpec('help')
 
 HISTORY_SPEC = FlagSpec('history')
 HISTORY_SPEC.ShortFlag('-a')
+HISTORY_SPEC.ShortFlag('-r')
 HISTORY_SPEC.ShortFlag('-c')
 HISTORY_SPEC.ShortFlag('-d', args.Int)
 

--- a/frontend/flag_def.py
+++ b/frontend/flag_def.py
@@ -161,6 +161,7 @@ HELP_SPEC = FlagSpec('help')
 
 
 HISTORY_SPEC = FlagSpec('history')
+HISTORY_SPEC.ShortFlag('-a')
 HISTORY_SPEC.ShortFlag('-c')
 HISTORY_SPEC.ShortFlag('-d', args.Int)
 

--- a/osh/builtin_lib.py
+++ b/osh/builtin_lib.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 from _devbuild.gen import arg_types
 from _devbuild.gen.runtime_asdl import value_e, value__Str
 from _devbuild.gen.syntax_asdl import loc
-from core import error
+from core.pyerror import e_die_status, e_strict
 from core import state
 from core import vm
 from core.pyerror import e_usage
@@ -54,7 +54,14 @@ class History(vm._Builtin):
       val = cast(value__Str, UP_val)
       return val.s
     else:
-      raise error.ErrExit(1, "$HISTFILE is not a string, it should be.", loc.Missing())
+      # TODO: can we recover line information here?
+      #       might be useful to show where HISTFILE was set
+      e_strict("$HISTFILE should only ever be a string", loc.Missing())
+
+      # TODO: support bash-like behaviour here where we try to convert $HISTFILE
+      # to a string in anyway possible
+      e_die_status(1, "Conversion of non-string value, $HISTFILE, to a string is not implemented",
+                   loc.Missing())
 
   def Run(self, cmd_val):
     # type: (cmd_value__Argv) -> int

--- a/osh/builtin_lib.py
+++ b/osh/builtin_lib.py
@@ -35,10 +35,13 @@ class Bind(vm._Builtin):
 class History(vm._Builtin):
   """Show interactive command history."""
 
-  def __init__(self, readline, f):
-    # type: (Optional[Readline], mylib.Writer) -> None
+  def __init__(self, readline, history_filename, f):
+    # type: (Optional[Readline], str, mylib.Writer) -> None
     self.readline = readline
     self.f = f  # this hook is for unit testing only
+
+    # TODO: we should be reading this from $HISTFILE (like bash) and not
+    self.history_filename = history_filename
 
   def Run(self, cmd_val):
     # type: (cmd_value__Argv) -> int
@@ -55,6 +58,10 @@ class History(vm._Builtin):
     # Clear all history
     if arg.c:
       readline.clear_history()
+      return 0
+
+    if arg.a:
+      readline.write_history_file(self.history_filename)
       return 0
 
     # Delete history entry by id number

--- a/osh/builtin_lib.py
+++ b/osh/builtin_lib.py
@@ -46,6 +46,7 @@ class History(vm._Builtin):
     self.mem = mem
 
   def GetHistoryFilename(self):
+    # type: () -> str
     # TODO: In non-strict mode we should try to cast the HISTFILE value to a
     # string following bash's rules
 

--- a/osh/builtin_lib.py
+++ b/osh/builtin_lib.py
@@ -41,9 +41,8 @@ class History(vm._Builtin):
   def __init__(self, readline, mem, f):
     # type: (Optional[Readline], state.Mem, mylib.Writer) -> None
     self.readline = readline
-    self.f = f  # this hook is for unit testing only
-
     self.mem = mem
+    self.f = f  # this hook is for unit testing only
 
   def GetHistoryFilename(self):
     # type: () -> str

--- a/osh/builtin_lib.py
+++ b/osh/builtin_lib.py
@@ -55,7 +55,7 @@ class History(vm._Builtin):
       val = cast(value__Str, UP_val)
       return val.s
     else:
-      raise error.ErrExit(1, "$HISTFILE is not a string, it should be." + str(UP_val), loc.Missing())
+      raise error.ErrExit(1, "$HISTFILE is not a string, it should be.", loc.Missing())
 
   def Run(self, cmd_val):
     # type: (cmd_value__Argv) -> int

--- a/osh/builtin_lib.py
+++ b/osh/builtin_lib.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 from _devbuild.gen import arg_types
 from _devbuild.gen.runtime_asdl import value_e, value__Str
 from _devbuild.gen.syntax_asdl import loc
-from core.pyerror import e_die_status, e_strict
+from core import error
 from core import state
 from core import vm
 from core.pyerror import e_usage
@@ -54,14 +54,12 @@ class History(vm._Builtin):
       val = cast(value__Str, UP_val)
       return val.s
     else:
-      # TODO: can we recover line information here?
-      #       might be useful to show where HISTFILE was set
-      e_strict("$HISTFILE should only ever be a string", loc.Missing())
-
       # TODO: support bash-like behaviour here where we try to convert $HISTFILE
       # to a string in anyway possible
-      e_die_status(1, "Conversion of non-string value, $HISTFILE, to a string is not implemented",
-                   loc.Missing())
+
+      # TODO: can we recover line information here?
+      #       might be useful to show where HISTFILE was set
+      raise error.Strict("$HISTFILE should only ever be a string", loc.Missing())
 
   def Run(self, cmd_val):
     # type: (cmd_value__Argv) -> int

--- a/osh/builtin_lib_test.py
+++ b/osh/builtin_lib_test.py
@@ -10,8 +10,6 @@ import unittest
 # unit testing
 import readline
 
-from _devbuild.gen.syntax_asdl import loc
-
 from core import test_lib
 from core import state
 from core import alloc

--- a/osh/builtin_lib_test.py
+++ b/osh/builtin_lib_test.py
@@ -19,17 +19,16 @@ from osh import builtin_lib  # module under test
 
 
 class BuiltinTest(unittest.TestCase):
-  TEST_PATH = '_tmp/builtin_test_history.txt'
-
   def testHistoryBuiltin(self):
-     with open(BuiltinTest.TEST_PATH, 'w') as f:
+     test_path = '_tmp/builtin_test_history.txt'
+     with open(test_path, 'w') as f:
        f.write("""\
 echo hello
 ls one/
 ls two/
 echo bye
 """)
-     readline.read_history_file(BuiltinTest.TEST_PATH)
+     readline.read_history_file(test_path)
 
      # Show all
      f = cStringIO.StringIO()

--- a/osh/builtin_lib_test.py
+++ b/osh/builtin_lib_test.py
@@ -86,7 +86,7 @@ echo bye
 def _TestHistory(argv):
    f = cStringIO.StringIO()
    arena = alloc.Arena()
-   mem = state.Mem(loc.Missing(), [], arena, [])
+   mem = state.Mem('', [], arena, [])
    b = builtin_lib.History(readline, mem, f)
    cmd_val = test_lib.MakeBuiltinArgv(argv)
    b.Run(cmd_val)

--- a/spec/builtins2.test.sh
+++ b/spec/builtins2.test.sh
@@ -200,6 +200,22 @@ exists
 ## N-I zsh STDOUT:
 ## END
 
+#### HISTFILE must be a string
+case $SH in bash|mksh|dash|zsh) exit 0 ;; esac
+
+echo '
+HISTFILE=(a b c)
+history -r
+echo $?
+' | $SH -i
+
+## STDOUT:
+1
+^D
+## END
+## N-I bash/mksh/dash/zsh STDOUT:
+## END
+
 #### history usage
 history
 echo status=$?

--- a/spec/builtins2.test.sh
+++ b/spec/builtins2.test.sh
@@ -121,6 +121,34 @@ command command -v seq
 ## N-I zsh stdout-json: ""
 ## N-I zsh status: 127
 
+#### history -a
+case $SH in dash|mksh|zsh) exit 0 ;; esac
+
+rm -f tmp
+
+echo '
+history -c
+
+HISTFILE=tmp
+echo 1
+history -a
+echo 2
+' | $SH -i 
+
+cat tmp
+
+## STDOUT:
+1
+2
+^D
+HISTFILE=tmp
+echo 1
+history -a
+## END
+## N-I dash/mksh/zsh STDOUT:
+## END
+
+
 #### history usage
 history
 echo status=$?

--- a/spec/builtins2.test.sh
+++ b/spec/builtins2.test.sh
@@ -132,22 +132,73 @@ history -c
 HISTFILE=tmp
 echo 1
 history -a
+cat tmp
+
 echo 2
-' | $SH -i 
 
 cat tmp
+' | $SH -i
+
+# match osh's behaviour of echoing ^D for EDF
+case $SH in bash) echo '^D' ;; esac
 
 ## STDOUT:
 1
-2
-^D
 HISTFILE=tmp
 echo 1
 history -a
+2
+HISTFILE=tmp
+echo 1
+history -a
+^D
 ## END
 ## N-I dash/mksh/zsh STDOUT:
 ## END
 
+#### history -r
+case $SH in dash|mksh|zsh) exit 0 ;; esac
+
+rm -f tmp
+echo 'foo' > tmp
+
+echo '
+history -c
+
+HISTFILE=tmp
+history -r
+history
+' | $SH -i
+
+# match osh's behaviour of echoing ^D for EDF
+case $SH in bash) echo '^D' ;; esac
+
+## STDOUT:
+    1  HISTFILE=tmp
+    2  history -r
+    3  foo
+    4  history
+^D
+## END
+## N-I dash/mksh/zsh STDOUT:
+## END
+
+#### HISTFILE is defined initially
+case $SH in zsh) exit 0 ;; esac
+
+echo '
+if test -n $HISTFILE; then echo exists; fi
+' | $SH -i
+
+# match osh's behaviour of echoing ^D for EDF
+case $SH in bash|mksh|dash) echo '^D' ;; esac
+
+## STDOUT:
+exists
+^D
+## END
+## N-I zsh STDOUT:
+## END
 
 #### history usage
 history

--- a/spec/builtins2.test.sh
+++ b/spec/builtins2.test.sh
@@ -139,7 +139,7 @@ echo 2
 cat tmp
 ' | $SH -i
 
-# match osh's behaviour of echoing ^D for EDF
+# match osh's behaviour of echoing ^D for EOF
 case $SH in bash) echo '^D' ;; esac
 
 ## STDOUT:
@@ -170,7 +170,7 @@ history -r
 history
 ' | $SH -i
 
-# match osh's behaviour of echoing ^D for EDF
+# match osh's behaviour of echoing ^D for EOF
 case $SH in bash) echo '^D' ;; esac
 
 ## STDOUT:
@@ -190,7 +190,7 @@ echo '
 if test -n $HISTFILE; then echo exists; fi
 ' | $SH -i
 
-# match osh's behaviour of echoing ^D for EDF
+# match osh's behaviour of echoing ^D for EOF
 case $SH in bash|mksh|dash) echo '^D' ;; esac
 
 ## STDOUT:


### PR DESCRIPTION
Now we can do something like this:

```sh
$ echo 'start of osh session'
start of osh session
$ cat ~/.config/oil/history_osh
$ history -a
$ cat ~/.config/oil/history_osh
echo 'start of osh session'
cat ~/.config/oil/history_osh
history -a
```