### PR TITLE
xxx [core] create jobs for procs when sending to bg...

### DIFF
--- a/osh/builtin_process.py
+++ b/osh/builtin_process.py
@@ -69,7 +69,15 @@ class Fg(vm._Builtin):
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
 
-        pid = self.job_list.GetLastStopped()
+        pid = -1
+        if len(cmd_val.argv) > 1:
+            job_spec = cmd_val.argv[1]
+            job = self.job_list.GetJobWithSpec(job_spec)
+            if job:
+                pid = job.GroupId()
+        else:
+            pid = self.job_list.GetLastStopped()
+
         if pid == -1:
             log('No job to put in the foreground')
             return 1


### PR DESCRIPTION
and add basic job specs to `fg` builtin

Right now, only jobs started in the background get added to the jobs list. If some, say, starts `vim` in the foreground and sends it to the background with `Ctrl-z` the output of `jobs` will be empty. `fg` will still bring it back to the foreground as long as it's considered the last stopped process, but sending another process to the background will prevent the user from ever bringing the original process back to the foreground.

To make managing multiple background processes easier this commit adds processes stopped with `Ctrl-z` to the jobs list and adds support for the `%<digits>` flavor of job spec to the `fg` builtin.