### PR TITLE
[soil/app-tests] Run the full tests of ble.sh

### DIFF
--- a/test/ble.sh
+++ b/test/ble.sh
@@ -16,6 +16,8 @@ clone() {
   mkdir -p $out
   git clone --recursive --depth=50 --branch=osh \
     https://github.com/akinomyoga/ble.sh $out
+  git clone --depth=50 \
+    https://github.com/akinomyoga/contra.git "$out"/ext/contra.src
 }
 
 # TODO: What version of osh
@@ -28,6 +30,11 @@ build() {
   # make ble.sh
   cd $BASE_DIR
   make
+
+  # make contra for test
+  cd ext/contra.src
+  make
+  cp src/contra ..
 }
 
 # https://superuser.com/questions/380772/removing-ansi-color-codes-from-text-stream
@@ -38,12 +45,11 @@ filter-ansi() {
 run-tests() {
   cd $BASE_DIR
 
-  #wc -l oshrc.test-util
   #wc -l out/ble.osh
-  #wc -l lib/test-util.sh
+  #wc -l lib/test-*.sh
 
   # Force interactive shell on Travis, but remove color.
-  ../../_bin/osh -i --rcfile oshrc.test-util | filter-ansi
+  ../../_bin/osh out/ble.osh --test | filter-ansi
 
   echo DONE
 }


### PR DESCRIPTION
The current version 0.15.0 of osh can parse all the modules used in the full tests of ble.sh (with adjustments in branch `osh` of ble.sh), so we can now run the full tests.