### PR TITLE
[ysh] remove slice(), drop step from value.Slice

### DIFF
--- a/core/runtime.asdl
+++ b/core/runtime.asdl
@@ -91,7 +91,7 @@ module runtime
     # Internal detail?  Does it need to be a first class type, or maybe it can
     # double for a range?  It can't be serialized.
     # Might want for i in (1:n) { echo $i }, although it's inconsistent with shell ..
-  | Slice(IntBox? lower, IntBox? upper, IntBox? step)
+  | Slice(IntBox? lower, IntBox? upper)
 
   # What is valid in arrays or assoc arrays a[i] or A[i] in shell.
   # Used for ${a[i]=x}.  TODO: also use for lvalue/place.

--- a/library/func_cpython.py
+++ b/library/func_cpython.py
@@ -198,8 +198,6 @@ def Init(mem):
 
     # Temporary: use xrange until we rewrite in YSH
     SetGlobalFunc(mem, 'range', lambda *args: list(xrange(*args)))
-    # For the 'step' param.
-    SetGlobalFunc(mem, 'slice', slice)
 
     SetGlobalFunc(mem, 'any', any)  # IN-YSH with Bool
     SetGlobalFunc(mem, 'all', all)  # IN-YSH with Bool

--- a/spec/ysh-slice-range.test.sh
+++ b/spec/ysh-slice-range.test.sh
@@ -78,17 +78,6 @@ implicit
 (List)   ['4', '5']
 ## END
 
-#### Explicit slice with step
-shopt -s oil:all
-var mylist = [0,1,2,3,4,5,6,7,8]
-var x = mylist[slice(1, 7, 2)]
-write @x
-## STDOUT:
-1
-3
-5
-## END
-
 #### Index with expression
 var mydict = {['5']: 3}
 var val = mydict["$[2+3]"]

--- a/ysh/cpython.py
+++ b/ysh/cpython.py
@@ -98,15 +98,12 @@ def _PyObjToValue(val):
             return value.Dict(typed_dict)
 
     elif isinstance(val, slice):
-        s = value.Slice(None, None, None)
+        s = value.Slice(None, None)
         if val.start:
             s.lower = IntBox(val.start)
 
         if val.stop:
             s.upper = IntBox(val.stop)
-
-        if val.step:
-            s.step = IntBox(val.step)
 
         return s
 
@@ -176,18 +173,15 @@ def _ValueToPyObj(val):
 
         elif case(value_e.Slice):
             val = cast(value.Slice, UP_val)
-            step = 1
-            if val.step:
-                step = val.step.i
 
             if val.lower and val.upper:
-                return slice(val.lower.i, val.upper.i, step)
+                return slice(val.lower.i, val.upper.i)
             elif val.lower:
-                return slice(val.lower.i, None, step)
+                return slice(val.lower.i, None)
             elif val.upper:
-                return slice(None, val.upper.i, step)
+                return slice(None, val.upper.i)
 
-            return slice(None, None, None)
+            return slice(None, None)
 
         elif case(value_e.Eggex):
             return val  # passthrough

--- a/ysh/cpython.py
+++ b/ysh/cpython.py
@@ -8,7 +8,6 @@ from _devbuild.gen.runtime_asdl import (
     value,
     value_e,
     value_t,
-    IntBox,
 )
 from _devbuild.gen.syntax_asdl import loc
 from core import error

--- a/ysh/cpython.py
+++ b/ysh/cpython.py
@@ -97,16 +97,6 @@ def _PyObjToValue(val):
         else:
             return value.Dict(typed_dict)
 
-    elif isinstance(val, slice):
-        s = value.Slice(None, None)
-        if val.start:
-            s.lower = IntBox(val.start)
-
-        if val.stop:
-            s.upper = IntBox(val.stop)
-
-        return s
-
     elif isinstance(val, value.Eggex):
         return val  # passthrough
 
@@ -170,18 +160,6 @@ def _ValueToPyObj(val):
             for k, v in val.d.items():
                 d[k] = _ValueToPyObj(v)
             return d
-
-        elif case(value_e.Slice):
-            val = cast(value.Slice, UP_val)
-
-            if val.lower and val.upper:
-                return slice(val.lower.i, val.upper.i)
-            elif val.lower:
-                return slice(val.lower.i, None)
-            elif val.upper:
-                return slice(None, val.upper.i)
-
-            return slice(None, None)
 
         elif case(value_e.Eggex):
             return val  # passthrough

--- a/ysh/expr_eval.py
+++ b/ysh/expr_eval.py
@@ -1005,7 +1005,7 @@ class OilEvaluator(object):
                         index = cast(value.Slice, index)
                         try:
                             lower = index.lower.i if index.lower else 0
-                            upper = index.upper.i if index.upper else len(obj.items)
+                            upper = index.upper.i if index.upper else len(obj.strs)
                             return value.MaybeStrArray(obj.strs[lower:upper])
 
                         except IndexError:
@@ -1034,7 +1034,7 @@ class OilEvaluator(object):
                         index = cast(value.Slice, index)
                         try:
                             lower = index.lower.i if index.lower else 0
-                            upper = index.upper.i if index.upper else len(obj.items)
+                            upper = index.upper.i if index.upper else len(obj.s)
                             return value.Str(obj.s[lower:upper])
 
                         except IndexError:

--- a/ysh/expr_eval.py
+++ b/ysh/expr_eval.py
@@ -636,7 +636,7 @@ class OilEvaluator(object):
 
             upper = IntBox(cast(value.Int, UP_upper).i)
 
-        return value.Slice(lower, upper, IntBox(1))
+        return value.Slice(lower, upper)
 
     def _CompareNumeric(self, left, right, op):
         # type: (value_t, value_t, Id_t) -> bool
@@ -975,34 +975,26 @@ class OilEvaluator(object):
                     if case2(value_e.Slice):
                         index = cast(value.Slice, index)
 
-                        if mylib.PYTHON:
-                            # stride not supported in mycpp
+                        try:
+                            if index.lower and index.upper:
+                                return value.List(
+                                    obj.items[index.lower.i:index.upper.i])
 
-                            step = index.step.i if index.step else 1
+                            elif index.lower:
+                                return value.List(
+                                    obj.items[index.lower.i:len(obj.items)])
 
-                            try:
-                                if index.lower and index.upper:
-                                    return value.List(
-                                        obj.items[index.lower.i:index.upper.
-                                                  i:step])
+                            elif index.upper:
+                                return value.List(obj.items[:index.upper.i])
 
-                                elif index.lower:
-                                    return value.List(
-                                        obj.items[index.lower.i:len(obj.items
-                                                                    ):step])
+                            else:
+                                # l[:] == l
+                                return value.List(list(obj.items))
 
-                                elif index.upper:
-                                    return value.List(
-                                        obj.items[:index.upper.i:step])
-
-                                else:
-                                    # l[:] == l
-                                    return value.List(list(obj.items))
-
-                            except IndexError:
-                                # TODO: expr.Subscript has no error location
-                                raise error.Expr('index out of range',
-                                                 loc.Missing)
+                        except IndexError:
+                            # TODO: expr.Subscript has no error location
+                            raise error.Expr('index out of range',
+                                             loc.Missing)
 
                     elif case2(value_e.Int):
                         index = cast(value.Int, index)
@@ -1022,32 +1014,27 @@ class OilEvaluator(object):
                 with tagswitch(index) as case2:
                     if case2(value_e.Slice):
                         index = cast(value.Slice, index)
-                        if mylib.PYTHON:
-                            step = index.step.i if index.step else 1
+                        try:
+                            if index.lower and index.upper:
+                                return value.MaybeStrArray(
+                                    obj.strs[index.lower.i:index.upper.i])
 
-                            try:
-                                if index.lower and index.upper:
-                                    return value.MaybeStrArray(
-                                        obj.strs[index.lower.i:index.upper.
-                                                 i:step])
+                            elif index.lower:
+                                return value.MaybeStrArray(
+                                    obj.strs[index.lower.i:len(obj.strs)])
 
-                                elif index.lower:
-                                    return value.MaybeStrArray(
-                                        obj.strs[index.lower.i:len(obj.strs
-                                                                   ):step])
+                            elif index.upper:
+                                return value.MaybeStrArray(
+                                    obj.strs[:index.upper.i])
 
-                                elif index.upper:
-                                    return value.MaybeStrArray(
-                                        obj.strs[:index.upper.i:step])
+                            else:
+                                # l[:] == l
+                                return value.MaybeStrArray(list(obj.strs))
 
-                                else:
-                                    # l[:] == l
-                                    return value.MaybeStrArray(list(obj.strs))
-
-                            except IndexError:
-                                # TODO: expr.Subscript has no error location
-                                raise error.Expr('index out of range',
-                                                 loc.Missing)
+                        except IndexError:
+                            # TODO: expr.Subscript has no error location
+                            raise error.Expr('index out of range',
+                                             loc.Missing)
 
                     elif case2(value_e.Int):
                         index = cast(value.Int, index)
@@ -1068,31 +1055,24 @@ class OilEvaluator(object):
                 with tagswitch(index) as case2:
                     if case2(value_e.Slice):
                         index = cast(value.Slice, index)
+                        try:
+                            if index.lower and index.upper:
+                                return value.Str(obj.s[index.lower.i:index.upper.i])
 
-                        if mylib.PYTHON:
-                            step = index.step.i if index.step else 1
+                            elif index.lower:
+                                return value.Str(obj.s[index.lower.i:])
 
-                            try:
-                                if index.lower and index.upper:
-                                    return value.Str(obj.s[index.lower.i:index.
-                                                           upper.i:step])
+                            elif index.upper:
+                                return value.Str(obj.s[:index.upper.i])
 
-                                elif index.lower:
-                                    return value.Str(
-                                        obj.s[index.lower.i::step])
+                            else:
+                                # l[:] == l
+                                return obj
 
-                                elif index.upper:
-                                    return value.Str(
-                                        obj.s[:index.upper.i:step])
-
-                                else:
-                                    # l[:] == l
-                                    return obj
-
-                            except IndexError:
-                                # TODO: expr.Subscript has no error location
-                                raise error.Expr('index out of range',
-                                                 loc.Missing)
+                        except IndexError:
+                            # TODO: expr.Subscript has no error location
+                            raise error.Expr('index out of range',
+                                             loc.Missing)
 
                     elif case2(value_e.Int):
                         index = cast(value.Int, index)

--- a/ysh/expr_eval.py
+++ b/ysh/expr_eval.py
@@ -976,20 +976,9 @@ class OilEvaluator(object):
                         index = cast(value.Slice, index)
 
                         try:
-                            if index.lower and index.upper:
-                                return value.List(
-                                    obj.items[index.lower.i:index.upper.i])
-
-                            elif index.lower:
-                                return value.List(
-                                    obj.items[index.lower.i:len(obj.items)])
-
-                            elif index.upper:
-                                return value.List(obj.items[:index.upper.i])
-
-                            else:
-                                # l[:] == l
-                                return value.List(list(obj.items))
+                            lower = index.lower.i if index.lower else 0
+                            upper = index.upper.i if index.upper else len(obj.items)
+                            return value.List(obj.items[lower:upper])
 
                         except IndexError:
                             # TODO: expr.Subscript has no error location
@@ -1015,21 +1004,9 @@ class OilEvaluator(object):
                     if case2(value_e.Slice):
                         index = cast(value.Slice, index)
                         try:
-                            if index.lower and index.upper:
-                                return value.MaybeStrArray(
-                                    obj.strs[index.lower.i:index.upper.i])
-
-                            elif index.lower:
-                                return value.MaybeStrArray(
-                                    obj.strs[index.lower.i:len(obj.strs)])
-
-                            elif index.upper:
-                                return value.MaybeStrArray(
-                                    obj.strs[:index.upper.i])
-
-                            else:
-                                # l[:] == l
-                                return value.MaybeStrArray(list(obj.strs))
+                            lower = index.lower.i if index.lower else 0
+                            upper = index.upper.i if index.upper else len(obj.items)
+                            return value.MaybeStrArray(obj.strs[lower:upper])
 
                         except IndexError:
                             # TODO: expr.Subscript has no error location
@@ -1056,18 +1033,9 @@ class OilEvaluator(object):
                     if case2(value_e.Slice):
                         index = cast(value.Slice, index)
                         try:
-                            if index.lower and index.upper:
-                                return value.Str(obj.s[index.lower.i:index.upper.i])
-
-                            elif index.lower:
-                                return value.Str(obj.s[index.lower.i:])
-
-                            elif index.upper:
-                                return value.Str(obj.s[:index.upper.i])
-
-                            else:
-                                # l[:] == l
-                                return obj
+                            lower = index.lower.i if index.lower else 0
+                            upper = index.upper.i if index.upper else len(obj.items)
+                            return value.Str(obj.s[lower:upper])
 
                         except IndexError:
                             # TODO: expr.Subscript has no error location


### PR DESCRIPTION
With this change slices can only be created with the `:` syntax.