### PR TITLE
[core] clean up child process state on exit

### DIFF
--- a/core/process.py
+++ b/core/process.py
@@ -1117,10 +1117,7 @@ class Process(Job):
                     print_stderr('[%d] Done PID %d' % (self.job_id, self.pid))
 
                 self.job_list.RemoveJob(self.job_id)
-
-                # TODO: The `wait` builtin depends on the process object hanging
-                # around after completion. Fix that then uncomment this line.
-                # self.job_list.RemoveChildProcess(self.pid)
+                self.job_list.RemoveChildProcess(self.pid)
 
             if not self.in_background:
                 self.job_control.MaybeTakeTerminal()

--- a/osh/builtin_process.py
+++ b/osh/builtin_process.py
@@ -290,8 +290,7 @@ class Wait(vm._Builtin):
         # Get list of jobs.  Then we need to check if they are ALL stopped.
         # Returns the exit code of the last one on the COMMAND LINE, not the exit
         # code of last one to FINISH.
-        status = 1  # error
-        jobs = [] # List[process.Job]
+        jobs = [] # type: List[process.Job]
         for i, job_id in enumerate(job_ids):
             location = arg_locs[i]
 
@@ -314,6 +313,7 @@ class Wait(vm._Builtin):
 
             jobs.append(job)
 
+        status = 1  # error
         for job in jobs:
             wait_st = job.JobWait(self.waiter)
             UP_wait_st = wait_st

--- a/osh/builtin_process.py
+++ b/osh/builtin_process.py
@@ -309,8 +309,6 @@ class Wait(vm._Builtin):
                 job = self.job_list.ProcessFromPid(pid)
 
             if job is None:
-                self.errfmt.Print_("%s isn't a child of this shell" % job_id,
-                                   blame_loc=location)
                 return 127
 
             wait_st = job.JobWait(self.waiter)

--- a/osh/builtin_process.py
+++ b/osh/builtin_process.py
@@ -309,6 +309,8 @@ class Wait(vm._Builtin):
                 job = self.job_list.ProcessFromPid(pid)
 
             if job is None:
+                self.errfmt.Print_("%s isn't a child of this shell" % job_id,
+                                   blame_loc=location)
                 return 127
 
             jobs.append(job)

--- a/osh/builtin_process.py
+++ b/osh/builtin_process.py
@@ -22,7 +22,7 @@ from frontend import typed_args
 
 import posix_ as posix
 
-from typing import TYPE_CHECKING, Optional, cast
+from typing import TYPE_CHECKING, List, Optional, cast
 if TYPE_CHECKING:
     from core.process import Waiter, ExternalProgram, FdState
     from core.state import Mem, SearchPath
@@ -291,6 +291,7 @@ class Wait(vm._Builtin):
         # Returns the exit code of the last one on the COMMAND LINE, not the exit
         # code of last one to FINISH.
         status = 1  # error
+        jobs = [] # List[process.Job]
         for i, job_id in enumerate(job_ids):
             location = arg_locs[i]
 
@@ -311,6 +312,9 @@ class Wait(vm._Builtin):
             if job is None:
                 return 127
 
+            jobs.append(job)
+
+        for job in jobs:
             wait_st = job.JobWait(self.waiter)
             UP_wait_st = wait_st
             with tagswitch(wait_st) as case:

--- a/spec/background.test.sh
+++ b/spec/background.test.sh
@@ -94,11 +94,11 @@ echo "status=$?"
 ## stdout-json: "status=7\nstatus=9\n"
 
 #### Wait on multiple specific IDs returns last status
-{ sleep 0.1; exit 8; } &
+{ sleep 0.08; exit 8; } &
 jid1=$!
-{ sleep 0.1; exit 9; } &
+{ sleep 0.09; exit 9; } &
 jid2=$!
-{ sleep 0.1; exit 7; } &
+{ sleep 0.07; exit 7; } &
 jid3=$!
 wait $jid1 $jid2 $jid3  # NOTE: not using %1 %2 %3 syntax on purpose
 echo "status=$?"  # third job I think

--- a/spec/background.test.sh
+++ b/spec/background.test.sh
@@ -87,18 +87,18 @@ echo "status=$?"
 pid1=$!
 { sleep 0.07; exit 7; } &
 pid2=$!
-wait $pid1
-echo "status=$?"
 wait $pid2
 echo "status=$?"
-## stdout-json: "status=9\nstatus=7\n"
+wait $pid1
+echo "status=$?"
+## stdout-json: "status=7\nstatus=9\n"
 
 #### Wait on multiple specific IDs returns last status
-{ sleep 0.08; exit 8; } &
+{ sleep 0.1; exit 8; } &
 jid1=$!
-{ sleep 0.09; exit 9; } &
+{ sleep 0.1; exit 9; } &
 jid2=$!
-{ sleep 0.07; exit 7; } &
+{ sleep 0.1; exit 7; } &
 jid3=$!
 wait $jid1 $jid2 $jid3  # NOTE: not using %1 %2 %3 syntax on purpose
 echo "status=$?"  # third job I think


### PR DESCRIPTION
Right now this table grows unbounded.

This commit also removes the log generated by `wait` when a job doesn't exist. This isn't a fundamental thing, but it keeps the spec tests "clean". Happy to roll that change back if you think the log will be helpful, @andychu.