### PR TITLE
[ysh] remove range() builtin, add RangeIterator

### DIFF
--- a/frontend/syntax.asdl
+++ b/frontend/syntax.asdl
@@ -518,7 +518,7 @@ module syntax
 
     # Ranges are written 1:2, with first class expression syntax. There is no
     # step as in Python. Use range(0, 10, step=2) for that.
-  #| Range(expr lower, expr upper)
+  | Range(expr lower, expr upper)
 
     # Slices occur within [] only.  Unlike ranges, the start/end can be #
     # implicit.  Like ranges, denote a step with slice(0, 10, step=2).

--- a/library/func_cpython.py
+++ b/library/func_cpython.py
@@ -184,9 +184,6 @@ def Init(mem):
     # round()
     # divmod() - probably useful?  Look at the implementation
 
-    # Temporary: use xrange until we rewrite in YSH
-    SetGlobalFunc(mem, 'range', lambda *args: list(xrange(*args)))
-
     SetGlobalFunc(mem, 'any', any)  # IN-YSH with Bool
     SetGlobalFunc(mem, 'all', all)  # IN-YSH with Bool
     SetGlobalFunc(mem, 'sum', sum)  # IN-YSH with +

--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -1398,7 +1398,7 @@ class CommandEvaluator(object):
                             else:
                                 e_die_status(
                                     2,
-                                    'Ranger iteration expects at most 2 loop variables',
+                                    'Range iteration expects at most 2 loop variables',
                                     node.keyword)
 
                         else:

--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -1389,7 +1389,17 @@ class CommandEvaluator(object):
                         elif case(value_e.Range):
                             val = cast(value.Range, UP_val)
                             it2 = val_ops.RangeIterator(val)
-                            name1 = location.LName(node.iter_names[0])
+
+                            if n == 1:
+                                name1 = location.LName(node.iter_names[0])
+                            elif n == 2:
+                                i_name = location.LName(node.iter_names[0])
+                                name1 = location.LName(node.iter_names[1])
+                            else:
+                                e_die_status(
+                                    2,
+                                    'Ranger iteration expects at most 2 loop variables',
+                                    node.keyword)
 
                         else:
                             raise error.InvalidType2(

--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -1386,6 +1386,11 @@ class CommandEvaluator(object):
                             else:
                                 raise AssertionError()
 
+                        elif case(value_e.Range):
+                            val = cast(value.Range, UP_val)
+                            it2 = val_ops.RangeIterator(val)
+                            name1 = location.LName(node.iter_names[0])
+
                         else:
                             raise error.InvalidType2(
                                 val, 'for loop expected List or Dict',

--- a/spec/ysh-funcs-builtin.test.sh
+++ b/spec/ysh-funcs-builtin.test.sh
@@ -104,9 +104,9 @@ false
 #### sum()
 var start = 42
 
-write $[sum( range(3) )]
-write $[sum( range(3), start)]
-write $[sum( range(0), start)]
+write $[sum( 0:3 )]
+write $[sum( 0:3, start)]
+write $[sum( 0:0, start)]
 ## STDOUT:
 3
 45
@@ -114,7 +114,7 @@ write $[sum( range(0), start)]
 ## END
 
 #### reversed()
-var x = reversed(range(3))
+var x = reversed(0:3)
 write @x
 ## STDOUT:
 2

--- a/spec/ysh-funcs.test.sh
+++ b/spec/ysh-funcs.test.sh
@@ -150,7 +150,7 @@ var cache = []
 var maxSize = 4
 
 func remove(l, i) {
-  for i in (range(i, len(l) - 1)) {
+  for i in (i:len(l) - 1) {
     setvar l[i] = l[i + 1]
   }
 

--- a/spec/ysh-slice-range.test.sh
+++ b/spec/ysh-slice-range.test.sh
@@ -105,11 +105,17 @@ var b = a[:]
 for i in (1:5) {
     echo $[i]
 }
+for i, n in (1:4) {
+    echo "$[i], $[n]"
+}
 ## STDOUT:
 1
 2
 3
 4
+0, 1
+1, 2
+2, 3
 ## END
 
 #### Loops over bogus ranges terminate

--- a/spec/ysh-slice-range.test.sh
+++ b/spec/ysh-slice-range.test.sh
@@ -125,16 +125,6 @@ var t3 = mytable[:2, %(name age)]
 (Str)   'TODO: Table Slicing'
 ## END
 
-#### Index a list with a range, not a slice.  TODO: Figure out semantics
-shopt -s oil:all
-var mylist = [1,2,3,4,5]
-var r = 1:3
-var myslice = mylist[r]
-## status: 3
-## STDOUT:
-TODO
-## END
-
 #### List(0:3) should copy the list?
 shopt -s oil:all
 var mylist = List(0:3)

--- a/spec/ysh-slice-range.test.sh
+++ b/spec/ysh-slice-range.test.sh
@@ -101,6 +101,26 @@ var b = a[:]
 (List)   [1, 2, 3]
 ## END
 
+#### Iterate over range
+for i in (1:5) {
+    echo $[i]
+}
+## STDOUT:
+1
+2
+3
+4
+## END
+
+#### Loops over bogus ranges terminate
+# Regression test for bug found during dev. Loops over backwards ranges should
+# terminate immediately.
+for i in (5:1) {
+    echo $[i]
+}
+## STDOUT:
+## END
+
 #### Slices with Multiple Dimensions (for QTT)
 
 qtt pretty :mytable <<< '''

--- a/spec/ysh-word-eval.test.sh
+++ b/spec/ysh-word-eval.test.sh
@@ -92,18 +92,9 @@ true
 3.14
 ## END
 
-#### @[range()]
-shopt -s oil:all
-write @[range(10, 15, 2)]
-## STDOUT:
-10
-12
-14
-## END
-
 #### Wrong sigil with $range() is runtime error
 shopt -s oil:upgrade
-echo $[range(10, 15, 2)]
+echo $[10:15]
 echo 'should not get here'
 ## status: 3
 ## STDOUT:
@@ -119,7 +110,7 @@ write -- @mylist
 
 write -- ___
 
-var list2 = [range]
+var list2 = [List]
 write -- @list2
 
 ## status: 3

--- a/test/spec.sh
+++ b/test/spec.sh
@@ -860,7 +860,7 @@ ysh-scope() {
 }
 
 ysh-slice-range() {
-  sh-spec spec/ysh-slice-range.test.sh --oils-failures-allowed 5 \
+  sh-spec spec/ysh-slice-range.test.sh --oils-failures-allowed 1 \
     $OSH_LIST "$@"
 }
 

--- a/ysh/cpython.py
+++ b/ysh/cpython.py
@@ -70,6 +70,15 @@ def _PyObjToValue(val):
         #    return value.BashArray(shell_array)
         return value.List(typed_array)
 
+    elif isinstance(val, xrange):
+        # awkward, but should go away once everything is typed...
+        l = list(val)
+        if len(l) > 1:
+            return value.Range(l[0], l[-1])
+
+        # Empty range
+        return value.Range(0, 0)
+
     elif isinstance(val, dict):
         is_shell_dict = True
 
@@ -161,6 +170,10 @@ def _ValueToPyObj(val):
 
         elif case(value_e.Eggex):
             return val  # passthrough
+
+        elif case(value_e.Range):
+            val = cast(value.Range, UP_val)
+            return xrange(val.lower, val.upper)
 
         elif case(value_e.Func):
             val = cast(value.Func, UP_val)

--- a/ysh/expr_eval.py
+++ b/ysh/expr_eval.py
@@ -643,6 +643,31 @@ class ExprEvaluator(object):
 
         return value.Slice(lower, upper)
 
+    def _EvalRange(self, node):
+        # type: (expr.Range) -> value_t
+
+        if not node.lower:
+            raise error.Expr('Missing range lower bound', loc.Missing)
+
+        UP_lower = self._EvalExpr(node.lower)
+        if UP_lower.tag() != value_e.Int:
+            raise error.InvalidType('Range indices must be Ints',
+                                    loc.Missing)
+
+        lower = cast(value.Int, UP_lower)
+
+        if not node.upper:
+            raise error.Expr('Missing range upper bound', loc.Missing)
+
+        UP_upper = self._EvalExpr(node.upper)
+        if UP_upper.tag() != value_e.Int:
+            raise error.InvalidType('Range indices must be Ints',
+                                    loc.Missing)
+
+        upper = cast(value.Int, UP_upper)
+
+        return value.Range(lower.i, upper.i)
+
     def _CompareNumeric(self, left, right, op):
         # type: (value_t, value_t, Id_t) -> bool
         left = self._ValueToNumber(left)
@@ -1190,6 +1215,10 @@ class ExprEvaluator(object):
             elif case(expr_e.Slice):  # a[:0]
                 node = cast(expr.Slice, UP_node)
                 return self._EvalSlice(node)
+
+            elif case(expr_e.Range):
+                node = cast(expr.Range, UP_node)
+                return self._EvalRange(node)
 
             elif case(expr_e.Compare):
                 node = cast(expr.Compare, UP_node)

--- a/ysh/expr_eval.py
+++ b/ysh/expr_eval.py
@@ -646,8 +646,7 @@ class ExprEvaluator(object):
     def _EvalRange(self, node):
         # type: (expr.Range) -> value_t
 
-        if not node.lower:
-            raise error.Expr('Missing range lower bound', loc.Missing)
+        assert node.lower is not None
 
         UP_lower = self._EvalExpr(node.lower)
         if UP_lower.tag() != value_e.Int:
@@ -656,8 +655,7 @@ class ExprEvaluator(object):
 
         lower = cast(value.Int, UP_lower)
 
-        if not node.upper:
-            raise error.Expr('Missing range upper bound', loc.Missing)
+        assert node.upper is not None
 
         UP_upper = self._EvalExpr(node.upper)
         if UP_upper.tag() != value_e.Int:

--- a/ysh/expr_to_ast.py
+++ b/ysh/expr_to_ast.py
@@ -574,15 +574,8 @@ class Transformer(object):
                     return self.Expr(pnode.GetChild(0))
 
                 if n == 3:
-                    # Note: 1:4 was special syntax for Python 2 range(1, 4),
-                    # which is [1,2,3]
-                    #
-                    # Since we're doing a minimal version of YSH, let's avoid
-                    # special syntax, and just use the builtin
-
-                    p_die('Ranges not implemented', loc.Missing)
-                    #return expr.Range(self.Expr(pnode.GetChild(0)),
-                    #                  self.Expr(pnode.GetChild(2)))
+                    return expr.Range(self.Expr(pnode.GetChild(0)),
+                                      self.Expr(pnode.GetChild(2)))
 
                 raise AssertionError(n)
 

--- a/ysh/val_ops.py
+++ b/ysh/val_ops.py
@@ -221,6 +221,24 @@ class ArrayIter(_ContainerIter):
         return value.Str(self.strs[self.i])
 
 
+class RangeIterator(_ContainerIter):
+    """ for x in (m:n) { """
+
+    def __init__(self, val):
+        # type: (value.Range) -> None
+        _ContainerIter.__init__(self)
+        self.val = val
+        self.i = val.lower
+
+    def Done(self):
+        # type: () -> int
+        return self.i == self.val.upper
+
+    def FirstValue(self):
+        # type: () -> value_t
+        return value.Int(self.i)
+
+
 class ListIterator(_ContainerIter):
     """ for x in (mylist) { """
 

--- a/ysh/val_ops.py
+++ b/ysh/val_ops.py
@@ -228,15 +228,14 @@ class RangeIterator(_ContainerIter):
         # type: (value.Range) -> None
         _ContainerIter.__init__(self)
         self.val = val
-        self.i = val.lower
 
     def Done(self):
         # type: () -> int
-        return self.i >= self.val.upper
+        return self.val.lower + self.i >= self.val.upper
 
     def FirstValue(self):
         # type: () -> value_t
-        return value.Int(self.i)
+        return value.Int(self.val.lower + self.i)
 
 
 class ListIterator(_ContainerIter):

--- a/ysh/val_ops.py
+++ b/ysh/val_ops.py
@@ -232,7 +232,7 @@ class RangeIterator(_ContainerIter):
 
     def Done(self):
         # type: () -> int
-        return self.i == self.val.upper
+        return self.i >= self.val.upper
 
     def FirstValue(self):
         # type: () -> value_t


### PR DESCRIPTION
These commits replace the `range` builtin with `:` syntax for range creation. You can now do loops like the following:
```
$ bin/ysh
ysh$ for i in (0:10) { echo "$[i]" }
0
1
2
3
4
5
6
7
8
9
ysh$
```

In the current implementation, ranges must have both limits specified. So, ranges like `:10` that are otherwise equivalent to the one in the example, are disallowed. How do we feel about this?