### PR TITLE
[core] only take back tty on stop if necessary

### DIFF
--- a/core/process.py
+++ b/core/process.py
@@ -617,7 +617,6 @@ class SetPgid(ChildStateChange):
         # type: (Process) -> None
         try:
             posix.setpgid(proc.pid, self.pgid)
-            proc.pgid = self.pgid
         except (IOError, OSError) as e:
             print_stderr(
                 'osh: parent failed to set process group for PID %d to %d: %s' %
@@ -1021,8 +1020,7 @@ class Process(Job):
         for st in self.state_changes:
             st.ApplyFromParent(self)
 
-        if self.pgid == -1:
-            self.pgid = pid
+        self.pgid = posix.getpgid(pid)
 
         # Program invariant: We keep track of every child process!
         self.job_list.AddChildProcess(pid, self)

--- a/core/process.py
+++ b/core/process.py
@@ -87,6 +87,7 @@ STYLE_DEFAULT = 0
 STYLE_LONG = 1
 STYLE_PID_ONLY = 2
 
+POSITION_UNSET = -1
 POSITION_BACKGROUND = 0
 POSITION_FOREGROUND = 1
 
@@ -924,7 +925,7 @@ class Process(Job):
         self.close_w = -1
 
         self.pid = -1
-        self.pgid = -1
+        self.position = POSITION_UNSET
         self.status = -1
 
     def Init_ParentPipeline(self, pi):
@@ -1024,8 +1025,6 @@ class Process(Job):
         # racing in calls to tcsetpgrp() in the parent. See APUE sec. 9.2.
         for st in self.state_changes:
             st.ApplyFromParent(self)
-
-        self.pgid = posix.getpgid(pid)
 
         # Program invariant: We keep track of every child process!
         self.job_list.AddChildProcess(pid, self)

--- a/spec/stateful/job_control.py
+++ b/spec/stateful/job_control.py
@@ -268,10 +268,11 @@ def suspend_status(sh):
 
 @register(skip_shells=['zsh'])
 def no_spurious_tty_take(sh):
-  'A background job getting stopped by SIGTTIN should not disrupt foreground processes'
+  'A background job getting stopped (e.g. by SIGTTIN) or exiting should not disrupt foreground processes'
   expect_prompt(sh)
 
-  sh.sendline('cat &')
+  sh.sendline('cat &') # stop
+  sh.sendline('sleep 1 &') # exit
   time.sleep(0.1)  # seems necessary
 
   # background cat should have been stopped by SIGTTIN immediately, but we don't

--- a/spec/stateful/job_control.py
+++ b/spec/stateful/job_control.py
@@ -266,7 +266,7 @@ def suspend_status(sh):
   expect_prompt(sh)
 
 
-@register()
+@register(skip_shells=['zsh'])
 def no_spurious_tty_take(sh):
   'A background job getting stopped by SIGTTIN should not disrupt foreground processes'
   expect_prompt(sh)
@@ -277,8 +277,10 @@ def no_spurious_tty_take(sh):
   # background cat should have been stopped by SIGTTIN immediately, but we don't
   # hear about it from wait() until the foreground job has been started because
   # the shell was blocked in readline when the signal fired.
-  sh.sendline('python -c "import sys; print(sys.stdin.readline().strip() + \'bar\')"')
-  sh.expect('.*Stopped.*')
+  sh.sendline('python2 -c "import sys; print(sys.stdin.readline().strip() + \'bar\')"')
+  if 'osh' in sh.shell_label:
+    # Quirk of osh. TODO: supress this print for background jobs?
+    sh.expect('.*Stopped.*')
 
   # foreground cat should not have been stopped.
   sh.sendline('foo')

--- a/spec/stateful/job_control.py
+++ b/spec/stateful/job_control.py
@@ -275,14 +275,14 @@ def no_spurious_tty_take(sh):
   time.sleep(0.1)  # seems necessary
 
   # background cat should have been stopped by SIGTTIN immediately, but we don't
-  # hear about it from wait() until the foreground job has been started because
+  # hear about it from wait() until the foreground process has been started because
   # the shell was blocked in readline when the signal fired.
   sh.sendline('python2 -c "import sys; print(sys.stdin.readline().strip() + \'bar\')"')
   if 'osh' in sh.shell_label:
     # Quirk of osh. TODO: supress this print for background jobs?
     sh.expect('.*Stopped.*')
 
-  # foreground cat should not have been stopped.
+  # foreground procoess should not have been stopped.
   sh.sendline('foo')
   sh.expect('foobar')
 


### PR DESCRIPTION
When the main shell wakes up from wait() with WIFSTOPPED, it unconditionally takes back the TTY from whichever process was just stopped. This can cause problems when running background jobs, though.

Consider the following script:
```bash
  $ cat &
  $ cat
```
The first cat is forked and placed into its own process group. The shell remains in the foreground. This means cat will immediately be stopped with SIGTTIN when it tries to read from stdin. The main shell doesn't know this yet, though! It's blocked waiting for input from readline. The second cat is forked and placed into its own group, just like the first one; and since it's running in the foreground, the main shell gives it control of the TTY. After handing over the TTY the shell finally gets notified about the first cat being stopped (as expected) via wait() and does some post-stop bookkeeping, including taking back the TTY! This causes the second cat to immediately get stopped by SIGTTIN, confusing the user.

To avoid this awkward behavior, this commit updates the post-stop bookkeeping to only take back the terminal from processes that were originally running in the foreground.