### PR TITLE
Compatibility changes for building oil-native on macos

### DIFF
--- a/build/ninja-rules-cpp.sh
+++ b/build/ninja-rules-cpp.sh
@@ -24,7 +24,7 @@ REPO_ROOT=$(cd "$(dirname $0)/.."; pwd)
 
 . build/common.sh  # for $BASE_CXXFLAGS
 
-# for HAVE_READLINE and READLINE_DIR
+# for HAVE_READLINE, READLINE_DIR, and STRIP_FLAGS
 if ! . _build/detected-config.sh; then
   die "Can't find _build/detected-config.sh.  Run './configure'"
 fi
@@ -50,7 +50,7 @@ link_flags=''  # link flags
 setglobal_cxx() {
   local compiler=$1
 
-  case $compiler in 
+  case $compiler in
     (cxx)   cxx='c++'    ;;
     (clang) cxx=$CLANGXX ;;
     (*)     die "Invalid compiler $compiler" ;;
@@ -226,7 +226,9 @@ setglobal_link_flags() {
       ;;
   esac
 
-  link_flags="$link_flags -Wl,--gc-sections"
+  if test -n "$STRIP_FLAGS"; then
+    link_flags="$link_flags -Wl,$STRIP_FLAGS"
+  fi
 }
 
 compile_one() {

--- a/build/ninja-rules-cpp.sh
+++ b/build/ninja-rules-cpp.sh
@@ -226,7 +226,7 @@ setglobal_link_flags() {
       ;;
   esac
 
-  if test -n "$STRIP_FLAGS"; then
+  if test -n "${STRIP_FLAGS:-}"; then
     link_flags="$link_flags -Wl,$STRIP_FLAGS"
   fi
 }

--- a/configure
+++ b/configure
@@ -351,8 +351,6 @@ detect_c_language() {
   #  check_sizeof SIZEOF_WCHAR_T 'wchar_t' 4
   #fi
 
-  cc_statement HAVE_ENVIRON 'char **my_environ = environ;' '#include <unistd.h>'
-
   # TODO: Detect header and size.
   echo '#define HAVE_WCHAR_H 1'
   echo '#define SIZEOF_WCHAR_T 4'

--- a/configure
+++ b/configure
@@ -249,6 +249,16 @@ echo_shell_vars() {
   fi
   echo "PREFIX=$FLAG_prefix"
   echo "DATAROOTDIR=$FLAG_datarootdir"
+  cat >$TMP/ld_flags.c <<EOF
+int main() {
+  return 0;
+}
+EOF
+  if cc_quiet $TMP/ld_flags.c -Wl,--gc-sections; then
+    echo 'STRIP_FLAGS=--gc-sections'
+  elif cc_quiet $TMP/ld_flags.c -Wl,-dead_strip; then
+    echo 'STRIP_FLAGS=-dead_strip'
+  fi
 }
 
 # c.m4 AC_LANG_INT_SAVE

--- a/configure
+++ b/configure
@@ -341,6 +341,8 @@ detect_c_language() {
   #  check_sizeof SIZEOF_WCHAR_T 'wchar_t' 4
   #fi
 
+  cc_statement HAVE_ENVIRON 'char **my_environ = environ;' '#include <unistd.h>'
+
   # TODO: Detect header and size.
   echo '#define HAVE_WCHAR_H 1'
   echo '#define SIZEOF_WCHAR_T 4'

--- a/configure
+++ b/configure
@@ -249,14 +249,9 @@ echo_shell_vars() {
   fi
   echo "PREFIX=$FLAG_prefix"
   echo "DATAROOTDIR=$FLAG_datarootdir"
-  cat >$TMP/ld_flags.c <<EOF
-int main() {
-  return 0;
-}
-EOF
-  if cc_quiet $TMP/ld_flags.c -Wl,--gc-sections; then
+  if cc_quiet build/detect-cc.c -Wl,--gc-sections; then
     echo 'STRIP_FLAGS=--gc-sections'
-  elif cc_quiet $TMP/ld_flags.c -Wl,-dead_strip; then
+  elif cc_quiet build/detect-cc.c -Wl,-dead_strip; then
     echo 'STRIP_FLAGS=-dead_strip'
   fi
 }

--- a/configure-test.sh
+++ b/configure-test.sh
@@ -121,7 +121,8 @@ test_echo_vars() {
   fi
   if ! test "$output" = 'HAVE_READLINE=
 PREFIX=/usr/local
-DATAROOTDIR='; then
+DATAROOTDIR=
+STRIP_FLAGS=--gc-sections'; then
     die "Unexpected echo_shell_vars output: $output"
   fi
 
@@ -134,7 +135,8 @@ DATAROOTDIR='; then
   if ! test "$output" = 'HAVE_READLINE=1
 READLINE_DIR=
 PREFIX=/usr/local
-DATAROOTDIR='; then
+DATAROOTDIR=
+STRIP_FLAGS=--gc-sections'; then
     die "Unexpected echo_shell_vars output: $output"
   fi
 
@@ -148,7 +150,8 @@ DATAROOTDIR='; then
   if ! test "$output" = 'HAVE_READLINE=1
 READLINE_DIR=/path/to/readline
 PREFIX=/usr/local
-DATAROOTDIR='; then
+DATAROOTDIR=
+STRIP_FLAGS=--gc-sections'; then
     die "Unexpected echo_shell_vars output: $output"
   fi
 

--- a/cpp/core.cc
+++ b/cpp/core.cc
@@ -20,6 +20,10 @@
 
 #include "_gen/frontend/consts.h"  // gVersion
 
+#ifndef HAVE_ENVIRON // handle systems that don't include environ in unistd
+extern char **environ;
+#endif
+
 namespace pyos {
 
 SignalSafe* gSignalSafe = nullptr;

--- a/cpp/core.cc
+++ b/cpp/core.cc
@@ -20,9 +20,7 @@
 
 #include "_gen/frontend/consts.h"  // gVersion
 
-#ifndef HAVE_ENVIRON // handle systems that don't include environ in unistd
 extern char **environ;
-#endif
 
 namespace pyos {
 


### PR DESCRIPTION
This includes a change to check for `unistd.h` defining `environ` and one for the correct `ld` flags to use. This has currently only been tested on macos, so confirmation that this doesn't break linux would be welcome.

This should fix #1658 and at least the `environ` part of #1272.