### PR TITLE
[eggex breaking] disallow any kind of $x ${x} "$x ${x}" in eggex

### DIFF
--- a/doc/eggex.md
+++ b/doc/eggex.md
@@ -204,16 +204,21 @@ In contrast, regexes have many confusing syntaxes for negation:
 
     /\w/-i vs /\w/i
 
-### Splice Other Patterns With Uppercase Names
+### Splice Other Patterns `@var_name` or `UpperCaseVarName`
 
-New in Eggex!  You can reuse patterns with `PatternName`.
+This allows you to reuse patterns.  Using uppercase variables:
 
-See the example at the front of this document.
+    var D = / digit{3} /
+
+    var ip_addr = / D '.' D '.' D '.' D /
+
+Using normal variables:
+
+    var part = / digit{3} /
+
+    var ip_addr = / @part '.' @part '.' @part '.' @part /
 
 This is similar to how `lex` and `re2c` work.
-
-If the host language discourages uppercase identifiers, use `@pattern_name`
-instead.
 
 ### Group and Capture With `()` and `<>`
 

--- a/frontend/syntax.asdl
+++ b/frontend/syntax.asdl
@@ -547,10 +547,9 @@ module syntax
   | Range(Token start, Token end)
   | CharLiteral(Token tok)
 
-  | SimpleVarSub %SimpleVarSub
-  | BracedVarSub %BracedVarSub
   | SingleQuoted %SingleQuoted
-  | DoubleQuoted %DoubleQuoted
+    # @chars
+  | Splice(Token name, str var_name)
 
   # Char Sets and Ranges both use Char Codes
   # with u_braced == true : \u{ff}
@@ -591,11 +590,7 @@ module syntax
     # @D
   | Splice(Token name, str var_name)
 
-    # $literal ${literal} 'no-backslashes' "other$foo"
-  | SimpleVarSub %SimpleVarSub
-  | BracedVarSub %BracedVarSub
   | SingleQuoted %SingleQuoted
-  | DoubleQuoted %DoubleQuoted
 
     # Compound:
   | Repeat(re child, re_repeat op)

--- a/spec/ysh-regex.test.sh
+++ b/spec/ysh-regex.test.sh
@@ -291,7 +291,7 @@ if ('123' ~ pat) {
 yes
 ## END
 
-#### Named Capture With ~ Assigns Variable
+#### Operator ~ assigns named variable
 shopt -s oil:all
 var pat = /<d+ : month>/
 echo $pat
@@ -325,13 +325,13 @@ no
 yes
 ## END
 
-#### double quoted, $x, and ${x}
+#### Single quotes and splicing (do what "foo $x ${x}" used to)
 shopt -s oil:all
 var pat = ''
 
 var x = 'x'
 var y = 'y'
-setvar pat = / $x ${x} "abc" "$x${y}"/
+setvar pat = / @x @x 'abc' @x @y /
 echo $pat
 
 if ('xxabcx' ~ pat) { echo yes } else { echo no }
@@ -469,7 +469,7 @@ if ($'\x7e' ~ pat) { echo yes } else { echo no }
 
 #### non-ASCII bytes must be singleton terms, e.g. '\x7f\xff' is disallowed
 var bytes = $'\x7f\xff'
-var pat = / [ $bytes ] /
+var pat = / [ @bytes ] /
 echo $pat
 ## status: 1
 ## stdout-json: ""
@@ -492,9 +492,9 @@ shopt -s oil:all
 var literal = 'f'
 var pat = null
 
-setvar pat = / %start $literal+ %end /
+setvar pat = / %start @literal+ %end /
 echo $pat
-setvar pat = / %start ($literal)+ %end /
+setvar pat = / %start (@literal)+ %end /
 echo $pat
 
 if ('fff' ~ pat) { echo yes }
@@ -513,9 +513,9 @@ shopt -s oil:all
 var literal = 'foo'
 var pat = null
 
-setvar pat = / %start $literal+ %end /
+setvar pat = / %start @literal+ %end /
 echo $pat
-setvar pat = / %start ($literal)+ %end /
+setvar pat = / %start (@literal)+ %end /
 echo $pat
 
 if ('foofoo' ~ pat) { echo yes }
@@ -688,7 +688,7 @@ for line in (lines) {
 
   # = / $line /
 
-  if ("x$line" ~ / dot $line /) {
+if ("x$line" ~ / dot @line /) {
   #if (line ~ / $line /) {
     write "matched $line"
   }
@@ -705,10 +705,6 @@ matched bar
 #### Regex with [ (bug regression)
 shopt --set oil:all
 
-if ('[' ~ / "[" /) {
-  echo 'dq'
-}
-
 if ('[' ~ / '[' /) {
   echo 'sq'
 }
@@ -723,7 +719,6 @@ if ("a" ~ / s* 'imports' s* '=' s* '[' /) {
 }
 
 ## STDOUT:
-dq
 sq
 char class
 ## END
@@ -834,7 +829,7 @@ dq "
 shopt -s oil:all
 
 var literal = '-'
-var pat = / [ 'a' 'b' $literal ] /
+var pat = / [ 'a' 'b' @literal ] /
 write pat=$pat
 write 'c-d' 'ab' 'cd' | grep $pat
 ## STDOUT:

--- a/test/oil-runtime-errors.sh
+++ b/test/oil-runtime-errors.sh
@@ -67,37 +67,6 @@ _should-run() {
   fi
 }
 
-test-regex-literals() {
-  set +o errexit
-
-  _should-run "var sq = / 'foo'+ /"
-
-  _error-case '
-  var dq = / "foo"+ /
-  echo $dq
-  '
-
-  _should-run '
-  var dq = / ("foo")+ /
-  echo $dq
-
-  var dq2 = / <"foo">+ /
-  echo $dq2
-  '
-
-  _error-case '
-  var literal = "foo"
-  var svs = / $literal+ /
-  echo $svs
-  '
-
-  _error-case '
-  var literal = "foo"
-  var bvs = / ${literal}+ /
-  echo $bvs
-  '
-}
-
 test-undefined-vars() {
   set +o errexit
 
@@ -291,7 +260,10 @@ EOF
   _error-case ' = / [ \u{7f}-\u{80} ] /'
 
   # Now test special characters
-  _should-run ' = / [ \\ "^-]" "abc" ] /'
+  _should-run "$(cat <<'EOF'
+= / [ \\ '^-]' 'abc' ] /
+EOF
+)"
 
   # Special chars in ranges are disallowed for simplicity
   _error-case " = / [ a-'^' ] /"
@@ -300,6 +272,28 @@ EOF
 
   # Hm this runs but will cause a syntax error.  Could disallow it.
   # _should-run ' = / ["^"] /'
+}
+
+test-eggex-2() {
+  set +o errexit
+
+  _should-run "var sq = / 'foo'+ /"
+
+  _should-run "$(cat <<'EOF'
+  var sq = / ('foo')+ /
+  echo $sq
+
+  var sq2 = / <'foo'>+ /
+  echo $sq2
+EOF
+)"
+
+
+  _error-case '
+  var literal = "foo"
+  var svs = / @literal+ /
+  echo $svs
+  '
 }
 
 soil-run() {

--- a/ysh/expr_to_ast.py
+++ b/ysh/expr_to_ast.py
@@ -1179,18 +1179,8 @@ class Transformer(object):
         typ = p_node.GetChild(0).typ
         if ISNONTERMINAL(typ):
             p_child = p_node.GetChild(0)
-            if typ == grammar_nt.braced_var_sub:
-                return cast(BracedVarSub, p_child.GetChild(1).tok)
-
-            if typ == grammar_nt.dq_string:
-                return cast(DoubleQuoted, p_child.GetChild(1).tok)
-
             if typ == grammar_nt.sq_string:
                 return cast(SingleQuoted, p_child.GetChild(1).tok)
-
-            if typ == grammar_nt.simple_var_sub:
-                tok = p_node.GetChild(0).tok
-                return SimpleVarSub(tok, lexer.TokenSliceLeft(tok, 1))
 
             if typ == grammar_nt.char_literal:
                 return class_literal_term.CharLiteral(p_node.GetChild(0).tok)
@@ -1207,19 +1197,11 @@ class Transformer(object):
         e.g. 'abc' or "abc$mychars" | dq_string ..."""
         assert p_node.typ == grammar_nt.class_literal_term, p_node
 
-        typ = p_node.GetChild(0).typ
+        first = p_node.GetChild(0)
+        typ = first.typ
 
         if ISNONTERMINAL(typ):
             p_child = p_node.GetChild(0)
-            if typ == grammar_nt.simple_var_sub:
-                tok = p_child.GetChild(0).tok
-                return SimpleVarSub(tok, lexer.TokenSliceLeft(tok, 1))
-
-            if typ == grammar_nt.braced_var_sub:
-                return cast(BracedVarSub, p_child.GetChild(1).tok)
-
-            if typ == grammar_nt.dq_string:
-                return cast(DoubleQuoted, p_child.GetChild(1).tok)
 
             n = p_node.NumChildren()
 
@@ -1233,7 +1215,11 @@ class Transformer(object):
                 return class_literal_term.Range(start, end)
 
         else:
-            if p_node.GetChild(0).tok.id == Id.Expr_Bang:
+            if first.tok.id == Id.Expr_At:
+                tok1 = p_node.GetChild(1).tok
+                return class_literal_term.Splice(tok1, lexer.TokenVal(tok1))
+
+            if first.tok.id == Id.Expr_Bang:
                 return self._NameInClass(
                     p_node.GetChild(0).tok,
                     p_node.GetChild(1).tok)
@@ -1315,18 +1301,8 @@ class Transformer(object):
             if typ == grammar_nt.class_literal:
                 return re.CharClassLiteral(False, self._ClassLiteral(p_child))
 
-            if typ == grammar_nt.braced_var_sub:
-                return cast(BracedVarSub, p_child.GetChild(1).tok)
-
-            if typ == grammar_nt.dq_string:
-                return cast(DoubleQuoted, p_child.GetChild(1).tok)
-
             if typ == grammar_nt.sq_string:
                 return cast(SingleQuoted, p_child.GetChild(1).tok)
-
-            if typ == grammar_nt.simple_var_sub:
-                tok = p_atom.GetChild(0).tok
-                return SimpleVarSub(tok, lexer.TokenSliceLeft(tok, 1))
 
             if typ == grammar_nt.char_literal:
                 return p_atom.GetChild(0).tok

--- a/ysh/grammar.pgen2
+++ b/ysh/grammar.pgen2
@@ -511,13 +511,11 @@ range_char: Expr_Name | Expr_DecInt | sq_string | char_literal
 # digit or a-z
 # We have to do further validation of ranges later.
 class_literal_term: (
-    range_char ['-' range_char ]
-  | '!' Expr_Name
-    # $mychars or ${mymodule.mychars}
-  | simple_var_sub | braced_var_sub
-    # e.g. 'abc' or "abc$mychars" 
     # NOTE: range_char has sq_string
-  | dq_string
+    range_char ['-' range_char ]
+    # splice a literal set of characters
+  | '@' Expr_Name
+  | '!' Expr_Name
     # Reserved for [[.collating sequences.]] (Unicode)
   | '.' Expr_Name
     # Reserved for [[=character equivalents=]] (Unicode)
@@ -558,11 +556,11 @@ re_atom: (
   | '@' Expr_Name
     # any %start %end are preferred
   | '.' | '^' | '$'
-    # literal STRINGS like $foo or ${module.foo}
-  | simple_var_sub | braced_var_sub
     # In a language-independent spec, backslashes are disallowed within 'sq'.
     # Write it with char literals outside strings: 'foo' \\ 'bar' \n
-  | sq_string | dq_string
+    # 
+    # No double-quoted strings because you can write "x = $x" with 'x = ' @x
+  | sq_string
 
     # grouping (non-capturing in Perl; capturing in ERE although < > is preferred)
   | '(' regex ')'


### PR DESCRIPTION
Instead allow splicing strings with @splice

It's meant as a hint that it does ESCAPING rather than raw substitution

BIG SIMPLIFICATION