### PR TITLE
Add missing ysh to uninstall script

### DIFF
--- a/uninstall
+++ b/uninstall
@@ -37,7 +37,7 @@ main() {
   local working_dir=$PWD  # save for later
 
   cd "$bin_dest"
-  for link in osh oil; do
+  for link in osh oil ysh; do
     if ! rm "$bin_dest/$link"; then
       log "Couldn't remove $link symlink in $bin_dest"
     else


### PR DESCRIPTION
The ysh symlink is not being removed by the uninstall script. Add it to the FOR loop along with "osh" and "oil", so there's no leftovers.

That second change at the end of the file was added by Neovim:

``` diff
❯ git diff master origin/fix/add-missing-ysh-to-uninstall
diff --git a/uninstall b/uninstall
index 06b0aaca3..3377c6646 100755
--- a/uninstall
+++ b/uninstall
@@ -37,7 +37,7 @@ main() {
   local working_dir=$PWD  # save for later
 
   cd "$bin_dest"
-  for link in osh oil; do
+  for link in osh oil ysh; do
     if ! rm "$bin_dest/$link"; then
       log "Couldn't remove $link symlink in $bin_dest"
     else
@@ -65,4 +65,4 @@ main() {
   fi
 }
 
-main "$@"
\ No newline at end of file
+main "$@"
```