### PR TITLE
[osh refactor] Replace spids with explicit token fields

### DIFF
--- a/frontend/syntax.asdl
+++ b/frontend/syntax.asdl
@@ -298,12 +298,12 @@ module syntax
   | ExpandedAlias(command child, List[Redir] redirects, List[EnvPair] more_env)
   | Sentence(command child, Token terminator)
     # Note: Only represents "bare assignment"
-  | ShAssignment(List[AssignPair] pairs, List[Redir] redirects)
+  | ShAssignment(Token var, List[AssignPair] pairs, List[Redir] redirects)
   | ControlFlow(Token keyword, word? arg_word)
     # Note: There are spids for every pipeline operator, parallel to
     # stderr_indices
-  | Pipeline(List[command] children, bool negated, List[int] stderr_indices)
-  | AndOr(List[id] ops, List[command] children)
+  | Pipeline(Token pipline_op, List[command] children, bool negated, List[int] stderr_indices)
+  | AndOr(Token op, List[id] ops, List[Token] op_toks, List[command] children)
     # Part of for, while, until (but not if, case, ShFunction).  No redirects.
   | DoGroup(Token left, List[command] children, Token right)
     # A brace group is a compound command, with redirects.
@@ -323,7 +323,8 @@ module syntax
   | WhileUntil(Token keyword, condition cond, command body, List[Redir] redirects)
   | If(Token if_kw, List[IfArm] arms, Token? else_kw, List[command] else_action,
        Token? fi_kw, List[Redir] redirects)
-  | Case(word to_match, List[CaseArm] arms, List[Redir] redirects)
+  | Case(Token case_kw, word to_match, Token? in_kw, List[CaseArm] arms,
+         Token? esac_kw, List[Redir] redirects)
     # The keyword is optional in the case of bash-style functions
     # (ie. "foo() { ... }") which do not have one.
   | ShFunction(Token? keyword, loc name_loc, str name, command body)

--- a/frontend/syntax.asdl
+++ b/frontend/syntax.asdl
@@ -302,7 +302,7 @@ module syntax
   | ControlFlow(Token keyword, word? arg_word)
     # Note: There are spids for every pipeline operator, parallel to
     # stderr_indices
-  | Pipeline(Token pipline_op, List[command] children, bool negated, List[int] stderr_indices)
+  | Pipeline(Token pipeline_op, List[command] children, bool negated, List[int] stderr_indices)
   | AndOr(Token op, List[id] ops, List[Token] op_toks, List[command] children)
     # Part of for, while, until (but not if, case, ShFunction).  No redirects.
   | DoGroup(Token left, List[command] children, Token right)

--- a/frontend/syntax.asdl
+++ b/frontend/syntax.asdl
@@ -302,8 +302,8 @@ module syntax
   | ControlFlow(Token keyword, word? arg_word)
     # Note: There are spids for every pipeline operator, parallel to
     # stderr_indices
-  | Pipeline(Token pipeline_op, List[command] children, bool negated, List[int] stderr_indices)
-  | AndOr(Token op, List[id] ops, List[Token] op_toks, List[command] children)
+  | Pipeline(List[command] children, bool negated, List[int] stderr_indices)
+  | AndOr(List[Token] ops, List[command] children)
     # Part of for, while, until (but not if, case, ShFunction).  No redirects.
   | DoGroup(Token left, List[command] children, Token right)
     # A brace group is a compound command, with redirects.

--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -1128,7 +1128,7 @@ class CommandEvaluator(object):
         while i < n:
           #log('i %d status %d', i, status)
           child = node.children[i]
-          op_id = node.ops[i-1]
+          op_id = node.ops[i-1].id
 
           #log('child %s op_id %s', child, op_id)
 

--- a/osh/cmd_parse.py
+++ b/osh/cmd_parse.py
@@ -1458,7 +1458,7 @@ class CommandParser(object):
 
     case_node.spids.append(case_kw.span_id)
     case_node.spids.append(in_kw.span_id if in_kw else runtime.NO_SPID)
-    case_node.spids.append(esac_kw.span_id if in_kw else runtime.NO_SPID)
+    case_node.spids.append(esac_kw.span_id if esac_kw else runtime.NO_SPID)
     return case_node
 
   def _ParseOilElifElse(self, if_node):

--- a/osh/cmd_parse.py
+++ b/osh/cmd_parse.py
@@ -1443,7 +1443,7 @@ class CommandParser(object):
       # TODO: should it return a list of nodes, and extend?
       self._Peek()
     else:
-        esac_kw = word_.AsKeywordToken(self.cur_word)
+      esac_kw = word_.AsKeywordToken(self.cur_word)
 
     self._Peek()
     if self.parse_opts.parse_brace() and self.c_id == Id.Lit_RBrace:


### PR DESCRIPTION
Nodes changed:
 - `command.AndOr`
 - `command.ShAssignment`
 - `command.Pipeline`
 - `command.Case`