### PR TITLE
[test/spec] Split history builtin tests from builtins2 tests

### DIFF
--- a/core/shell.py
+++ b/core/shell.py
@@ -530,7 +530,7 @@ def Main(lang, arg_r, environ, login_shell, loader, readline):
 
   # Interactive, depend on readline
   builtins[builtin_i.bind] = builtin_lib.Bind(readline, errfmt)
-  builtins[builtin_i.history] = builtin_lib.History(readline, mem, mylib.Stdout())
+  builtins[builtin_i.history] = builtin_lib.History(readline, mem, errfmt, mylib.Stdout())
 
   #
   # Initialize Evaluators

--- a/core/test_lib.py
+++ b/core/test_lib.py
@@ -210,6 +210,7 @@ def InitCommandEvaluator(
       builtin_i.history: builtin_lib.History(
         readline,
         mem,
+        errfmt,
         mylib.Stdout(),
       ),
 

--- a/osh/builtin_lib.py
+++ b/osh/builtin_lib.py
@@ -87,7 +87,7 @@ class History(vm._Builtin):
     if arg.r:
       history_filename = self.GetHistoryFilename()
       if not path_stat.exists(history_filename):
-        self.errfmt.Print_("The file '%s' ($HISTFILE) does not exist" % history_filename, loc.Missing())
+        self.errfmt.Print_("HISTFILE %r doesn't exist" % history_filename, loc.Missing())
         return 1
 
       readline.read_history_file(history_filename)

--- a/osh/builtin_lib.py
+++ b/osh/builtin_lib.py
@@ -13,6 +13,7 @@ from core import vm
 from core.pyerror import e_usage
 from frontend import flag_spec
 from mycpp import mylib
+from pylib import path_stat
 
 from typing import Optional, cast, TYPE_CHECKING
 if TYPE_CHECKING:
@@ -83,7 +84,12 @@ class History(vm._Builtin):
       return 0
 
     if arg.r:
-      readline.read_history_file(self.GetHistoryFilename())
+      history_filename = self.GetHistoryFilename()
+      history_file_exists = path_stat.exists(history_filename)
+      if not history_file_exists:
+        raise error.ErrExit(1, "The file '%s' ($HISTFILE) does not exist" % history_filename, loc.Missing())
+
+      readline.read_history_file(history_filename)
       return 0
 
     # Delete history entry by id number

--- a/osh/builtin_lib.py
+++ b/osh/builtin_lib.py
@@ -39,10 +39,11 @@ class Bind(vm._Builtin):
 class History(vm._Builtin):
   """Show interactive command history."""
 
-  def __init__(self, readline, mem, f):
-    # type: (Optional[Readline], state.Mem, mylib.Writer) -> None
+  def __init__(self, readline, mem, errfmt, f):
+    # type: (Optional[Readline], state.Mem, ErrorFormatter, mylib.Writer) -> None
     self.readline = readline
     self.mem = mem
+    self.errfmt = errfmt
     self.f = f  # this hook is for unit testing only
 
   def GetHistoryFilename(self):
@@ -85,9 +86,9 @@ class History(vm._Builtin):
 
     if arg.r:
       history_filename = self.GetHistoryFilename()
-      history_file_exists = path_stat.exists(history_filename)
-      if not history_file_exists:
-        raise error.ErrExit(1, "The file '%s' ($HISTFILE) does not exist" % history_filename, loc.Missing())
+      if not path_stat.exists(history_filename):
+        self.errfmt.Print_("The file '%s' ($HISTFILE) does not exist" % history_filename, loc.Missing())
+        return 1
 
       readline.read_history_file(history_filename)
       return 0

--- a/osh/builtin_lib_test.py
+++ b/osh/builtin_lib_test.py
@@ -13,6 +13,7 @@ import readline
 from core import test_lib
 from core import state
 from core import alloc
+from core import ui
 from frontend import flag_def  # side effect: flags are defined!
 _ = flag_def
 from osh import builtin_lib  # module under test
@@ -84,7 +85,8 @@ def _TestHistory(argv):
    f = cStringIO.StringIO()
    arena = alloc.Arena()
    mem = state.Mem('', [], arena, [])
-   b = builtin_lib.History(readline, mem, f)
+   errfmt = ui.ErrorFormatter(arena)
+   b = builtin_lib.History(readline, mem, errfmt, f)
    cmd_val = test_lib.MakeBuiltinArgv(argv)
    b.Run(cmd_val)
    return f.getvalue()

--- a/spec/builtin-history.test.sh
+++ b/spec/builtin-history.test.sh
@@ -71,7 +71,7 @@ exists
 
 echo '
 HISTFILE=(a b c)
-history -r
+history -a
 echo $?
 ' | $SH -i
 

--- a/spec/builtin-history.test.sh
+++ b/spec/builtin-history.test.sh
@@ -1,0 +1,103 @@
+#### history -a
+rm -f tmp
+
+echo '
+history -c
+
+HISTFILE=tmp
+echo 1
+history -a
+cat tmp
+
+echo 2
+
+cat tmp
+' | $SH -i
+
+# match osh's behaviour of echoing ^D for EOF
+case $SH in bash) echo '^D' ;; esac
+
+## STDOUT:
+1
+HISTFILE=tmp
+echo 1
+history -a
+2
+HISTFILE=tmp
+echo 1
+history -a
+^D
+## END
+
+#### history -r
+rm -f tmp
+echo 'foo' > tmp
+
+echo '
+history -c
+
+HISTFILE=tmp
+history -r
+history
+' | $SH -i
+
+# match osh's behaviour of echoing ^D for EOF
+case $SH in bash) echo '^D' ;; esac
+
+## STDOUT:
+    1  HISTFILE=tmp
+    2  history -r
+    3  foo
+    4  history
+^D
+## END
+
+#### HISTFILE is defined initially
+echo '
+if test -n $HISTFILE; then echo exists; fi
+' | $SH -i
+
+# match osh's behaviour of echoing ^D for EOF
+case $SH in bash) echo '^D' ;; esac
+
+## STDOUT:
+exists
+^D
+## END
+
+#### HISTFILE must be a string
+
+# TODO: we should support bash's behaviour here
+
+echo '
+HISTFILE=(a b c)
+history -r
+echo $?
+' | $SH -i
+
+## STDOUT:
+0
+## END
+## OK osh STDOUT:
+1
+^D
+## END
+
+#### history -d to delete history item
+
+# TODO: Respect HISTFILE and fix this test
+
+history -d 1
+echo status=$?
+
+# problem: default for integers is -1
+history -d -1
+echo status=$?
+history -d -2
+echo status=$?
+
+## STDOUT:
+status=0
+status=1
+status=1
+## END

--- a/spec/builtin-history.test.sh
+++ b/spec/builtin-history.test.sh
@@ -65,6 +65,22 @@ exists
 ^D
 ## END
 
+#### HISTFILE must point to a file
+
+echo '
+HISTFILE=_tmp/does-not-exist
+history -r
+echo $?
+' | $SH -i
+
+# match osh's behaviour of echoing ^D for EOF
+case $SH in bash) echo '^D' ;; esac
+
+## STDOUT:
+1
+^D
+## END
+
 #### HISTFILE must be a string
 
 # TODO: we should support bash's behaviour here

--- a/spec/builtins2.test.sh
+++ b/spec/builtins2.test.sh
@@ -121,101 +121,6 @@ command command -v seq
 ## N-I zsh stdout-json: ""
 ## N-I zsh status: 127
 
-#### history -a
-case $SH in dash|mksh|zsh) exit 0 ;; esac
-
-rm -f tmp
-
-echo '
-history -c
-
-HISTFILE=tmp
-echo 1
-history -a
-cat tmp
-
-echo 2
-
-cat tmp
-' | $SH -i
-
-# match osh's behaviour of echoing ^D for EOF
-case $SH in bash) echo '^D' ;; esac
-
-## STDOUT:
-1
-HISTFILE=tmp
-echo 1
-history -a
-2
-HISTFILE=tmp
-echo 1
-history -a
-^D
-## END
-## N-I dash/mksh/zsh STDOUT:
-## END
-
-#### history -r
-case $SH in dash|mksh|zsh) exit 0 ;; esac
-
-rm -f tmp
-echo 'foo' > tmp
-
-echo '
-history -c
-
-HISTFILE=tmp
-history -r
-history
-' | $SH -i
-
-# match osh's behaviour of echoing ^D for EOF
-case $SH in bash) echo '^D' ;; esac
-
-## STDOUT:
-    1  HISTFILE=tmp
-    2  history -r
-    3  foo
-    4  history
-^D
-## END
-## N-I dash/mksh/zsh STDOUT:
-## END
-
-#### HISTFILE is defined initially
-case $SH in zsh) exit 0 ;; esac
-
-echo '
-if test -n $HISTFILE; then echo exists; fi
-' | $SH -i
-
-# match osh's behaviour of echoing ^D for EOF
-case $SH in bash|mksh|dash) echo '^D' ;; esac
-
-## STDOUT:
-exists
-^D
-## END
-## N-I zsh STDOUT:
-## END
-
-#### HISTFILE must be a string
-case $SH in bash|mksh|dash|zsh) exit 0 ;; esac
-
-echo '
-HISTFILE=(a b c)
-history -r
-echo $?
-' | $SH -i
-
-## STDOUT:
-1
-^D
-## END
-## N-I bash/mksh/dash/zsh STDOUT:
-## END
-
 #### history usage
 history
 echo status=$?
@@ -256,28 +161,6 @@ status=127
 status=127
 status=127
 ## END
-
-#### history -d to delete history item
-
-# TODO: Respect HISTFILE and fix this test
-
-case $SH in (dash|mksh|zsh) exit ;; esac
-
-history -d 1
-echo status=$?
-
-# problem: default for integers is -1
-history -d -1
-echo status=$?
-history -d -2
-echo status=$?
-
-## STDOUT:
-status=0
-status=1
-status=1
-## END
-## N-I dash/mksh/zsh stdout-json: ""
 
 #### $(command type ls)
 type() { echo FUNCTION; }

--- a/test/spec.sh
+++ b/test/spec.sh
@@ -446,8 +446,13 @@ builtin-printf() {
 }
 
 builtins2() {
-  sh-spec spec/builtins2.test.sh --osh-failures-allowed 1 \
+  sh-spec spec/builtins2.test.sh \
     ${REF_SHELLS[@]} $ZSH $OSH_LIST "$@"
+}
+
+builtin-history() {
+  sh-spec spec/builtin-history.test.sh --osh-failures-allowed 1 \
+    $BASH $OSH_LIST "$@"
 }
 
 # dash and mksh don't implement 'dirs'

--- a/test/spec_osh.py
+++ b/test/spec_osh.py
@@ -70,6 +70,8 @@ def Define(sp):
 
   sp.File('builtin-getopts')
 
+  sp.File('builtin-history')
+
   sp.File('builtin-io')
 
   sp.File('builtin-printf')


### PR DESCRIPTION
As per https://github.com/oilshell/oil/pull/1587#discussion_r1181092501.

---

While working on this I realized we were missing the case where `HISTFILE` does not point to a file (even if it's a valid string). This should return an error code if a user tries to then `history -r`.