### PR TITLE
[ysh language] Parse multiple expression case patterns

### DIFF
--- a/frontend/parse_lib.py
+++ b/frontend/parse_lib.py
@@ -384,7 +384,7 @@ class ParseContext(object):
         """
         e_parser = self._YshParser()
         with ctx_PNodeAllocator(e_parser):
-            pnode, last_token = e_parser.Parse(lexer, grammar_nt.case_pat)
+            pnode, last_token = e_parser.Parse(lexer, grammar_nt.ysh_case_pat)
 
             pattern = self.tr.YshCasePattern(pnode)
 

--- a/frontend/parse_lib.py
+++ b/frontend/parse_lib.py
@@ -376,15 +376,19 @@ class ParseContext(object):
         return lvalue, iterable, last_token
 
     def ParseYshCasePattern(self, lexer):
-        # type: (Lexer) -> pat_t
-        """(6) | (7), / dot* '.py' /, (else), etc."""
+        # type: (Lexer) -> Tuple[pat_t, Token]
+        """(6) | (7), / dot* '.py' /, (else), etc.
+
+        Alongside the pattern, this returns the LBrace token at the start of the
+        case arm body.
+        """
         e_parser = self._YshParser()
         with ctx_PNodeAllocator(e_parser):
-            pnode, _last_token = e_parser.Parse(lexer, grammar_nt.case_pat)
+            pnode, last_token = e_parser.Parse(lexer, grammar_nt.case_pat)
 
             pattern = self.tr.YshCasePattern(pnode)
 
-        return pattern
+        return pattern, last_token
 
     def ParseProc(self, lexer, out):
         # type: (Lexer, command.Proc) -> Token

--- a/osh/cmd_parse.py
+++ b/osh/cmd_parse.py
@@ -1161,6 +1161,11 @@ class CommandParser(object):
         ate = self._Eat(Id.Lit_LBrace)
         left = word_.BraceToken(ate)
 
+        return self._ParseBraceGroupAfterLBrace(left)
+
+    def _ParseBraceGroupAfterLBrace(self, left):
+        # type: (Token) -> BraceGroup
+
         # PROBLEM: can't use 'ate' here because osh/word_parse.py has a hack for
         # proc { } to translate Token Id.Op_RBrace -> Id.Lit_LBrace.
 
@@ -1515,6 +1520,9 @@ class CommandParser(object):
         if discriminant in (Id.Op_LParen, Id.Arith_Slash):
             # pat_exprs, pat_else or pat_eggex
             pattern = self.parse_ctx.ParseYshCasePattern(self.lexer)
+
+            # TODO: how to get this?
+            left = self.w_parser.cur_token
         else:
             # pat_words
             pat_words = []  # type: List[word_t]
@@ -1535,8 +1543,11 @@ class CommandParser(object):
                     break
             pattern = pat.Words(pat_words)
 
+            ate = self._Eat(Id.Lit_LBrace)
+            left = word_.BraceToken(ate)
+
         self._NewlineOk()
-        action = self.ParseBraceGroup()
+        action = self._ParseBraceGroupAfterLBrace(left)
 
         # The left token of the action is our "middle" token
         return CaseArm(left_tok, pattern, action.left, action.children,

--- a/osh/cmd_parse.py
+++ b/osh/cmd_parse.py
@@ -1161,11 +1161,6 @@ class CommandParser(object):
         ate = self._Eat(Id.Lit_LBrace)
         left = word_.BraceToken(ate)
 
-        return self._ParseBraceGroupAfterLBrace(left)
-
-    def _ParseBraceGroupAfterLBrace(self, left):
-        # type: (Token) -> BraceGroup
-
         doc_token = None  # type: Token
         self._GetWord()
         if self.c_id == Id.Op_Newline:
@@ -1516,7 +1511,7 @@ class CommandParser(object):
         pattern = None  # type: pat_t
         if discriminant in (Id.Op_LParen, Id.Arith_Slash):
             # pat_exprs, pat_else or pat_eggex
-            pattern, left = self.parse_ctx.ParseYshCasePattern(self.lexer)
+            pattern = self.w_parser.ParseYshCasePattern()
         else:
             # pat_words
             pat_words = []  # type: List[word_t]
@@ -1537,11 +1532,8 @@ class CommandParser(object):
                     break
             pattern = pat.Words(pat_words)
 
-            ate = self._Eat(Id.Lit_LBrace)
-            left = word_.BraceToken(ate)
-
         self._NewlineOk()
-        action = self._ParseBraceGroupAfterLBrace(left)
+        action = self.ParseBraceGroup()
 
         # The left token of the action is our "middle" token
         return CaseArm(left_tok, pattern, action.left, action.children,

--- a/osh/cmd_parse.py
+++ b/osh/cmd_parse.py
@@ -1166,9 +1166,6 @@ class CommandParser(object):
     def _ParseBraceGroupAfterLBrace(self, left):
         # type: (Token) -> BraceGroup
 
-        # PROBLEM: can't use 'ate' here because osh/word_parse.py has a hack for
-        # proc { } to translate Token Id.Op_RBrace -> Id.Lit_LBrace.
-
         doc_token = None  # type: Token
         self._GetWord()
         if self.c_id == Id.Op_Newline:

--- a/osh/cmd_parse.py
+++ b/osh/cmd_parse.py
@@ -1519,10 +1519,7 @@ class CommandParser(object):
         pattern = None  # type: pat_t
         if discriminant in (Id.Op_LParen, Id.Arith_Slash):
             # pat_exprs, pat_else or pat_eggex
-            pattern = self.parse_ctx.ParseYshCasePattern(self.lexer)
-
-            # TODO: how to get this?
-            left = self.w_parser.cur_token
+            pattern, left = self.parse_ctx.ParseYshCasePattern(self.lexer)
         else:
             # pat_words
             pat_words = []  # type: List[word_t]

--- a/osh/cmd_parse_test.py
+++ b/osh/cmd_parse_test.py
@@ -656,7 +656,7 @@ case (x) {
             self.assertEqual(pat_e.YshExprs, pattern.tag())
 
             # TODO: Fix this test!
-            #self.assertEqual(2, len(pattern.e))
+            self.assertEqual(2, len(pattern.exprs))
 
         node = assert_ParseCommandLine(
             self, """\

--- a/osh/word_parse.py
+++ b/osh/word_parse.py
@@ -1158,8 +1158,8 @@ class WordParser(WordEmitter):
 
     def ParseYshCasePattern(self):
         # type: () -> pat_t
-
         pat, last_token = self.parse_ctx.ParseYshCasePattern(self.lexer)
+
         if last_token.id == Id.Op_LBrace:
             last_token.id = Id.Lit_LBrace
         self.buffered_word = last_token

--- a/osh/word_parse.py
+++ b/osh/word_parse.py
@@ -80,6 +80,7 @@ from _devbuild.gen.syntax_asdl import (
     command,
     expr_t,
     ArgList,
+    pat_t,
 )
 from core import alloc
 from core.error import p_die
@@ -1154,6 +1155,16 @@ class WordParser(WordEmitter):
             last_token.id = Id.Lit_LBrace
         self.buffered_word = last_token
         self._SetNext(lex_mode_e.ShCommand)  # TODO: Do we need this?
+
+    def ParseYshCasePattern(self):
+        # type: () -> pat_t
+
+        pat, last_token = self.parse_ctx.ParseYshCasePattern(self.lexer)
+        if last_token.id == Id.Op_LBrace:
+            last_token.id = Id.Lit_LBrace
+        self.buffered_word = last_token
+
+        return pat
 
     def ParseImport(self, node):
         # type: (command.Import) -> None

--- a/test/parse-errors.sh
+++ b/test/parse-errors.sh
@@ -1270,21 +1270,26 @@ ysh_case() {
   }
   '
 
-  # TODO: make this parse
-  if false; then
-    _ysh-should-parse '
-    case (num) {
-        (1) | (2) | (3)
-      | (4) | (5) {
-        echo small
-      }
-
-      (else) {
-        echo large
-      }
+  _ysh-should-parse '
+  case (num) {
+    (1) | (2) {
+      echo number
     }
-    '
-  fi
+  }
+  '
+
+  _ysh-should-parse '
+  case (num) {
+      (1) | (2) | (3)
+    | (4) | (5) {
+      echo small
+    }
+
+    (else) {
+      echo large
+    }
+  }
+  '
 
   # Example invalid cases from grammar brain-storming
   _ysh-parse-error '

--- a/ysh/expr_to_ast.py
+++ b/ysh/expr_to_ast.py
@@ -778,7 +778,7 @@ class Transformer(object):
 
     def YshCasePattern(self, pnode):
         # type: (PNode) -> pat_t
-        assert pnode.typ == grammar_nt.case_pat, pnode
+        assert pnode.typ == grammar_nt.ysh_case_pat, pnode
 
         pattern = pnode.GetChild(0)
         typ = pattern.typ

--- a/ysh/expr_to_ast.py
+++ b/ysh/expr_to_ast.py
@@ -777,7 +777,7 @@ class Transformer(object):
                              (typ, nt_name))
 
     def YshCasePattern(self, pnode):
-        # type: (PNode) -> pat_t
+        # type: (PNode) -> Tuple[pat_t, Token]
         assert pnode.typ == grammar_nt.case_pat, pnode
 
         # We need to descriminate against

--- a/ysh/expr_to_ast.py
+++ b/ysh/expr_to_ast.py
@@ -782,9 +782,9 @@ class Transformer(object):
 
         pattern = pnode.GetChild(0)
         typ = pattern.typ
-        if typ == grammar_nt.pat_paren:
+        if typ == Id.Op_LParen:
             # pat_expr or pat_else
-            pattern = pattern.GetChild(1)
+            pattern = pnode.GetChild(1)
             typ = pattern.typ
 
             if typ == grammar_nt.pat_else:

--- a/ysh/expr_to_ast.py
+++ b/ysh/expr_to_ast.py
@@ -780,7 +780,6 @@ class Transformer(object):
         # type: (PNode) -> pat_t
         assert pnode.typ == grammar_nt.case_pat, pnode
 
-        # We need to descriminate against
         pattern = pnode.GetChild(0)
         typ = pattern.typ
         if typ == grammar_nt.pat_paren:

--- a/ysh/expr_to_ast.py
+++ b/ysh/expr_to_ast.py
@@ -777,7 +777,7 @@ class Transformer(object):
                              (typ, nt_name))
 
     def YshCasePattern(self, pnode):
-        # type: (PNode) -> Tuple[pat_t, Token]
+        # type: (PNode) -> pat_t
         assert pnode.typ == grammar_nt.case_pat, pnode
 
         # We need to descriminate against
@@ -792,8 +792,8 @@ class Transformer(object):
                 return pat.Else
             elif typ == grammar_nt.pat_exprs:
                 exprs = []  # type: List[expr_t]
-                assert pattern.children
-                for child in pattern.children:
+                for i in xrange(pattern.NumChildren()):
+                    child = pattern.GetChild(i)
                     if child.typ == grammar_nt.expr:
                         expr = self.Expr(child)
                         exprs.append(expr)

--- a/ysh/expr_to_ast.py
+++ b/ysh/expr_to_ast.py
@@ -791,11 +791,13 @@ class Transformer(object):
             if typ == grammar_nt.pat_else:
                 return pat.Else
             elif typ == grammar_nt.pat_exprs:
-                # TODO: recursively extract all expressions
-                #       but this is fine for now as we only parse one expression
-                e = pattern.GetChild(0).GetChild(0)
-                expr = self.Expr(e)
-                return pat.YshExprs([expr])
+                exprs = []  # type: List[expr_t]
+                assert pattern.children
+                for child in pattern.children:
+                    if child.typ == grammar_nt.expr:
+                        expr = self.Expr(child)
+                        exprs.append(expr)
+                return pat.YshExprs(exprs)
 
         elif typ == grammar_nt.pat_eggex:
             # pat_eggex

--- a/ysh/grammar.pgen2
+++ b/ysh/grammar.pgen2
@@ -604,7 +604,7 @@ regex: [re_alt] (('|'|'or') re_alt)*
 #                  ^-- End of pattern/beginning of case arm body
 # }
 
-case_pat: (
+ysh_case_pat: (
     '(' (pat_else | pat_exprs)
   | pat_eggex
 ) [Op_Newline] '{'

--- a/ysh/grammar.pgen2
+++ b/ysh/grammar.pgen2
@@ -591,7 +591,17 @@ regex: [re_alt] (('|'|'or') re_alt)*
 #
 # case (foo) {
 #   (40 + 2) | (0) { echo number }
-#   ^^^^^^^^-- This is pattern
+#   ^^^^^^^^^^^^^^-- This is pattern
+# }
+#
+# Due to limitations created from pgen2/cmd_parser interactions, we also parse
+# the leading '{' token of the case arm body in pgen2. We do this to help pgen2
+# figure out when to transfer control back to the cmd_parser. For more details
+# see #oil-dev > Dev Friction / Smells.
+#
+# case (foo) {
+#   (40 + 2) | (0) { echo number }
+#                  ^-- End of pattern/beginning of case arm body
 # }
 
 case_pat: (

--- a/ysh/grammar.pgen2
+++ b/ysh/grammar.pgen2
@@ -605,9 +605,7 @@ case_pat: (
 pat_paren: '(' (pat_else | pat_exprs)
 
 pat_exprs: expr ')' [Op_Newline] ('|' [Op_Newline] '(' expr ')' [Op_Newline])*
-
 pat_else: 'else' ')'
-
 pat_eggex: '/' regex [re_flags] '/'
 
 # e.g. /digit+ ; multiline !ignorecase/

--- a/ysh/grammar.pgen2
+++ b/ysh/grammar.pgen2
@@ -605,17 +605,12 @@ regex: [re_alt] (('|'|'or') re_alt)*
 # }
 
 case_pat: (
-    pat_paren
+    '(' (pat_else | pat_exprs)
   | pat_eggex
 ) [Op_Newline] '{'
 
-# This odd factorization is present so pat_exprs+pat_else can be parsed
-# unambiguously. Furthermore, seperating it from `case_pat` makes it both
-# easier to read and transform in `expr_to_ast.py`
-pat_paren: '(' (pat_else | pat_exprs)
-
-pat_exprs: expr ')' [Op_Newline] ('|' [Op_Newline] '(' expr ')' [Op_Newline])*
 pat_else: 'else' ')'
+pat_exprs: expr ')' [Op_Newline] ('|' [Op_Newline] '(' expr ')' [Op_Newline])*
 pat_eggex: '/' regex [re_flags] '/'
 
 # e.g. /digit+ ; multiline !ignorecase/

--- a/ysh/grammar.pgen2
+++ b/ysh/grammar.pgen2
@@ -597,16 +597,14 @@ regex: [re_alt] (('|'|'or') re_alt)*
 case_pat: (
     pat_paren
   | pat_eggex
-)
+) [Op_Newline] '{'
 
 # This odd factorization is present so pat_exprs+pat_else can be parsed
 # unambiguously. Furthermore, seperating it from `case_pat` makes it both
 # easier to read and transform in `expr_to_ast.py`
 pat_paren: '(' (pat_else | pat_exprs)
 
-pat_exprs: pat_expr # ([Op_Newline] '|' [Op_Newline] '(' pat_expr)*
-                    # ^^^-- adding all of this seems to break things
-pat_expr: expr ')'
+pat_exprs: expr ')' [Op_Newline] ('|' [Op_Newline] '(' expr ')' [Op_Newline])*
 
 pat_else: 'else' ')'
 

--- a/ysh/grammar_gen.py
+++ b/ysh/grammar_gen.py
@@ -210,7 +210,7 @@ def main(argv):
             tr = expr_to_ast.Transformer(gr)
             if start_symbol == 'eval_input':
                 ast_node = tr.Expr(pnode)
-            elif start_symbol == 'case_pat':
+            elif start_symbol == 'ysh_case_pat':
                 ast_node = tr.YshCasePattern(pnode)
             else:
                 ast_node = tr.VarDecl(pnode)


### PR DESCRIPTION
Ie. this can now be parsed:

```
case (x) {
  (1) | (2) {
    echo number
  }
}
```