### PR TITLE
[builtin/json] Don't use global fdopen(0) for stdin

### DIFF
--- a/asdl/ast.py
+++ b/asdl/ast.py
@@ -1,24 +1,6 @@
-#-------------------------------------------------------------------------------
-# Parser for ASDL [1] definition files. Reads in an ASDL description and parses
-# it into an AST that describes it.
-#
-# The EBNF we're parsing here: Figure 1 of the paper [1]. Extended to support
-# modules and attributes after a product. Words starting with Capital letters
-# are terminals. Literal tokens are in "double quotes". Others are
-# non-terminals. Id is either TokenId or ConstructorId.
-#
-# module        ::= "module" Id "{" [definitions] "}"
-# definitions   ::= { TypeId "=" type }
-# type          ::= product | sum
-# product       ::= fields ["attributes" fields]
-# fields        ::= "(" { field, "," } field ")"
-# field         ::= TypeId ["?" | "*"] [Id]
-# sum           ::= constructor { "|" constructor } ["attributes" fields]
-# constructor   ::= ConstructorId [fields]
-#
-# [1] "The Zephyr Abstract Syntax Description Language" by Wang, et. al. See
-#     http://asdl.sourceforge.net/
-#-------------------------------------------------------------------------------
+"""
+AST for ASDL.  (Not self-hosted!)
+"""
 from __future__ import print_function
 
 import cStringIO
@@ -213,9 +195,8 @@ class Constructor(_CompoundAST):
 
 class Sum(AST):
 
-  def __init__(self, types, attributes=None, generate=None):
+  def __init__(self, types, generate=None):
     self.types = types  # type: List[Constructor]
-    self.attributes = attributes or []
     self.generate = generate or []
 
   def Print(self, f, indent):
@@ -223,11 +204,6 @@ class Sum(AST):
     f.write('%sSum {\n' % ind)
     for t in self.types:
       t.Print(f, indent + 1)
-    if self.attributes:
-      f.write('\n')
-      f.write('%s  (attributes)\n' % ind)
-      for a in self.attributes:
-        a.Print(f, indent + 1)
     if self.generate:
       f.write('%s  generate %s\n' % (ind, self.generate))
     f.write('%s}\n' % ind)
@@ -239,20 +215,14 @@ class SimpleSum(Sum):
 
 class Product(_CompoundAST):
 
-  def __init__(self, fields, attributes=None):
+  def __init__(self, fields):
     _CompoundAST.__init__(self, fields)
-    self.attributes = attributes or []
 
   def Print(self, f, indent):
     ind = indent * '  '
     f.write('%sProduct {\n' % ind)
     for field in self.fields:
       field.Print(f, indent + 1)
-    if self.attributes:
-      f.write('\n')
-      f.write('%s  (attributes)\n' % ind)
-      for a in self.attributes:
-        a.Print(f, indent + 1)
     f.write('%s}\n' % ind)
 
 

--- a/asdl/examples/shared_variant.asdl
+++ b/asdl/examples/shared_variant.asdl
@@ -2,8 +2,7 @@
 
 module shared_variant {
 
-  -- Testing out this unused syntax
-  prod_with_attrs = (string a, string b) attributes (int* spid)
+  prod = (string a, string b)
 
   DoubleQuoted = (int left, string* tokens) 
 
@@ -12,7 +11,6 @@ module shared_variant {
     -- Use the existing TYPE DoubleQuoted, but create a new TAG
     -- expr_e.DoubleQuoted.
   | DoubleQuoted %DoubleQuoted
-  attributes (int* spids)
 
   Token = (int id, string val)
 

--- a/asdl/examples/typed_arith.asdl
+++ b/asdl/examples/typed_arith.asdl
@@ -13,6 +13,5 @@ module arith {
   | Index(arith_expr a, arith_expr index)
     -- Using Python's style for now.  Bash uses length instead of end.
   | Slice(arith_expr a, arith_expr? begin, arith_expr? end, arith_expr? stride)
-  attributes (int* spids)
 }
 

--- a/asdl/examples/typed_arith_parse.py
+++ b/asdl/examples/typed_arith_parse.py
@@ -124,9 +124,6 @@ def LeftAssign(p, token, left, rbp):
   if not isinstance(left, (arith_expr.Var, arith_expr.Index)):
     raise tdop.ParseError("Can't assign to %r" % left)
   node = arith_expr.Binary(token.val, left, p.ParseUntil(rbp))
-  # For TESTING
-  node.spids.append(42)
-  node.spids.append(43)
   return node
 
 

--- a/asdl/examples/typed_demo.py
+++ b/asdl/examples/typed_demo.py
@@ -22,7 +22,7 @@ def main(argv):
   print(op)
   print(repr(op))
 
-  n1 = cflow.Break()
+  n1 = cflow.Break
 
   # Type error!
   # n2 = cflow.Return()

--- a/asdl/front_end.py
+++ b/asdl/front_end.py
@@ -12,7 +12,7 @@ from asdl.util import log
 
 _ = log
 
-_KEYWORDS = ['use', 'module', 'attributes', 'generate']
+_KEYWORDS = ['use', 'module', 'generate']
 
 _TOKENS = [
     ('Keyword', ''),
@@ -230,7 +230,7 @@ class ASDLParser(object):
                 | NAME '%' NAME  # shared variant
 
     compound_type : product
-                  | constructor ('|' constructor)* attributes?
+                  | constructor ('|' constructor)*
     """
     if self.cur_token.kind == TokenKind.LParen:
       # If we see a (, it's a product
@@ -257,7 +257,6 @@ class ASDLParser(object):
         if self.cur_token.kind != TokenKind.Pipe:
           break
         self._advance()
-      attributes = self._parse_optional_attributes()
       generate = self._parse_optional_generate()
 
       # Additional validation
@@ -268,9 +267,9 @@ class ASDLParser(object):
                                   self.cur_token.lineno)
 
       if _SumIsSimple(sumlist):
-        return SimpleSum(sumlist, attributes, generate)
+        return SimpleSum(sumlist, generate)
       else:
-        return Sum(sumlist, attributes, generate)
+        return Sum(sumlist, generate)
 
   def _parse_type_expr(self):
     """
@@ -353,16 +352,6 @@ class ASDLParser(object):
     self._match(TokenKind.RParen)
     return fields
 
-  def _parse_optional_attributes(self):
-    """
-    attributes = 'attributes' fields
-    """
-    if self._at_keyword('attributes'):
-      self._advance()
-      return self._parse_fields()
-    else:
-      return None
-
   def _parse_list(self):
     """
     list_inner: NAME ( ',' NAME )* ','?
@@ -397,7 +386,7 @@ class ASDLParser(object):
     """
     product: fields attributes?
     """
-    return Product(self._parse_fields(), self._parse_optional_attributes())
+    return Product(self._parse_fields())
 
   def _advance(self):
     """Return current token; read next token into self.cur_token."""

--- a/asdl/gen_cpp_test.cc
+++ b/asdl/gen_cpp_test.cc
@@ -114,7 +114,7 @@ TEST shared_variant_test() {
 
   log("tok->tag() for Token = %d", tok->tag());
 
-  auto* eof = Alloc<tok::Eof>();
+  auto* eof = tok::Eof;
   tok = eof;
   log("tok->tag() for Eof = %d", tok->tag());
 
@@ -176,6 +176,7 @@ TEST dicts_test() {
 }
 
 using typed_demo_asdl::flag_type;
+using typed_demo_asdl::flag_type__Bool;
 using typed_demo_asdl::SetToArg_;
 
 ObjHeader make_global(ObjHeader header) {
@@ -184,7 +185,7 @@ ObjHeader make_global(ObjHeader header) {
 }
 
 // TODO: We should always use these, rather than 'new flag_type::Bool()'
-GcGlobal<flag_type::Bool> g_ft = {make_global(flag_type::Bool::obj_header())};
+GcGlobal<flag_type__Bool> g_ft = {make_global(flag_type__Bool::obj_header())};
 
 // Use __ style
 using typed_demo_asdl::cflow__Return;
@@ -203,7 +204,7 @@ TEST literal_test() {
   // Interesting, initializer list part of the constructor "runs".  Otherwise
   // this doesn't work.
   log("g_ft.tag() = %d", g_ft.obj.tag());
-  auto ft = Alloc<flag_type::Bool>();
+  auto ft = flag_type::Bool;
   ASSERT_EQ(g_ft.obj.tag(), ft->tag());
 
   log("g_ret.tag() = %d", g_ret.obj.tag());

--- a/asdl/gen_python_test.py
+++ b/asdl/gen_python_test.py
@@ -129,9 +129,8 @@ class ArithAstTest(unittest.TestCase):
     print('-- COMPOUND SUM --')
     print()
 
-    # TODO: Should be cflow_t.Break() and cflow_i.Break
-    c = cflow.Break()
-    assert isinstance(c, cflow.Break)
+    c = cflow.Break
+    assert isinstance(c, typed_demo_asdl.cflow__Break)
     assert isinstance(c, typed_demo_asdl.cflow_t)
     assert isinstance(c, pybase.CompoundObj)
 

--- a/bin/osh_parse.py
+++ b/bin/osh_parse.py
@@ -86,7 +86,7 @@ def main(argv):
     if argv[1] == '-c':
       # This path is easier to run through GDB
       line_reader = reader.StringLineReader(argv[2], arena)
-      src = source.CFlag()
+      src = source.CFlag
 
     elif argv[1] == '-n':  # For benchmarking, allow osh_parse -n file.txt
       path = argv[2]

--- a/core/completion_test.py
+++ b/core/completion_test.py
@@ -203,7 +203,7 @@ class CompletionTest(unittest.TestCase):
     }
     """, arena=arena)
     node = c_parser.ParseLogicalLine()
-    proc = Proc(node.name, node.name_tok, proc_sig.Open(), node.body, [], True)
+    proc = Proc(node.name, node.name_tok, proc_sig.Open, node.body, [], True)
 
     cmd_ev = test_lib.InitCommandEvaluator(arena=arena)
 

--- a/core/executor.py
+++ b/core/executor.py
@@ -367,7 +367,7 @@ class ShellExecutor(vm._Executor):
       if self.job_control.Enabled():
         p.AddStateChange(process.SetPgid(process.OWN_LEADER))
 
-      pid = p.StartProcess(trace.Fork())
+      pid = p.StartProcess(trace.Fork)
       self.mem.last_bg_pid = pid  # for $!
       self.job_list.AddJob(p)  # show in 'jobs' list
     return 0
@@ -413,7 +413,7 @@ class ShellExecutor(vm._Executor):
     if self.job_control.Enabled():
       p.AddStateChange(process.SetPgid(process.OWN_LEADER))
 
-    return p.RunProcess(self.waiter, trace.ForkWait())
+    return p.RunProcess(self.waiter, trace.ForkWait)
 
   def RunCommandSub(self, cs_part):
     # type: (CommandSub) -> str
@@ -453,7 +453,7 @@ class ShellExecutor(vm._Executor):
     r, w = posix.pipe()
     p.AddStateChange(process.StdoutToPipe(r, w))
 
-    p.StartProcess(trace.CommandSub())
+    p.StartProcess(trace.CommandSub)
     #log('Command sub started %d', pid)
 
     chunks = []  # type: List[str]
@@ -578,7 +578,7 @@ class ShellExecutor(vm._Executor):
       p.AddStateChange(process.SetPgid(process.OWN_LEADER))
 
     # Fork, letting the child inherit the pipe file descriptors.
-    p.StartProcess(trace.ProcessSub())
+    p.StartProcess(trace.ProcessSub)
 
     ps_frame = self.process_sub_stack[-1]
 

--- a/core/process.py
+++ b/core/process.py
@@ -455,7 +455,7 @@ class FdState(object):
 
           # NOTE: we could close the read pipe here, but it doesn't really
           # matter because we control the code.
-          here_proc.StartProcess(trace.HereDoc())
+          here_proc.StartProcess(trace.HereDoc)
           #log('Started %s as %d', here_proc, pid)
           self._PushWait(here_proc)
 
@@ -1206,7 +1206,7 @@ class Pipeline(Job):
       if pgid != INVALID_PGID:
         proc.AddStateChange(SetPgid(pgid))
 
-      pid = proc.StartProcess(trace.PipelinePart())
+      pid = proc.StartProcess(trace.PipelinePart)
       if i == 0 and pgid != INVALID_PGID:
         # Mimick bash and use the PID of the first process as the group for the
         # whole pipeline.

--- a/core/shell.py
+++ b/core/shell.py
@@ -617,7 +617,7 @@ def Main(lang, arg_r, environ, login_shell, loader, readline):
   hist_ev = history.Evaluator(readline, hist_ctx, debug_f)
 
   if flag.c is not None:
-    src = source.CFlag()  # type: source_t
+    src = source.CFlag  # type: source_t
     line_reader = reader.StringLineReader(flag.c, arena)  # type: reader._Reader
     if flag.i:  # -c and -i can be combined
       mutable_opts.set_interactive()
@@ -631,13 +631,13 @@ def Main(lang, arg_r, environ, login_shell, loader, readline):
   else:
     if script_name is None:
       if flag.headless:
-        src = source.Headless()
+        src = source.Headless
         line_reader = None  # unused!
         # Not setting '-i' flag for now.  Some people's bashrc may want it?
       else:
         stdin = mylib.Stdin()
         if stdin.isatty():
-          src = source.Interactive()
+          src = source.Interactive
           line_reader = reader.InteractiveLineReader(
               arena, prompt_ev, hist_ev, readline, prompt_state)
           mutable_opts.set_interactive()

--- a/core/state.py
+++ b/core/state.py
@@ -874,7 +874,7 @@ class _ArgFrame(object):
     # type: (int) -> value_t
     index = self.num_shifted + arg_num - 1
     if index >= len(self.argv):
-      return value.Undef()
+      return value.Undef
 
     return value.Str(self.argv[index])
 
@@ -1575,7 +1575,7 @@ class Mem(object):
     if op_id == Id.VSub_Bang:  # $!
       n = self.last_bg_pid
       if n == -1:
-        return value.Undef()  # could be an error
+        return value.Undef  # could be an error
 
     elif op_id == Id.VSub_QMark:  # $?
       # External commands need WIFEXITED test.  What about subshells?
@@ -1802,7 +1802,7 @@ class Mem(object):
         else:
           if val is None:  # declare -rx nonexistent
             # set -o nounset; local foo; echo $foo  # It's still undefined!
-            val = value.Undef()  # export foo, readonly foo
+            val = value.Undef  # export foo, readonly foo
 
           cell = Cell(bool(flags & SetExport),
                       bool(flags & SetReadOnly),
@@ -1972,7 +1972,7 @@ class Mem(object):
         # TODO: value.Int()
         return value.Obj(self.TryStatus())
       else:
-        return value.Undef()  # STUB
+        return value.Undef  # STUB
 
     if name == '_this_dir':
       if len(self.this_dir) == 0:
@@ -1980,7 +1980,7 @@ class Mem(object):
         # Should we give a custom error here?
         # If you're at the interactive shell, 'source mymodule.oil' will still
         # work because 'source' sets it.
-        return value.Undef()
+        return value.Undef
       else:
         return value.Str(self.this_dir[-1])  # top of stack
 
@@ -2073,7 +2073,7 @@ class Mem(object):
     if cell:
       return cell.val
 
-    return value.Undef()
+    return value.Undef
 
   def GetCell(self, name, which_scopes=scope_e.Shopt):
     # type: (str, scope_t) -> Cell
@@ -2129,7 +2129,7 @@ class Mem(object):
         mylib.dict_erase(name_map, cell_name)
 
         # alternative that some shells use:
-        #   name_map[cell_name].val = value.Undef()
+        #   name_map[cell_name].val = value.Undef
         #   cell.exported = False
 
         # This should never happen because we do recursive lookups of namerefs.

--- a/core/state_test.py
+++ b/core/state_test.py
@@ -255,7 +255,7 @@ class MemTest(unittest.TestCase):
     test_lib.AssertAsdlEqual(self, value.Str('x'), val)
 
     val = mem.GetValue('undef', scope_e.Dynamic)
-    test_lib.AssertAsdlEqual(self, value.Undef(), val)
+    test_lib.AssertAsdlEqual(self, value.Undef, val)
 
   def testExportThenAssign(self):
     """Regression Test"""

--- a/core/test_lib.py
+++ b/core/test_lib.py
@@ -125,7 +125,7 @@ def MakeArena(source_name):
 
 def InitLineLexer(s, arena):
   line_lexer = lexer.LineLexer(arena)
-  src = source.Interactive()
+  src = source.Interactive
   line_lexer.Reset(SourceLine(1, s, src), 0)
   return line_lexer
 

--- a/cpp/frontend_flag_spec.cc
+++ b/cpp/frontend_flag_spec.cc
@@ -51,7 +51,7 @@ void _CreateDefaults(DefaultPair_c* in,
     case flag_type_e::Str: {
       const char* s = pair->val.s;
       if (s == nullptr) {
-        val = Alloc<value::Undef>();
+        val = value::Undef;
       } else {
         val = Alloc<value::Str>(StrFromC(s));
       }

--- a/frontend/args.py
+++ b/frontend/args.py
@@ -134,7 +134,7 @@ if mylib.PYTHON:
     # type: (Any) -> value_t
 
     if py_val is None:
-      val = value.Undef()  # type: value_t
+      val = value.Undef  # type: value_t
     elif isinstance(py_val, bool):
       val = value.Bool(py_val)
     elif isinstance(py_val, int):

--- a/frontend/flag_spec.py
+++ b/frontend/flag_spec.py
@@ -160,7 +160,7 @@ def _Default(arg_type, arg_default=None):
   elif arg_type == args.Float:
     default = value.Float(-1.0)  # ditto
   elif arg_type == args.String:
-    default = value.Undef()  # e.g. read -d '' is NOT the default
+    default = value.Undef  # e.g. read -d '' is NOT the default
   elif isinstance(arg_type, list):
     default = value.Str('')  # This isn't valid
   else:
@@ -263,7 +263,7 @@ class _FlagSpec(object):
     assert len(char) == 1  # 'r' for -r +r
     self.plus_flags.append(char)
 
-    self.defaults[char] = value.Undef()
+    self.defaults[char] = value.Undef
     # '+' or '-'.  TODO: Should we make it a bool?
     self.fields[char] = flag_type_e.Str
 

--- a/frontend/syntax.asdl
+++ b/frontend/syntax.asdl
@@ -150,9 +150,6 @@ module syntax
      Token left, List[expr] positional, List[NamedArg] named, Token right
   )
 
-  # TODO: every word_part has Token left, Token right, and remove int* spids
-  # these are used in the main program for alias expansion
-
   AssocPair = (CompoundWord key, CompoundWord value)
 
   word_part = 
@@ -266,8 +263,9 @@ module syntax
 
   # Each if arm starts with either an "if" or "elif" keyword
   # In YSH, the then keyword is not used (replaced by braces {})
-  IfArm = (Token keyword, condition cond, Token? then_kw, List[command] action,
-  	   List[int] spids)
+  IfArm = (
+      Token keyword, condition cond, Token? then_kw, List[command] action,
+      List[int] spids)
 
   for_iter =
     Args                      # for x; do echo $x; done # implicit "$@"
@@ -280,11 +278,6 @@ module syntax
       Token left, Token? doc_token, List[command] children,
       List[Redir] redirects, Token right
   )
-
-  # TODO: every command needs Token left
-  # also add Token right_lok (a lok is a token used for the pretty printer ONLY)
-  # then Case, ForEach, and ShFunction also have Token in_lok, esac_lok, etc.
-  # REMOVE int* spids
 
   # Retain references to lines
   BlockArg = (BraceGroup brace_group, List[SourceLine] lines)
@@ -337,9 +330,8 @@ module syntax
     # Some nodes optimize it out as List[command], but we use CommandList for
     # 1. the top level
     # 2. ls ; ls & ls  (same line)
-    # 3. CommandSub # single child that's a CommandList
-    # 4. Subshell # single child that's a CommandList
-    # Similar to DoGroup, except that has do and done spids.
+    # 3. CommandSub  # single child that's a CommandList
+    # 4. Subshell  # single child that's a CommandList
   | CommandList(List[command] children)
 
     # Oil stuff

--- a/oil_lang/NINJA_subgraph.py
+++ b/oil_lang/NINJA_subgraph.py
@@ -30,6 +30,7 @@ def NinjaGraph(ru):
   ru.cc_library(
       '//oil_lang/grammar',
       srcs = ['_gen/oil_lang/grammar_tables.cc'],
+      deps = ['//cpp/pgen2'],
       generated_headers = [
         '_gen/oil_lang/grammar_nt.h',
       ])

--- a/oil_lang/expr_eval.py
+++ b/oil_lang/expr_eval.py
@@ -111,7 +111,7 @@ def _PyObjToValue(val):
   # type: (Any) -> value_t
 
   if val is None:
-    return value.Undef()
+    return value.Undef
 
   elif isinstance(val, bool):
     return value.Bool(val)
@@ -667,7 +667,7 @@ class OilEvaluator(object):
       return value.Float(float(c))
 
     if id_ == Id.Expr_Null:
-      return value.Undef()
+      return value.Undef
     if id_ == Id.Expr_True:
       return value.Bool(True)
     if id_ == Id.Expr_False:

--- a/oil_lang/expr_to_ast.py
+++ b/oil_lang/expr_to_ast.py
@@ -181,7 +181,7 @@ class Transformer(object):
       if p_node.NumChildren() >= 3:
         value = self.Expr(p_node.GetChild(2))
       else:
-        value = expr.Implicit()
+        value = expr.Implicit
 
     if id_ == Id.Op_LBracket:  # {[x+y]: 'val'}
       key = self.Expr(p_node.GetChild(1))
@@ -311,7 +311,7 @@ class Transformer(object):
 
     if id_ == Id.Expr_Func:
       # STUB.  This should really be a Func, not Lambda.
-      return expr.Lambda([], expr.Implicit())
+      return expr.Lambda([], expr.Implicit)
 
     raise NotImplementedError(Id_str(id_))
 
@@ -913,7 +913,7 @@ class Transformer(object):
 
     n = pnode.NumChildren()
     if n == 1:  # proc f { 
-      sig = proc_sig.Open()  # type: proc_sig_t
+      sig = proc_sig.Open  # type: proc_sig_t
     elif n == 3:  # proc f () {
       sig = proc_sig.Closed.CreateNull(alloc_lists=True)  # no params
     elif n == 4:  # proc f [foo, bar='z', @args] {

--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -423,7 +423,7 @@ class CommandEvaluator(object):
 
           try:
             if t == '-':
-              result.arg = redirect_arg.CloseFd()
+              result.arg = redirect_arg.CloseFd
             elif t[-1] == '-':
               target_fd = int(t[:-1])
               result.arg = redirect_arg.MoveFd(target_fd)
@@ -1341,7 +1341,7 @@ class CommandEvaluator(object):
           e_die("Function %s was already defined (redefine_proc)" % node.name,
                 node.name_tok)
         self.procs[node.name] = Proc(
-            node.name, node.name_tok, proc_sig.Open(), node.body, [], True)
+            node.name, node.name_tok, proc_sig.Open, node.body, [], True)
 
         status = 0
 

--- a/osh/cmd_parse.py
+++ b/osh/cmd_parse.py
@@ -221,7 +221,7 @@ def _MakeAssignPair(parse_ctx, preparsed, arena):
   # TODO: Should we also create a rhs_expr.ArrayLiteral here?
   n = len(w.parts)
   if part_offset == n:
-    rhs = rhs_word.Empty()  # type: rhs_word_t
+    rhs = rhs_word.Empty  # type: rhs_word_t
   else:
     # tmp2 is for intersection of C++/MyPy type systems
     tmp2 = CompoundWord(w.parts[part_offset:])
@@ -250,7 +250,7 @@ def _AppendMoreEnv(preparsed_list, more_env):
     var_name = lexer.TokenSliceRight(left_token, -1)
     n = len(w.parts)
     if part_offset == n:
-      val = rhs_word.Empty()  # type: rhs_word_t
+      val = rhs_word.Empty  # type: rhs_word_t
     else:
       val = CompoundWord(w.parts[part_offset:])
 
@@ -1242,11 +1242,11 @@ class CommandParser(object):
           p_die('Expected at most 2 loop variables', for_kw)
 
     elif self.c_id == Id.KW_Do:
-      node.iterable = for_iter.Args()  # implicitly loop over "$@"
+      node.iterable = for_iter.Args  # implicitly loop over "$@"
       # do not advance
 
     elif self.c_id == Id.Op_Semi:  # for x; do
-      node.iterable = for_iter.Args()  # implicitly loop over "$@"
+      node.iterable = for_iter.Args  # implicitly loop over "$@"
       self._Next()
 
     else:  # for foo BAD
@@ -2306,9 +2306,9 @@ class CommandParser(object):
     """
     self._Peek()
     if self.c_id == Id.Op_Newline:
-      return parse_result.EmptyLine()
+      return parse_result.EmptyLine
     if self.c_id == Id.Eof_Real:
-      return parse_result.Eof()
+      return parse_result.Eof
 
     node = self._ParseCommandLine()
     return parse_result.Node(node)

--- a/osh/sh_expr_eval.py
+++ b/osh/sh_expr_eval.py
@@ -129,7 +129,7 @@ def OldValue(lval, mem, exec_opts):
       s = word_eval.GetArrayItem(array_val.strs, lval.index)
 
       if s is None:
-        val = value.Str('')  # NOTE: Other logic is value.Undef()?  0?
+        val = value.Str('')  # NOTE: Other logic is value.Undef?  0?
       else:
         assert isinstance(s, str), s
         val = value.Str(s)
@@ -651,7 +651,7 @@ class ArithEvaluator(object):
                     ui.ValType(left))
 
           if s is None:
-            val = value.Undef()
+            val = value.Undef
           else:
             val = value.Str(s)
 

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -96,7 +96,7 @@ def DecayArray(val):
     raise AssertionError(val.tag())
 
   if s is None:
-    return value.Undef()
+    return value.Undef
   else:
     return value.Str(s)
 
@@ -734,7 +734,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
     UP_val = val
     with tagswitch(val) as case:
       if case(value_e.Undef):
-        return value.Undef()  # ${!undef} is just weird bash behavior
+        return value.Undef  # ${!undef} is just weird bash behavior
 
       elif case(value_e.Str):
         val = cast(value.Str, UP_val)
@@ -1003,7 +1003,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
         s = GetArrayItem(array_val.strs, index)
 
         if s is None:
-          val = value.Undef()
+          val = value.Undef
         else:
           val = value.Str(s)
 
@@ -1014,7 +1014,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
         s = assoc_val.d.get(key)
 
         if s is None:
-          val = value.Undef()
+          val = value.Undef
         else:
           val = value.Str(s)
 
@@ -1974,7 +1974,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
             append = False
 
           if part_offset == len(w.parts):
-            rhs = rhs_word.Empty()  # type: rhs_word_t
+            rhs = rhs_word.Empty  # type: rhs_word_t
           else:
             # tmp is for intersection of C++/MyPy type systems
             tmp = CompoundWord(w.parts[part_offset:])

--- a/osh/word_parse.py
+++ b/osh/word_parse.py
@@ -192,7 +192,7 @@ class WordParser(WordEmitter):
     # return a Compound with no parts, which is explicitly checked with a
     # custom error message.
     if len(w.parts) == 0 and arg_lex_mode == lex_mode_e.VSub_ArgDQ:
-      return rhs_word.Empty()
+      return rhs_word.Empty
 
     return w
 
@@ -282,7 +282,7 @@ class WordParser(WordEmitter):
 
     if self.token_type == Id.Right_DollarBrace:
       # e.g. ${v/a} is the same as ${v/a/}  -- empty replacement string
-      return suffix_op.PatSub(pat, rhs_word.Empty(), replace_mode, slash_tok)
+      return suffix_op.PatSub(pat, rhs_word.Empty, replace_mode, slash_tok)
 
     if self.token_type == Id.Lit_Slash:
       replace = self._ReadVarOpArg(lex_mode_e.VSub_ArgUnquoted)  # do not stop at /

--- a/tea/tea_main.py
+++ b/tea/tea_main.py
@@ -53,7 +53,7 @@ def Main(arg_r):
   errfmt = ui.ErrorFormatter(arena)
 
   if arg.c is not None:
-    arena.PushSource(source.CFlag())
+    arena.PushSource(source.CFlag)
     line_reader = reader.StringLineReader(arg.c, arena)  # type: reader._Reader
   else:
     script_name = arg_r.Peek()


### PR DESCRIPTION
Instead, use the same ReadAll() function that 'read' does, and use yajl.loads().  (Our future custom JSON parser will have this interface too.)

We no longer get a crash in

    nohup bin/osh -c 'echo hi'

- Add a test/nohup.sh test harness, and run it in CI.
- core/ui.py: Add fallback to current location.  So we have a location for 'bad file descriptor' under nohup.