### PR TITLE
[oil_lang] statically type some more expression evaluators

### DIFF
--- a/core/runtime.asdl
+++ b/core/runtime.asdl
@@ -4,8 +4,10 @@ module runtime
 {
   # import these types from syntax.asdl
   use frontend syntax {
-    word CompoundWord ArgList command re redir_loc Token proc_sig loc IntParamBox
+    word CompoundWord ArgList command re redir_loc Token proc_sig loc
   }
+
+  IntBox = (int i)
 
   # Evaluating SimpleCommand results in either an argv array or an assignment.
   # in 'local foo', rval is None.
@@ -72,8 +74,8 @@ module runtime
 
     # TODO: we might be able to combine these types when the refactor is done
     # and we don't need to be able to recover their pyobj representations. 
-  | Slice(IntParamBox? lower, IntParamBox? upper, IntParamBox? step)
-  | Range(IntParamBox? lower, IntParamBox? upper, IntParamBox? step)
+  | Slice(IntBox? lower, IntBox? upper, IntBox? step)
+  | Range(IntBox? lower, IntBox? upper, IntBox? step)
 
     # Hack for a PyObject.  # TODO: Remove
   | Obj(any obj)

--- a/core/runtime.asdl
+++ b/core/runtime.asdl
@@ -4,7 +4,7 @@ module runtime
 {
   # import these types from syntax.asdl
   use frontend syntax {
-    word CompoundWord ArgList command re redir_loc Token proc_sig loc
+    word CompoundWord ArgList command re redir_loc Token proc_sig loc IntParamBox
   }
 
   # Evaluating SimpleCommand results in either an argv array or an assignment.
@@ -54,6 +54,8 @@ module runtime
 
     -- TODO: remove MaybeStrArray in favor of this
   | List(List[value] items)
+    # Tuples are like lists, but immutable.
+  | Tuple(List[value] items)
 
     -- TODO: remove AssocArray in favor of this
   | Dict(Dict[str, value] d)
@@ -67,6 +69,11 @@ module runtime
     # - Expr for ^[1 + 2] 
     # - Template for ^"$1 and $2"
     # - Proc, Func
+
+    # TODO: we might be able to combine these types when the refactor is done
+    # and we don't need to be able to recover their pyobj representations. 
+  | Slice(IntParamBox? lower, IntParamBox? upper, IntParamBox? step)
+  | Range(IntParamBox? lower, IntParamBox? upper, IntParamBox? step)
 
     # Hack for a PyObject.  # TODO: Remove
   | Obj(any obj)

--- a/frontend/syntax.asdl
+++ b/frontend/syntax.asdl
@@ -454,7 +454,7 @@ module syntax
 
   # Subscripts are lists of expressions
   #   a[:i, n]      (we don't have matrices, but we have data frames)
-  Subscript = (expr obj, List[expr] indices)
+  Subscript = (expr obj, expr index)
 
   # Attributes are obj.attr, d->key, name::scope,
   Attribute = (expr obj, Token op, Token attr, expr_context ctx)

--- a/mycpp/cppgen_pass.py
+++ b/mycpp/cppgen_pass.py
@@ -1149,10 +1149,15 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
         if o.end_index:
             self.write(', ')
             self.accept(o.end_index)
-        self.write(')')
 
         if o.stride:
-            raise AssertionError('Stride not supported')
+            if not o.begin_index or not o.end_index:
+                raise AssertionError('Stride only supported with beginning and ending index')
+
+            self.write(', ')
+            self.accept(o.stride)
+
+        self.write(')')
 
     def visit_conditional_expr(self, o: 'mypy.nodes.ConditionalExpr') -> T:
         if not _CheckCondition(o.cond, self.types):

--- a/mycpp/examples/containers.py
+++ b/mycpp/examples/containers.py
@@ -37,6 +37,9 @@ def ListDemo():
   for i in intlist:
     log("i = %d", i)
 
+  for i in intlist[0:len(intlist):2]:
+    log("stride i = %d", i)
+
   log('1? %d', 1 in intlist)
   log('42? %d', 42 in intlist)
 

--- a/mycpp/examples/strings.py
+++ b/mycpp/examples/strings.py
@@ -75,6 +75,10 @@ def run_tests():
 
   print("%r" % "tab\tline\nline\r\n")
 
+  s = 'a1b2c3d4e5'
+  print(s[0:10:2])
+  print(s[1:10:2])
+
 
 def run_benchmarks():
   # type: () -> None

--- a/mycpp/gc_list.h
+++ b/mycpp/gc_list.h
@@ -56,6 +56,9 @@ class List {
   // L[begin:end]
   List* slice(int begin, int end);
 
+  // L[begin:end:step]
+  List* slice(int begin, int end, int step);
+
   // Should we have a separate API that doesn't return it?
   // https://stackoverflow.com/questions/12600330/pop-back-return-value
   T pop();
@@ -201,6 +204,12 @@ List<T>* List<T>::slice(int begin) {
 // L[begin:end]
 template <typename T>
 List<T>* List<T>::slice(int begin, int end) {
+  return slice(begin, end, 1);
+}
+
+// L[begin:end:step]
+template <typename T>
+List<T>* List<T>::slice(int begin, int end, int step) {
   if (begin < 0) {
     begin = len_ + begin;
   }
@@ -213,7 +222,8 @@ List<T>* List<T>::slice(int begin, int end) {
   DCHECK(end >= 0);
 
   List<T>* result = NewList<T>();
-  for (int i = begin; i < end; i++) {
+  // step might be negative
+  for (int i = begin; i >= begin && i < end; i += step) {
     result->append(slab_->items_[i]);
   }
 

--- a/mycpp/gc_list.h
+++ b/mycpp/gc_list.h
@@ -223,7 +223,7 @@ List<T>* List<T>::slice(int begin, int end, int step) {
 
   List<T>* result = NewList<T>();
   // step might be negative
-  for (int i = begin; i >= begin && i < end; i += step) {
+  for (int i = begin; begin <= i && i < end; i += step) {
     result->append(slab_->items_[i]);
   }
 

--- a/mycpp/gc_list_test.cc
+++ b/mycpp/gc_list_test.cc
@@ -297,6 +297,11 @@ TEST list_methods_test() {
   ASSERT_EQ(2, len(slice2));
   ASSERT_EQ(5, slice2->index_(0));
 
+  List<int>* slice3 = ints->slice(1, 4, 2);
+  ASSERT_EQ(2, len(slice2));
+  ASSERT_EQ(6, slice3->index_(0));
+  ASSERT_EQ(8, slice3->index_(1));
+
   log("-- before pop(0)");
   for (int i = 0; i < len(ints); ++i) {
     log("ints[%d] = %d", i, ints->index_(i));

--- a/mycpp/gc_str.cc
+++ b/mycpp/gc_str.cc
@@ -156,7 +156,7 @@ Str* Str::slice(int begin, int end, int step) {
   Str* result = NewStr(new_len + 1);
   // step might be negative
   int j = 0;
-  for (int i = begin; i >= begin && i < end; i += step, j++) {
+  for (int i = begin; begin <= i && i < end; i += step, j++) {
     result->data_[j] = data_[i];
   }
   result->data_[new_len] = '\0';

--- a/mycpp/gc_str.cc
+++ b/mycpp/gc_str.cc
@@ -111,6 +111,59 @@ Str* Str::index_(int i) {
   return result;
 }
 
+// s[begin:end:step]
+Str* Str::slice(int begin, int end, int step) {
+  int len_ = len(this);
+  begin = std::min(begin, len_);
+  end = std::min(end, len_);
+
+  assert(begin <= len_);
+  assert(end <= len_);
+
+  if (begin < 0) {
+    begin = len_ + begin;
+  }
+
+  if (end < 0) {
+    end = len_ + end;
+  }
+
+  begin = std::min(begin, len_);
+  end = std::min(end, len_);
+
+  begin = std::max(begin, 0);
+  end = std::max(end, 0);
+
+  assert(begin >= 0);
+  assert(begin <= len_);
+
+  assert(end >= 0);
+  assert(end <= len_);
+
+  int astep = std::abs(step);
+  int new_len = (end - begin);
+  new_len = new_len / astep + (new_len % astep);
+
+  // Tried to use std::clamp() here but we're not compiling against cxx-17
+  new_len = std::max(new_len, 0);
+  new_len = std::min(new_len, len_);
+
+  // printf("len(%d) [%d, %d] newlen(%d)\n",  len_, begin, end, new_len);
+
+  assert(new_len >= 0);
+  assert(new_len <= len_);
+
+  Str* result = NewStr(new_len + 1);
+  // step might be negative
+  int j = 0;
+  for (int i = begin; i >= begin && i < end; i += step, j++) {
+    result->data_[j] = data_[i];
+  }
+  result->data_[new_len] = '\0';
+
+  return result;
+}
+
 // s[begin:end]
 Str* Str::slice(int begin, int end) {
   int len_ = len(this);

--- a/mycpp/gc_str.h
+++ b/mycpp/gc_str.h
@@ -27,6 +27,7 @@ class Str {
 
   Str* slice(int begin);
   Str* slice(int begin, int end);
+  Str* slice(int begin, int end, int step);
 
   Str* strip();
   // Used for CommandSub in osh/cmd_exec.py

--- a/oil_lang/expr_eval.py
+++ b/oil_lang/expr_eval.py
@@ -8,7 +8,7 @@ from _devbuild.gen.id_kind_asdl import Id, Id_t, Kind
 from _devbuild.gen.syntax_asdl import (
     loc, loc_t, re, re_t, Token, word_part, word_part_t,
     SingleQuoted, DoubleQuoted, BracedVarSub, SimpleVarSub, ShArrayLiteral,
-    CommandSub, IntParamBox,
+    CommandSub,
 
     expr, expr_e, expr_t, place_expr, place_expr_e, place_expr_t,
     Attribute, Subscript,
@@ -22,6 +22,7 @@ from _devbuild.gen.runtime_asdl import (
     part_value, part_value_t,
     lvalue,
     value, value_e, value_t,
+    IntBox,
 )
 from core import error
 from core.error import e_die, e_die_status
@@ -148,13 +149,13 @@ def _PyObjToValue(val):
   elif isinstance(val, slice):
       s = value.Slice(None, None, None)
       if val.start:
-        s.lower = IntParamBox(val.start)
+        s.lower = IntBox(val.start)
 
       if val.stop:
-        s.upper = IntParamBox(val.stop)
+        s.upper = IntBox(val.stop)
 
       if val.step:
-        s.step = IntParamBox(val.step)
+        s.step = IntBox(val.step)
 
       return s
 
@@ -163,11 +164,11 @@ def _PyObjToValue(val):
       # awkward, but should go away once everything is typed...
       l = list(val)
       if len(l) > 1:
-        r.lower = IntParamBox(l[0])
-        r.upper = IntParamBox(l[-1])
-        r.step = IntParamBox(l[1] - l[0])
+        r.lower = IntBox(l[0])
+        r.upper = IntBox(l[-1])
+        r.step = IntBox(l[1] - l[0])
       elif len(l) == 1:
-        r.lower = IntParamBox(l[0])
+        r.lower = IntBox(l[0])
 
       return r
 
@@ -1098,28 +1099,28 @@ class OilEvaluator(object):
 
     upper = cast(value.Int, UP_upper)
 
-    return value.Range(IntParamBox(lower.i), IntParamBox(upper.i), IntParamBox(1))
+    return value.Range(IntBox(lower.i), IntBox(upper.i), IntBox(1))
 
   def _EvalSlice(self, node):
     # type: (expr.Slice) -> value_t
 
-    lower = None # type: Optional[IntParamBox]
-    upper = None # type: Optional[IntParamBox]
+    lower = None # type: Optional[IntBox]
+    upper = None # type: Optional[IntBox]
     if node.lower:
       UP_lower = _PyObjToValue(self._EvalExpr(node.lower))
       if UP_lower.tag() != value_e.Int:
         raise error.InvalidType('Slice indices must be Ints', loc.Missing)
 
-      lower = IntParamBox(cast(value.Int, UP_lower).i)
+      lower = IntBox(cast(value.Int, UP_lower).i)
 
     if node.upper:
       UP_upper = _PyObjToValue(self._EvalExpr(node.upper))
       if UP_upper.tag() != value_e.Int:
         raise error.InvalidType('Slice indices must be Ints', loc.Missing)
 
-      upper = IntParamBox(cast(value.Int, UP_upper).i)
+      upper = IntBox(cast(value.Int, UP_upper).i)
 
-    return value.Slice(lower, upper, IntParamBox(1))
+    return value.Slice(lower, upper, IntBox(1))
 
   def _CompareNumeric(self, left, right, op):
     # type: (value_t, value_t, Id_t) -> bool

--- a/oil_lang/expr_eval.py
+++ b/oil_lang/expr_eval.py
@@ -1108,14 +1108,14 @@ class OilEvaluator(object):
     if node.lower:
       UP_lower = _PyObjToValue(self._EvalExpr(node.lower))
       if UP_lower.tag() != value_e.Int:
-        raise error.InvalidType('Expected Int', loc.Missing)
+        raise error.InvalidType('Slice indices must be Ints', loc.Missing)
 
       lower = IntParamBox(cast(value.Int, UP_lower).i)
 
     if node.upper:
       UP_upper = _PyObjToValue(self._EvalExpr(node.upper))
       if UP_upper.tag() != value_e.Int:
-        raise error.InvalidType('Expected Int', loc.Missing)
+        raise error.InvalidType('Slice indices must be Ints', loc.Missing)
 
       upper = IntParamBox(cast(value.Int, UP_upper).i)
 
@@ -1464,7 +1464,7 @@ class OilEvaluator(object):
       elif case(value_e.Dict):
         obj = cast(value.Dict, UP_obj)
         if index.tag() != value_e.Str:
-            raise error.InvalidType('expected String', loc.Missing)
+            raise error.InvalidType('expected String index for Dict', loc.Missing)
 
         index = cast(value.Str, UP_index)
         try:

--- a/oil_lang/expr_to_ast.py
+++ b/oil_lang/expr_to_ast.py
@@ -140,6 +140,9 @@ class Transformer(object):
       assert p_args.typ == grammar_nt.subscriptlist
       indices = []  # type: List[expr_t]
       n = p_args.NumChildren()
+      if n > 1:
+        p_die("Only 1 subscript is accepted", p_args.GetChild(1).tok)
+
       a = p_args.GetChild(0)
       return Subscript(base, self._Subscript(a))
 

--- a/oil_lang/expr_to_ast.py
+++ b/oil_lang/expr_to_ast.py
@@ -140,10 +140,8 @@ class Transformer(object):
       assert p_args.typ == grammar_nt.subscriptlist
       indices = []  # type: List[expr_t]
       n = p_args.NumChildren()
-      for i in xrange(0, n, 2):  # was children[::2]
-        a = p_args.GetChild(i)
-        indices.append(self._Subscript(a))
-      return Subscript(base, indices)
+      a = p_args.GetChild(0)
+      return Subscript(base, self._Subscript(a))
 
     if op_tok.id in (Id.Expr_Dot, Id.Expr_RArrow, Id.Expr_DColon):
       attr = p_trailer.GetChild(1).tok  # will be Id.Expr_Name

--- a/spec/oil-slice-range.test.sh
+++ b/spec/oil-slice-range.test.sh
@@ -89,21 +89,9 @@ write @x
 5
 ## END
 
-#### Index with a Tuple
-var mydict = {[2,3]: 'foo'}
-var val = mydict[(2, 3)]
-echo $val
-# TODO: This should work!
-setvar val = mydict[2, 3]
-echo $val
-## STDOUT:
-foo
-foo
-## END
-
 #### Index with expression
-var mydict = {[5]: 3}
-var val = mydict[2+3]
+var mydict = {['5']: 3}
+var val = mydict["$[2+3]"]
 echo $val
 ## STDOUT:
 3

--- a/test/oil-runtime-errors.sh
+++ b/test/oil-runtime-errors.sh
@@ -198,11 +198,6 @@ test-EvalExpr-calls() {
 
   _expr-error-case '
     var d = {}
-    = d[len("foo"), len(42)]
-  '
-
-  _expr-error-case '
-    var d = {}
     setvar d[len(42)] = "foo"
   '
 

--- a/test/parse-errors.sh
+++ b/test/parse-errors.sh
@@ -732,6 +732,10 @@ ysh_expr() {
   # Disallowed unconditionally
   _ysh-parse-error '=a'
 
+  _ysh-parse-error '
+    var d = {}
+    = d["foo", "bar"]
+  '
 }
 
 ysh_expr_more() {


### PR DESCRIPTION
This patch adds ranges, slices, and tuples to the runtime and 
statically types the expression evaluators for slices, ranges, tuples,
lists, dictionaries, and if-statements. 

It also adds limited stride support to slices and updates a few spec
tests to reflect the latest dictionary semantics, namely: only strings
can be used as keys now (tuples, ints, etc... have been dropped).