### PR TITLE
job control overhaul

### DIFF
--- a/core/executor.py
+++ b/core/executor.py
@@ -364,6 +364,7 @@ class ShellExecutor(vm._Executor):
                 pi.Add(p)
 
             pi.StartPipeline(self.waiter)
+            pi.SetBackground()
             last_pid = pi.LastPid()
             self.mem.last_bg_pid = last_pid  # for $!
 
@@ -378,6 +379,7 @@ class ShellExecutor(vm._Executor):
             if self.job_control.Enabled():
                 p.AddStateChange(process.SetPgid(process.OWN_LEADER))
 
+            p.SetBackground()
             pid = p.StartProcess(trace.Fork)
             self.mem.last_bg_pid = pid  # for $!
             self.job_list.AddJob(p)  # show in 'jobs' list

--- a/core/main_loop.py
+++ b/core/main_loop.py
@@ -217,9 +217,7 @@ def Interactive(flag, cmd_ev, c_parser, display, prompt_plugin, waiter, errfmt):
                         display.EraseLines()
                         # POSIX shell behavior: waitpid(-1) and show job "Done"
                         # messages
-                        r = waiter.WaitForOne(waitpid_options=WNOHANG)
-                        while r == process.W1_OK:
-                            r = waiter.WaitForOne(waitpid_options=WNOHANG)
+                        waiter.PollNotifications()
                         quit = True
                     elif case(parse_result_e.Eof):
                         display.EraseLines()
@@ -275,7 +273,7 @@ def Interactive(flag, cmd_ev, c_parser, display, prompt_plugin, waiter, errfmt):
 
             status = cmd_ev.LastStatus()
 
-            r = waiter.WaitForOne(waitpid_options=WNOHANG)
+            waiter.PollNotifications()
 
             if is_return:
                 done = True

--- a/core/main_loop.py
+++ b/core/main_loop.py
@@ -24,7 +24,6 @@ from mycpp.mylib import log, print_stderr, tagswitch
 
 import fanos
 import posix_ as posix
-from posix_ import WNOHANG
 
 from typing import cast, Any, List, TYPE_CHECKING
 if TYPE_CHECKING:

--- a/core/main_loop.py
+++ b/core/main_loop.py
@@ -218,6 +218,8 @@ def Interactive(flag, cmd_ev, c_parser, display, prompt_plugin, waiter, errfmt):
                         # POSIX shell behavior: waitpid(-1) and show job "Done"
                         # messages
                         r = waiter.WaitForOne(waitpid_options=WNOHANG)
+                        while r == process.W1_OK:
+                            r = waiter.WaitForOne(waitpid_options=WNOHANG)
                         quit = True
                     elif case(parse_result_e.Eof):
                         display.EraseLines()

--- a/core/main_loop.py
+++ b/core/main_loop.py
@@ -24,6 +24,7 @@ from mycpp.mylib import log, print_stderr, tagswitch
 
 import fanos
 import posix_ as posix
+from posix_ import WNOHANG
 
 from typing import cast, Any, List, TYPE_CHECKING
 if TYPE_CHECKING:
@@ -190,20 +191,19 @@ class Headless(object):
         return 0
 
 
-def Interactive(flag, cmd_ev, c_parser, display, prompt_plugin, errfmt):
-    # type: (arg_types.main, CommandEvaluator, CommandParser, _IDisplay, UserPlugin, ErrorFormatter) -> int
-
-    # TODO: Any could be _Attributes from frontend/args.py
+def Interactive(flag, cmd_ev, c_parser, display, prompt_plugin, waiter, errfmt):
+    # type: (arg_types.main, CommandEvaluator, CommandParser, _IDisplay, UserPlugin, process.Waiter, ErrorFormatter) -> int
 
     status = 0
     done = False
     while not done:
         mylib.MaybeCollect()  # manual GC point
 
-        # - This loop has a an odd structure because we want to do cleanup after
-        # every 'break'.  (The ones without 'done = True' were 'continue')
+        # - This loop has a an odd structure because we want to do cleanup
+        #   after every 'break'.  (The ones without 'done = True' were
+        #   'continue')
         # - display.EraseLines() needs to be called BEFORE displaying anything, so
-        # it appears in all branches.
+        #   it appears in all branches.
 
         while True:  # ONLY EXECUTES ONCE
             quit = False
@@ -215,6 +215,9 @@ def Interactive(flag, cmd_ev, c_parser, display, prompt_plugin, errfmt):
                 with tagswitch(result) as case:
                     if case(parse_result_e.EmptyLine):
                         display.EraseLines()
+                        # POSIX shell behavior: waitpid(-1) and show job "Done"
+                        # messages
+                        r = waiter.WaitForOne(waitpid_options=WNOHANG)
                         quit = True
                     elif case(parse_result_e.Eof):
                         display.EraseLines()
@@ -269,6 +272,9 @@ def Interactive(flag, cmd_ev, c_parser, display, prompt_plugin, errfmt):
                 break
 
             status = cmd_ev.LastStatus()
+
+            r = waiter.WaitForOne(waitpid_options=WNOHANG)
+
             if is_return:
                 done = True
                 break

--- a/core/process.py
+++ b/core/process.py
@@ -1749,6 +1749,7 @@ class JobList(object):
 # Some WaitForOne() return values
 W1_OK = -2  # waitpid(-1) returned
 W1_ECHILD = -3  # no processes to wait for
+W1_AGAIN = -4 # WNOHANG was passed and there were no state changes
 
 
 class Waiter(object):
@@ -1819,7 +1820,7 @@ class Waiter(object):
         """
         pid, status = pyos.WaitPid(waitpid_options)
         if pid == 0:  # WNOHANG passed, and no state changes
-            return W1_OK
+            return W1_AGAIN
         elif pid < 0:  # error case
             err_num = status
             #log('waitpid() error => %d %s', e.errno, pyutil.strerror(e))

--- a/core/process.py
+++ b/core/process.py
@@ -1875,3 +1875,11 @@ class Waiter(object):
         self.last_status = status  # for wait -n
         self.tracer.OnProcessEnd(pid, status)
         return W1_OK
+
+    def PollNotifications(self):
+        # type: () -> None
+        """
+        Process all pending state changes.
+        """
+        while self.WaitForOne(waitpid_options=posix.WNOHANG) == W1_OK:
+            continue

--- a/core/process.py
+++ b/core/process.py
@@ -1527,7 +1527,11 @@ class JobList(object):
         self.child_procs = {}  # type: Dict[int, Process]
         self.debug_pipelines = []  # type: List[Pipeline]
 
-        self.job_id = 1  # Strictly increasing
+        # Counter used to assign IDs to jobs. It is incremented every time a job
+        # is created. Once all active jobs are done it is reset to 1. I'm not
+        # sure if this reset behavior is mandated by POSIX, but other shells do
+        # it, so we mimick for the sake of compatability.
+        self.job_id = 1
 
     def AddJob(self, job):
         # type: (Job) -> int
@@ -1544,7 +1548,7 @@ class JobList(object):
         job_id = self.job_id
         self.jobs[job_id] = job
         job.job_id = job_id
-        self.job_id += 1  # For now, the ID is ever-increasing.
+        self.job_id += 1
         return job_id
 
     def RemoveJob(self, job_id):
@@ -1552,8 +1556,6 @@ class JobList(object):
         """Process and Pipeline can call this."""
         mylib.dict_erase(self.jobs, job_id)
 
-        # Reset job counter when all jobs finish to compatability with bash and
-        # others.
         if len(self.jobs) == 0:
             self.job_id = 1
 

--- a/core/process.py
+++ b/core/process.py
@@ -51,6 +51,7 @@ from posix_ import (
     WEXITSTATUS,
     WSTOPSIG,
     WTERMSIG,
+    WNOHANG,
     O_APPEND,
     O_CREAT,
     O_NONBLOCK,
@@ -1881,5 +1882,5 @@ class Waiter(object):
         """
         Process all pending state changes.
         """
-        while self.WaitForOne(waitpid_options=posix.WNOHANG) == W1_OK:
+        while self.WaitForOne(waitpid_options=WNOHANG) == W1_OK:
             continue

--- a/core/process.py
+++ b/core/process.py
@@ -1781,12 +1781,6 @@ class Waiter(object):
         self.tracer = tracer
         self.last_status = 127  # wait -n error code
 
-    #def CheckForNotifications(self):
-    #    """
-    #    Called by main_loop::Interactive()
-    #    """
-    #    pid, status = pyos.WaitPid(WNOHANG)
-
     def WaitForOne(self, waitpid_options=0):
         # type: (int) -> int
         """Wait until the next process returns (or maybe Ctrl-C).

--- a/core/pyos.py
+++ b/core/pyos.py
@@ -34,15 +34,21 @@ def FlushStdout():
     sys.stdout.flush()
 
 
-def WaitPid():
-    # type: () -> Tuple[int, int]
+def WaitPid(waitpid_options):
+    # type: (int) -> Tuple[int, int]
+    """
+    Return value:
+      pid is 0 if WNOHANG passed, and nothing has changed state
+      status: value that can be parsed with WIFEXITED() etc.
+    """
     try:
         # Notes:
         # - The arg -1 makes it like wait(), which waits for any process.
         # - WUNTRACED is necessary to get stopped jobs.  What about WCONTINUED?
         # - We don't retry on EINTR, because the 'wait' builtin should be
         #   interruptable.
-        pid, status = posix.waitpid(-1, WUNTRACED)
+        # - waitpid_options can be WNOHANG
+        pid, status = posix.waitpid(-1, WUNTRACED | waitpid_options)
     except OSError as e:
         return -1, e.errno
 

--- a/core/shell.py
+++ b/core/shell.py
@@ -890,7 +890,7 @@ def Main(lang, arg_r, environ, login_shell, loader, readline):
             prompt_plugin = prompt.UserPlugin(mem, parse_ctx, cmd_ev, errfmt)
             try:
                 status = main_loop.Interactive(flag, cmd_ev, c_parser, display,
-                                               prompt_plugin, errfmt)
+                                               prompt_plugin, waiter, errfmt)
             except util.UserExit as e:
                 status = e.status
 

--- a/cpp/core.cc
+++ b/cpp/core.cc
@@ -26,9 +26,9 @@ namespace pyos {
 
 SignalSafe* gSignalSafe = nullptr;
 
-Tuple2<int, int> WaitPid() {
+Tuple2<int, int> WaitPid(int waitpid_options) {
   int status;
-  int result = ::waitpid(-1, &status, WUNTRACED);
+  int result = ::waitpid(-1, &status, WUNTRACED | waitpid_options);
   if (result < 0) {
     if (errno == EINTR && gSignalSafe->PollSigInt()) {
       throw Alloc<KeyboardInterrupt>();

--- a/cpp/core.h
+++ b/cpp/core.h
@@ -35,7 +35,7 @@ const int EOF_SENTINEL = 256;
 const int NEWLINE_CH = 10;
 const int UNTRAPPED_SIGWINCH = -1;
 
-Tuple2<int, int> WaitPid();
+Tuple2<int, int> WaitPid(int waitpid_options);
 Tuple2<int, int> Read(int fd, int n, List<Str*>* chunks);
 Tuple2<int, int> ReadByte(int fd);
 Str* ReadLine();

--- a/cpp/core_test.cc
+++ b/cpp/core_test.cc
@@ -144,7 +144,7 @@ TEST pyos_test() {
   ASSERT(t.at1() >= 0.0);
   ASSERT(t.at2() >= 0.0);
 
-  Tuple2<int, int> result = pyos::WaitPid();
+  Tuple2<int, int> result = pyos::WaitPid(0);
   ASSERT_EQ(-1, result.at0());  // no children to wait on
 
   // This test isn't hermetic but it should work in most places, including in a

--- a/osh/builtin_process.py
+++ b/osh/builtin_process.py
@@ -180,22 +180,22 @@ class Exec(vm._Builtin):
 
 class Wait(vm._Builtin):
     """
-  wait: wait [-n] [id ...]
-      Wait for job completion and return exit status.
+    wait: wait [-n] [id ...]
+        Wait for job completion and return exit status.
 
-      Waits for each process identified by an ID, which may be a process ID or a
-      job specification, and reports its termination status.  If ID is not
-      given, waits for all currently active child processes, and the return
-      status is zero.  If ID is a a job specification, waits for all processes
-      in that job's pipeline.
+        Waits for each process identified by an ID, which may be a process ID or a
+        job specification, and reports its termination status.  If ID is not
+        given, waits for all currently active child processes, and the return
+        status is zero.  If ID is a a job specification, waits for all processes
+        in that job's pipeline.
 
-      If the -n option is supplied, waits for the next job to terminate and
-      returns its exit status.
+        If the -n option is supplied, waits for the next job to terminate and
+        returns its exit status.
 
-      Exit Status:
-      Returns the status of the last ID; fails if ID is invalid or an invalid
-      option is given.
-  """
+        Exit Status:
+        Returns the status of the last ID; fails if ID is invalid or an invalid
+        option is given.
+    """
 
     def __init__(self, waiter, job_list, mem, tracer, errfmt):
         # type: (Waiter, process.JobList, Mem, dev.Tracer, ErrorFormatter) -> None
@@ -280,13 +280,13 @@ class Wait(vm._Builtin):
                 raise error.Usage('expected PID or jobspec, got %r' % job_id,
                                   location)
 
-            job = self.job_list.JobFromPid(pid)
-            if job is None:
+            pr = self.job_list.ProcessFromPid(pid)
+            if pr is None:
                 self.errfmt.Print_("%d isn't a child of this shell" % pid,
                                    blame_loc=location)
                 return 127
 
-            wait_st = job.JobWait(self.waiter)
+            wait_st = pr.JobWait(self.waiter)
             UP_wait_st = wait_st
             with tagswitch(wait_st) as case:
                 if case(wait_status_e.Proc):

--- a/osh/builtin_process.py
+++ b/osh/builtin_process.py
@@ -90,7 +90,7 @@ class Fg(vm._Builtin):
         job.state = job_state_e.Running
         posix.killpg(pgid, SIGCONT)
 
-        status = 1 # error
+        status = -1
         wait_st = job.JobWait(self.waiter)
         UP_wait_st = wait_st
         with tagswitch(wait_st) as case:

--- a/spec/stateful/interactive.py
+++ b/spec/stateful/interactive.py
@@ -37,6 +37,7 @@ def bg_proc_notify(sh):
   expect_prompt(sh)
 
   sh.sendline('sleep 0.1 &')
+  sh.sendline('sleep 0.3 &')
 
   if sh.shell_label == 'bash':
     # e.g. [1] 12345
@@ -47,9 +48,10 @@ def bg_proc_notify(sh):
   expect_prompt(sh)
 
   # Wait until after it stops and then hit enter
-  time.sleep(0.2)
+  time.sleep(0.4)
   sh.sendline('')
-
+  sh.expect(r'.*Done.*')
+  sh.sendline('')
   sh.expect(r'.*Done.*')
 
   sh.sendline('echo status=$?')

--- a/spec/stateful/interactive.py
+++ b/spec/stateful/interactive.py
@@ -31,8 +31,8 @@ def syntax_error(sh):
 
 
 @register()
-def syntax_error(sh):
-  'notification about background job (issue 1093)'
+def bg_proc_notify(sh):
+  'notification about background process (issue 1093)'
 
   expect_prompt(sh)
 
@@ -49,6 +49,35 @@ def syntax_error(sh):
   # Wait until after it stops and then hit enter
   time.sleep(0.2)
   sh.sendline('')
+
+  sh.expect(r'.*Done.*')
+
+  sh.sendline('echo status=$?')
+  sh.expect('status=0')
+
+@register()
+def bg_pipeline_notify(sh):
+  'notification about background pipeline (issue 1093)'
+
+  expect_prompt(sh)
+
+  sh.sendline('sleep 0.1 | cat &')
+
+  if sh.shell_label == 'bash':
+    # e.g. [1] 12345
+    # not using trailing + because pexpect doc warns about that case
+    # dash doesn't print this
+    sh.expect(r'\[\d+\]')
+
+  expect_prompt(sh)
+
+  time.sleep(0.2)
+  sh.sendline('')
+  if 'osh' in sh.shell_label:
+      # need to wake up from wait() twice in osh
+      # TODO: can we avoid this? how do bash and others handle this?
+      expect_prompt(sh)
+      sh.sendline('')
 
   sh.expect(r'.*Done.*')
 

--- a/spec/stateful/interactive.py
+++ b/spec/stateful/interactive.py
@@ -55,12 +55,7 @@ def bg_proc_notify(sh):
   # Wait until after it stops and then hit enter
   time.sleep(0.4)
   sh.sendline('')
-  if 'osh' in sh.shell_label:
-      sh.expect(r'.*Done.*')
-      sh.sendline('')
-      sh.expect(r'.*Done.*')
-  else:
-      sh.expect(r'.*Done.*Done.*')
+  sh.expect(r'.*Done.*Done.*')
 
   sh.sendline('echo status=$?')
   sh.expect('status=0')
@@ -83,11 +78,6 @@ def bg_pipeline_notify(sh):
 
   time.sleep(0.2)
   sh.sendline('')
-  if 'osh' in sh.shell_label:
-      # need to wake up from wait() twice in osh
-      # TODO: can we avoid this? how do bash and others handle this?
-      expect_prompt(sh)
-      sh.sendline('')
 
   sh.expect(r'.*Done.*')
 

--- a/spec/stateful/interactive.py
+++ b/spec/stateful/interactive.py
@@ -37,8 +37,13 @@ def bg_proc_notify(sh):
   expect_prompt(sh)
 
   sh.sendline('sleep 0.1 &')
-  sh.sendline('sleep 0.3 &')
+  if sh.shell_label == 'bash':
+    # e.g. [1] 12345
+    # not using trailing + because pexpect doc warns about that case
+    # dash doesn't print this
+    sh.expect(r'\[\d+\]')
 
+  sh.sendline('sleep 0.2 &')
   if sh.shell_label == 'bash':
     # e.g. [1] 12345
     # not using trailing + because pexpect doc warns about that case
@@ -50,9 +55,12 @@ def bg_proc_notify(sh):
   # Wait until after it stops and then hit enter
   time.sleep(0.4)
   sh.sendline('')
-  sh.expect(r'.*Done.*')
-  sh.sendline('')
-  sh.expect(r'.*Done.*')
+  if 'osh' in sh.shell_label:
+      sh.expect(r'.*Done.*')
+      sh.sendline('')
+      sh.expect(r'.*Done.*')
+  else:
+      sh.expect(r'.*Done.*Done.*')
 
   sh.sendline('echo status=$?')
   sh.expect('status=0')

--- a/spec/stateful/job_control.py
+++ b/spec/stateful/job_control.py
@@ -405,6 +405,28 @@ def fg_job_id(sh):
   sh.expect('bar')
 
 
+@register()
+def wait_job_spec(sh):
+  'Wait using a job spec'
+  expect_prompt(sh)
+
+  sh.sendline('(sleep 2; exit 11) &')
+  sh.sendline('(sleep 1; exit 22) &')
+  sh.sendline('(sleep 3; exit 33) &')
+
+  time.sleep(1)
+  sh.sendline('wait %2; echo status=$?')
+  sh.expect('status=22')
+
+  time.sleep(1)
+  sh.sendline('wait %-; echo status=$?')
+  sh.expect('status=11')
+
+  time.sleep(1)
+  sh.sendline('wait %+; echo status=$?')
+  sh.expect('status=33')
+
+
 if __name__ == '__main__':
   try:
     sys.exit(harness.main(sys.argv))

--- a/spec/stateful/job_control.py
+++ b/spec/stateful/job_control.py
@@ -280,7 +280,7 @@ def no_spurious_tty_take(sh):
   # background cat should have been stopped by SIGTTIN immediately, but we don't
   # hear about it from wait() until the foreground process has been started because
   # the shell was blocked in readline when the signal fired.
-  sh.sendline('python2 -c "import sys; print(sys.stdin.readline().strip() + \'bar\')"')
+  sh.sendline(PYCAT % 'bar')
   time.sleep(0.1)  # seems necessary
   if 'osh' in sh.shell_label:
     # Quirk of osh. TODO: supress this print for background jobs?

--- a/spec/ysh-xtrace.test.sh
+++ b/spec/ysh-xtrace.test.sh
@@ -378,7 +378,7 @@ sed --regexp-extended 's/[[:digit:]]{2,}/12345/g' err.txt |
 > wait
 > wait
 [1] Done PID 12345
-[2] Done PID 12345
+[1] Done PID 12345
 | fork 12345
 | fork 12345
 ## END

--- a/spec/ysh-xtrace.test.sh
+++ b/spec/ysh-xtrace.test.sh
@@ -337,6 +337,7 @@ status=0
 . builtin set '+x'
 < wait
 > wait
+[1] Done PGID 12345
 | part 12345
 | part 12345
 | part 12345
@@ -376,6 +377,8 @@ sed --regexp-extended 's/[[:digit:]]{2,}/12345/g' err.txt |
 < wait
 > wait
 > wait
+[1] Done PID 12345
+[2] Done PID 12345
 | fork 12345
 | fork 12345
 ## END

--- a/test/stateful.sh
+++ b/test/stateful.sh
@@ -50,7 +50,7 @@ signals() {
 }
 
 interactive() {
-  spec/stateful/interactive.py $FIRST --oils-failures-allowed 1 "$@"
+  spec/stateful/interactive.py $FIRST "$@"
 }
 
 job-control() {


### PR DESCRIPTION
 [core] print notifications when bg jobs complete

To support notifying users about the completion of background jobs, this
commit updates the main loop for the interactive shell to pass the
WNOHANG to `WaitPid()`, adds state to `Job` about background/foreground
positioning. It also removes the `WhenDone()` method from `JobList` to
make reading the job completion codepath easier.

 [core] only take back tty on stop if necessary

When the main shell wakes up from wait() with WIFSTOPPED, it
unconditionally takes back the TTY from whichever process was just
stopped. This can cause problems when running background jobs, though.

Consider the following script:

  $ cat &
  $ cat

The first cat is forked and placed into its own process group. The shell
remains in the foreground. This means cat will immediately be stopped
with SIGTTIN when it tries to read from stdin. The main shell doesn't
know this yet, though! It's blocked waiting for input from readline. The
second cat is forked and placed into its own group, just like the first
one; and since it's running in the foreground, the main shell gives it
control of the TTY. After handing over the TTY the shell finally gets
notified about the first cat being stopped (as expected) via wait() and
does some post-stop bookkeeping, including taking back the TTY! This
causes the second cat to immediately get stopped by SIGTTIN, confusing
the user.

To avoid this awkward behavior, this commit updates the post-stop
bookkeeping to only take back the terminal from processes that were
originally running in the foreground.


[core] overhaul job control

- Remove JobList::WhenContinued(). It was only used in one place.
- Add support for POSIX job specs (%[0-9]+, %%, %-, %+, %) in `fg` builtin
- Add Job::ProcessGroupId() and refactor `fg` to deal with process groups and wait better
- Remove JobList::last_stopped_job. %+ and %- are computed by the builtins now
- Add a few more test to spec/stateful/job_control

[builtin/wait] Support "job spec" arguments
