### PR TITLE
[frontend refactor] CompoundWord is a loc_t!

### DIFF
--- a/bin/oils_for_unix.py
+++ b/bin/oils_for_unix.py
@@ -20,7 +20,7 @@ from __future__ import print_function
 import posix_ as posix
 import sys
 
-from _devbuild.gen.syntax_asdl import loc, loc_t
+from _devbuild.gen.syntax_asdl import loc, CompoundWord
 from core import error
 from core import shell
 from core import pyos
@@ -93,8 +93,7 @@ def AppBundleMain(argv):
   b = os_path.basename(argv[0])
   main_name, ext = os_path.splitext(b)
 
-  # TODO: Do we need span IDs here?
-  missing = loc.Missing  # type: loc_t
+  missing = None  # type: CompoundWord
   arg_r = args.Reader(argv, locs=[missing] * len(argv))
 
   login_shell = False

--- a/core/executor.py
+++ b/core/executor.py
@@ -210,7 +210,7 @@ class ShellExecutor(vm._Executor):
     """
     argv = cmd_val.argv
     if len(cmd_val.arg_locs):
-      arg0_loc = cmd_val.arg_locs[0]
+      arg0_loc = cmd_val.arg_locs[0]  # type: loc_t
     else:
       arg0_loc = loc.Missing
 

--- a/core/runtime.asdl
+++ b/core/runtime.asdl
@@ -3,7 +3,9 @@
 module runtime
 {
   # import these types from syntax.asdl
-  use frontend syntax { word ArgList command re redir_loc Token proc_sig loc }
+  use frontend syntax {
+    word CompoundWord ArgList command re redir_loc Token proc_sig loc
+  }
 
   # Evaluating SimpleCommand results in either an argv array or an assignment.
   # in 'local foo', rval is None.
@@ -11,9 +13,9 @@ module runtime
 
   # note: could import 'builtin' from synthetic option_asdl
   cmd_value =
-    Argv(List[str] argv, List[loc] arg_locs, ArgList? typed_args)
+    Argv(List[str] argv, List[CompoundWord] arg_locs, ArgList? typed_args)
   | Assign(int builtin_id,
-           List[str] argv, List[loc] arg_locs,
+           List[str] argv, List[CompoundWord] arg_locs,
            List[AssignArg] pairs)
 
   # A parse-time word_part from syntax.asdl is evaluated to a runtime

--- a/core/shell.py
+++ b/core/shell.py
@@ -9,7 +9,9 @@ import time
 from _devbuild.gen import arg_types
 from _devbuild.gen.option_asdl import option_i, builtin_i
 from _devbuild.gen.runtime_asdl import cmd_value
-from _devbuild.gen.syntax_asdl import loc, loc_t, source, source_t, IntParamBox
+from _devbuild.gen.syntax_asdl import (
+    loc, source, source_t, IntParamBox, CompoundWord
+)
 
 from core import alloc
 from core import comp_ui
@@ -79,8 +81,7 @@ def MakeBuiltinArgv(argv1):
   # type: (List[str]) -> cmd_value.Argv
   argv = ['']  # dummy for argv[0]
   argv.extend(argv1)
-  # no location info
-  missing = loc.Missing  # type: loc_t
+  missing = None  # type: CompoundWord
   return cmd_value.Argv(argv, [missing] * len(argv), None)
 
 

--- a/frontend/args.py
+++ b/frontend/args.py
@@ -53,7 +53,7 @@ However I don't see these used anywhere!  I only see ':' used.
 """
 from __future__ import print_function
 
-from _devbuild.gen.syntax_asdl import loc, loc_t
+from _devbuild.gen.syntax_asdl import loc, loc_t, CompoundWord
 from _devbuild.gen.runtime_asdl import value, value_e, value_t
 
 from asdl import runtime
@@ -158,7 +158,7 @@ class Reader(object):
   done to get args.
   """
   def __init__(self, argv, locs=None):
-    # type: (List[str], Optional[List[loc_t]]) -> None
+    # type: (List[str], Optional[List[CompoundWord]]) -> None
     self.argv = argv
     self.locs = locs
     self.n = len(argv)
@@ -191,8 +191,7 @@ class Reader(object):
     None is your SENTINEL for parsing.
     """
     if self.i >= self.n:
-      no_str = None  # type: str
-      return no_str, loc.Missing
+      return None, loc.Missing
     else:
       return self.argv[self.i], self.locs[self.i]
 
@@ -221,7 +220,7 @@ class Reader(object):
     return self.argv[self.i:]
 
   def Rest2(self):
-    # type: () -> Tuple[List[str], List[loc_t]]
+    # type: () -> Tuple[List[str], List[CompoundWord]]
     """Return the rest of the arguments."""
     return self.argv[self.i:], self.locs[self.i:]
 
@@ -231,10 +230,10 @@ class Reader(object):
 
   def _FirstLocation(self):
     # type: () -> loc_t
-    if self.locs:
+    if self.locs and self.locs[0] is not None:
       return self.locs[0]
     else:
-      return loc.Missing  # TODO: remove this when all have locations
+      return loc.Missing
 
   def Location(self):
     # type: () -> loc_t
@@ -243,9 +242,12 @@ class Reader(object):
         i = self.n - 1  # if the last arg is missing, point at the one before
       else:
         i = self.i
-      return self.locs[i]
+      if self.locs[i] is not None:
+        return self.locs[i]
+      else:
+        return loc.Missing
     else:
-      return loc.Missing  # TODO: remove this when all have locations
+      return loc.Missing
 
 
 class _Action(object):

--- a/frontend/location.py
+++ b/frontend/location.py
@@ -51,6 +51,10 @@ def TokenFor(loc_):
       else:
         return None
 
+    elif case(loc_e.ArgWord):
+      w = cast(CompoundWord, UP_location)
+      return LeftTokenForWord(w)
+
     elif case(loc_e.WordPart):
       loc_ = cast(loc.WordPart, UP_location)
       if loc_.p:

--- a/frontend/syntax.asdl
+++ b/frontend/syntax.asdl
@@ -89,13 +89,19 @@ module syntax
   # - maybe re-compute length on demand too
   Token = (id id, int col, int length, int span_id, SourceLine? line, str tval)
 
+  # Slight ASDL bug: CompoundWord has to be defined before using it as a shared
+  # variant.  The _product_counter algorithm should be moved into a separate
+  # tag-assigning pass, and shared between gen_python.py and gen_cpp.py.
+  CompoundWord = (List[word_part] parts)
+
   # Source location for errors
   # It's possible for word_part and word to have a beginning and end location
   loc = 
     Missing  # equivalent of runtime.NO_SPID
   | Token %Token
+    # Very common case: argv arrays need original location
+  | ArgWord %CompoundWord
   | WordPart(word_part p)
-    # Note: is it possible to only have CompoundWord?
   | Word(word w)
   | Arith(arith_expr a)
     # e.g. for errexit blaming
@@ -183,12 +189,6 @@ module syntax
   | FuncCall(Token name, ArgList args)
     # $[d->key], etc.
   | ExprSub(Token left, expr child, Token right)
-
-  # TODO: I think Token left should be copied into every CompoundWord
-  # either that, or CommandParser needs to reliably have GetToken(word_t)
-  # Invariant: CompoundWord always has at least one part (as opposed to
-  # rhs_word.Empty)
-  CompoundWord = (List[word_part] parts)
 
   # Use cases for Empty: RHS of 'x=', the argument in "${x:-}".
   # The latter is semantically necessary.  (See osh/word_parse.py). 

--- a/osh/builtin_bracket.py
+++ b/osh/builtin_bracket.py
@@ -5,24 +5,22 @@ from __future__ import print_function
 
 from _devbuild.gen.id_kind_asdl import Id
 from _devbuild.gen.runtime_asdl import value
-from _devbuild.gen.syntax_asdl import (
-    loc, loc_e, word, word_e, word_t, CompoundWord, bool_expr,
-)
+from _devbuild.gen.syntax_asdl import loc, word, word_e, word_t, bool_expr
 from _devbuild.gen.types_asdl import lex_mode_e
 
 from core import error
 from core.error import e_usage, p_die
 from core import vm
 from frontend import match
-from mycpp.mylib import log, tagswitch
-from osh import sh_expr_eval
+from mycpp.mylib import log
 from osh import bool_parse
+from osh import sh_expr_eval
 from osh import word_parse
 from osh import word_eval
 
 _ = log
 
-from typing import cast, TYPE_CHECKING, Optional
+from typing import cast, TYPE_CHECKING
 
 if TYPE_CHECKING:
   from _devbuild.gen.runtime_asdl import cmd_value
@@ -61,7 +59,7 @@ class _StringWordEmitter(word_parse.WordEmitter):
 
     #log('ARGV %s i %d', self.argv, self.i)
     s = self.cmd_val.argv[self.i]
-    left_loc = self.cmd_val.arg_locs[self.i]
+    arg_loc = self.cmd_val.arg_locs[self.i]
 
     self.i += 1
 
@@ -74,27 +72,7 @@ class _StringWordEmitter(word_parse.WordEmitter):
     if id_ == Id.Undefined_Tok:
       id_ = Id.Word_Compound
 
-    # TODO: cmd_value.Argv() should store CompoundWord directly, so we don't
-    # have to "unwrap" here
-    blame_word = None  # type: Optional[CompoundWord]
-    UP_left_loc = left_loc
-    with tagswitch(left_loc) as case:
-      if case(loc_e.Missing):
-        pass
-      elif case(loc_e.Word):
-        left_loc = cast(loc.Word, UP_left_loc)
-        left_word = left_loc.w
-        if left_word:
-          assert left_word.tag() == word_e.Compound
-          blame_word = cast(CompoundWord, left_word)
-      else:
-        # EvalWordSequence should have given us loc.Word()
-        raise AssertionError()
-
-    # TODO: use the location from arg_locs once we've replaced spid -> loc_t in
-    #       word.String. Currently, changing word.String blows up the refactor.
-    w = word.String(id_, s, blame_word)
-    return w
+    return word.String(id_, s, arg_loc)
 
   def Read(self):
     # type: () -> word.String

--- a/osh/builtin_misc.py
+++ b/osh/builtin_misc.py
@@ -811,7 +811,6 @@ class Help(vm._Builtin):
     topic, blame_loc = arg_r.Peek2()
     if topic is None:
       topic = 'help'
-      blame_loc = loc.Missing
     else:
       arg_r.Next()
 
@@ -830,8 +829,7 @@ class Help(vm._Builtin):
 
       # 3. This is mostly an interactive command.  Is it obnoxious to
       # quote the line of code?
-      self.errfmt.Print_('no help topics match %r' % topic,
-                         blame_loc=blame_loc)
+      self.errfmt.Print_('no help topics match %r' % topic, blame_loc)
       return 1
 
     print(contents)

--- a/osh/builtin_printf.py
+++ b/osh/builtin_printf.py
@@ -10,7 +10,7 @@ from _devbuild.gen import arg_types
 from _devbuild.gen.id_kind_asdl import Id, Kind, Id_t, Kind_t
 from _devbuild.gen.runtime_asdl import cmd_value, value, value_e
 from _devbuild.gen.syntax_asdl import (
-    loc, loc_e, loc_t, source, Token,
+    loc, loc_e, loc_t, source, Token, CompoundWord,
     printf_part, printf_part_e, printf_part_t,
 )
 from _devbuild.gen.types_asdl import lex_mode_e, lex_mode_t
@@ -160,7 +160,7 @@ class Printf(vm._Builtin):
     self.shell_start_time = time_.time()  # this object initialized in main()
 
   def _Format(self, parts, varargs, locs, out):
-    # type: (List[printf_part_t], List[str], List[loc_t], List[str]) -> int
+    # type: (List[printf_part_t], List[str], List[CompoundWord], List[str]) -> int
     """Hairy printf formatting logic."""
 
     arg_index = 0
@@ -247,7 +247,7 @@ class Printf(vm._Builtin):
 
           if arg_index < num_args:
             s = varargs[arg_index]
-            word_loc = locs[arg_index]
+            word_loc = locs[arg_index]  # type: loc_t
             arg_index += 1
             has_arg = True
           else:
@@ -311,9 +311,12 @@ class Printf(vm._Builtin):
                 d = -1
 
               else:
-                blame_loc = word_loc if has_arg else part.type
+                if has_arg:
+                  blame_loc = word_loc  # type: loc_t
+                else:
+                  blame_loc = part.type  
                 self.errfmt.Print_('printf expected an integer, got %r' % s,
-                                   blame_loc=blame_loc)
+                                   blame_loc)
                 return 1
 
             if part.type.id == Id.Format_Time:

--- a/prebuilt/frontend/args.mycpp.cc
+++ b/prebuilt/frontend/args.mycpp.cc
@@ -1490,6 +1490,7 @@ namespace args {  // define
 
 using syntax_asdl::loc;
 using syntax_asdl::loc_t;
+using syntax_asdl::CompoundWord;
 using runtime_asdl::value;
 using runtime_asdl::value_e;
 using runtime_asdl::value_t;
@@ -1526,7 +1527,7 @@ void _Attributes::Set(Str* name, runtime_asdl::value_t* val) {
   this->attrs->set(name, val);
 }
 
-Reader::Reader(List<Str*>* argv, List<syntax_asdl::loc_t*>* locs) {
+Reader::Reader(List<Str*>* argv, List<syntax_asdl::CompoundWord*>* locs) {
   this->argv = argv;
   this->locs = locs;
   this->n = len(argv);
@@ -1547,12 +1548,8 @@ Str* Reader::Peek() {
 }
 
 Tuple2<Str*, syntax_asdl::loc_t*> Reader::Peek2() {
-  Str* no_str = nullptr;
-  StackRoots _roots({&no_str});
-
   if (this->i >= this->n) {
-    no_str = nullptr;
-    return Tuple2<Str*, syntax_asdl::loc_t*>(no_str, loc::Missing);
+    return Tuple2<Str*, syntax_asdl::loc_t*>(nullptr, loc::Missing);
   }
   else {
     return Tuple2<Str*, syntax_asdl::loc_t*>(this->argv->index_(this->i), this->locs->index_(this->i));
@@ -1573,7 +1570,7 @@ Str* Reader::ReadRequired(Str* error_msg) {
 
 Tuple2<Str*, syntax_asdl::loc_t*> Reader::ReadRequired2(Str* error_msg) {
   Str* arg = nullptr;
-  syntax_asdl::loc_t* location = nullptr;
+  syntax_asdl::CompoundWord* location = nullptr;
   StackRoots _roots({&error_msg, &arg, &location});
 
   arg = this->Peek();
@@ -1589,8 +1586,8 @@ List<Str*>* Reader::Rest() {
   return this->argv->slice(this->i);
 }
 
-Tuple2<List<Str*>*, List<syntax_asdl::loc_t*>*> Reader::Rest2() {
-  return Tuple2<List<Str*>*, List<syntax_asdl::loc_t*>*>(this->argv->slice(this->i), this->locs->slice(this->i));
+Tuple2<List<Str*>*, List<syntax_asdl::CompoundWord*>*> Reader::Rest2() {
+  return Tuple2<List<Str*>*, List<syntax_asdl::CompoundWord*>*>(this->argv->slice(this->i), this->locs->slice(this->i));
 }
 
 bool Reader::AtEnd() {
@@ -1598,7 +1595,7 @@ bool Reader::AtEnd() {
 }
 
 syntax_asdl::loc_t* Reader::_FirstLocation() {
-  if (this->locs) {
+  if ((this->locs and this->locs->index_(0) != nullptr)) {
     return this->locs->index_(0);
   }
   else {
@@ -1615,7 +1612,12 @@ syntax_asdl::loc_t* Reader::Location() {
     else {
       i = this->i;
     }
-    return this->locs->index_(i);
+    if (this->locs->index_(i) != nullptr) {
+      return this->locs->index_(i);
+    }
+    else {
+      return loc::Missing;
+    }
   }
   else {
     return loc::Missing;

--- a/prebuilt/frontend/args.mycpp.h
+++ b/prebuilt/frontend/args.mycpp.h
@@ -194,19 +194,19 @@ class _Attributes {
 
 class Reader {
  public:
-  Reader(List<Str*>* argv, List<syntax_asdl::loc_t*>* locs = nullptr);
+  Reader(List<Str*>* argv, List<syntax_asdl::CompoundWord*>* locs = nullptr);
   void Next();
   Str* Peek();
   Tuple2<Str*, syntax_asdl::loc_t*> Peek2();
   Str* ReadRequired(Str* error_msg);
   Tuple2<Str*, syntax_asdl::loc_t*> ReadRequired2(Str* error_msg);
   List<Str*>* Rest();
-  Tuple2<List<Str*>*, List<syntax_asdl::loc_t*>*> Rest2();
+  Tuple2<List<Str*>*, List<syntax_asdl::CompoundWord*>*> Rest2();
   bool AtEnd();
   syntax_asdl::loc_t* _FirstLocation();
   syntax_asdl::loc_t* Location();
   List<Str*>* argv;
-  List<syntax_asdl::loc_t*>* locs;
+  List<syntax_asdl::CompoundWord*>* locs;
   int n;
   int i;
 


### PR DESCRIPTION
This avoids many loc.Word(w) wrappers, which reduces the number of allocated objects.

cmd_value.{Argv,Assign} can now just point directly to the original CompoundWord instances.

Another win for first-class variants.  This both simplified the code and made it more efficient.

Rebuilt prebuilt/ files.