### PR TITLE
[fix] Fix typos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ BYTECODE_ZIP := bytecode-opy.zip
 
 HAVE_OBJCOPY := $(shell command -v objcopy 2>/dev/null)
 
-# For faster tesing of builds
+# For faster testing of builds
 #default: _bin/oil.ovm-dbg
 
 # What the end user should build when they type 'make'.

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ These files make the slow "Oils Python" build, which is very different than the
     configure
     install
 
-These files are for teh C++ `oils-for-unix` tarball (in progress):
+These files are for the C++ `oils-for-unix` tarball (in progress):
 
     _build/
       oils.sh

--- a/asdl/gen_cpp.py
+++ b/asdl/gen_cpp.py
@@ -342,7 +342,7 @@ class ClassDefVisitor(visitor.AsdlVisitor):
         # This is the base class.
         Emit('class %(sum_name)s_t {')
         # Can't be constructed directly.  Note: this shows up in uftrace in debug
-        # mode, e.g. when we intantiate Token.  Do we need it?
+        # mode, e.g. when we instantiate Token.  Do we need it?
         Emit(' protected:')
         Emit('  %s_t() {' % sum_name)
         Emit('  }')

--- a/asdl/gen_python.py
+++ b/asdl/gen_python.py
@@ -522,7 +522,7 @@ class GenMyPyVisitor(visitor.AsdlVisitor):
             if variant.shared_type:
                 continue  # Don't generate a class for shared types.
             if len(variant.fields) == 0:
-                # We must use the old-style nameing here, ie. command__NoOp, in order
+                # We must use the old-style naming here, ie. command__NoOp, in order
                 # to support zero field variants as constants.
                 class_name = '%s__%s' % (sum_name, variant.name)
                 self._GenClass(variant, class_name, (sum_name + '_t',), i + 1)

--- a/benchmarks/osh-parser.sh
+++ b/benchmarks/osh-parser.sh
@@ -427,7 +427,7 @@ EOF
   fi
 
   if test -f $in_dir/elapsed.csv; then
-    cmark <<< '#### Elasped Time (milliseconds)'
+    cmark <<< '#### Elapsed Time (milliseconds)'
     echo
     csv2html $in_dir/elapsed.csv
   fi

--- a/benchmarks/pypy.sh
+++ b/benchmarks/pypy.sh
@@ -33,7 +33,7 @@ parse-with-cpython() {
 
 # ~4.8 seconds
 # NOTE: We could run it in a loop to see if the JIT warms up, but that would
-# only be for curiousity.  Most shell processes are short-lived, so it's the
+# only be for curiosity.  Most shell processes are short-lived, so it's the
 # wrong thing to optimize for.
 parse-with-pypy() {
   parse-abuild $PYPY

--- a/benchmarks/report.R
+++ b/benchmarks/report.R
@@ -5,7 +5,7 @@
 # Usage:
 #   benchmarks/report.R OUT_DIR [TIMES_CSV...]
 
-# Supress warnings about functions masked from 'package:stats' and 'package:base'
+# Suppress warnings about functions masked from 'package:stats' and 'package:base'
 #   filter, lag
 #   intersect, setdiff, setequal, union
 library(dplyr, warn.conflicts = FALSE)
@@ -1199,7 +1199,7 @@ Percent = function(n, total) {
 }
 
 PrettyPrintLong = function(d) {
-  tr = t(d)  # tranpose
+  tr = t(d)  # transpose
 
   row_names = rownames(tr)
 

--- a/benchmarks/vm-baseline.sh
+++ b/benchmarks/vm-baseline.sh
@@ -28,7 +28,7 @@ measure() {
   # TODO:
   # print-tasks should:
   # - use the whole shell path like _bin/osh
-  # - the host name shoudl be a column
+  # - the host name should be a column
   # - the join ID can be a file, and construct the task name from that
   # - Then maybe use tsv_columns_from_files.py like we do with cachegrind
 

--- a/build/common.sh
+++ b/build/common.sh
@@ -37,10 +37,10 @@ readonly CLANGXX=$CLANG_DIR/bin/clang++
 # I'm not sure if there's a GCC version of this?
 export ASAN_SYMBOLIZER_PATH=$CLANG_DIR_RELATIVE/bin/llvm-symbolizer
 
-# ThreadSanitizer doesn't always give us all locaitons, but this doesn't help
+# ThreadSanitizer doesn't always give us all locations, but this doesn't help
 # export TSAN_SYMBOLIZER_PATH=$ASAN_SYMBOLIZER_PATH
 
-# equivalent of 'cc' for C++ langauge
+# equivalent of 'cc' for C++ language
 # https://stackoverflow.com/questions/172587/what-is-the-difference-between-g-and-gcc
 CXX=${CXX:-'c++'}
 

--- a/build/cpython_defs.py
+++ b/build/cpython_defs.py
@@ -388,7 +388,7 @@ class OilMethodFilter(object):
 
     #log('= %s %s', def_name, method_name)
 
-    # If it doesn't appear in the .py source, it can't be used.  (Execption: it
+    # If it doesn't appear in the .py source, it can't be used.  (Exception: it
     # coudl be used in C source with dynamic lookup?  But I don't think CPython
     # does that.)
     #if method_name not in self.py_names:

--- a/build/cpython_defs.py
+++ b/build/cpython_defs.py
@@ -389,7 +389,7 @@ class OilMethodFilter(object):
     #log('= %s %s', def_name, method_name)
 
     # If it doesn't appear in the .py source, it can't be used.  (Exception: it
-    # coudl be used in C source with dynamic lookup?  But I don't think CPython
+    # could be used in C source with dynamic lookup?  But I don't think CPython
     # does that.)
     #if method_name not in self.py_names:
     if 0:

--- a/build/deps.sh
+++ b/build/deps.sh
@@ -96,7 +96,7 @@ install-ubuntu-packages() {
   ### Packages for build/py.sh all, building wedges, etc.
 
   # python2-dev is no longer available on Debian 12
-  # python-dev als seems gone
+  # python-dev also seems gone
   #
   # g++: essential
   # libreadline-dev: needed for the build/prepare.sh Python build.
@@ -424,7 +424,7 @@ container-wedges() {
   # For soil-benchmarks/ images
   deps/wedge.sh build deps/source.medo/R-libs/
 
-  # Not sure if we need thsi
+  # Not sure if we need this
   #deps/wedge.sh build deps/source.medo/python3/
 }
 

--- a/build/dev-shell-test.sh
+++ b/build/dev-shell-test.sh
@@ -50,7 +50,7 @@ test-cli() {
 test-python2() {
   banner "Testing python2"
 
-  # Can't do this beacuse of vendor/typing.py issue.
+  # Can't do this because of vendor/typing.py issue.
   # log "Testing oils_for_unix.py"
   # bin/oils_for_unix.py --help | head -n 2
 

--- a/build/ovm-actions.sh
+++ b/build/ovm-actions.sh
@@ -182,7 +182,7 @@ join-modules() {
 
   # Filter out comments, print the first line.
   #
-  # TODO: I don't want to depend on egrep and GNU flags on the target sytems?
+  # TODO: I don't want to depend on egrep and GNU flags on the target systems?
   # Ship this file I guess.
   egrep --no-filename --only-matching '^[a-zA-Z0-9_\.]+' $static $discovered \
     | sort | uniq

--- a/core/alloc.py
+++ b/core/alloc.py
@@ -205,7 +205,7 @@ class Arena(object):
 
         Used for ALIAS expansion, which happens in the PARSER.
 
-        The argument to aliases can span multiple lines, like htis:
+        The argument to aliases can span multiple lines, like this:
 
         $ myalias '1     2     3'
         """

--- a/core/comp_ui.py
+++ b/core/comp_ui.py
@@ -572,7 +572,7 @@ def InitReadline(
     # This determines the boundaries you get back from get_begidx() and
     # get_endidx() at completion time!
     # We could be more conservative and set it to ' ', but then cases like
-    # 'ls|w<TAB>' would try to complete the whole thing, intead of just 'w'.
+    # 'ls|w<TAB>' would try to complete the whole thing, instead of just 'w'.
     #
     # Note that this should not affect the OSH completion algorithm.  It only
     # affects what we pass back to readline and what readline displays to the

--- a/core/dev.py
+++ b/core/dev.py
@@ -57,7 +57,7 @@ class CrashDumper(object):
 
     debug info for the source?  Or does that come elsewhere?
 
-    Yeah I think you sould have two separate files.
+    Yeah I think you should have two separate files.
     - debug info for a given piece of code (needs hash)
       - this could just be the raw source files?  Does it need anything else?
       - I think it needs a hash so the VM dump can refer to it.

--- a/core/main_loop.py
+++ b/core/main_loop.py
@@ -297,7 +297,7 @@ def Interactive(flag, cmd_ev, c_parser, display, prompt_plugin, waiter, errfmt):
 
         # TODO: Replace this with a shell hook?  with 'trap', or it could be just
         # like command_not_found.  The hook can be 'echo $?' or something more
-        # complicated, i.e. with timetamps.
+        # complicated, i.e. with timestamps.
         if flag.print_status:
             print('STATUS\t%r' % status)
 
@@ -311,7 +311,7 @@ def Batch(cmd_ev, c_parser, errfmt, cmd_flags=0):
     Returns:
       int status, e.g. 2 on parse error
 
-    Can this be combined with interative loop?  Differences:
+    Can this be combined with interactive loop?  Differences:
 
     - Handling of parse errors.
     - Have to detect here docs at the end?

--- a/core/process.py
+++ b/core/process.py
@@ -290,7 +290,7 @@ class FdState(object):
             fd2 = cast(redir_loc.Fd, UP_loc).fd
 
             if fd1 == fd2:
-                # The user could have asked for it to be open on descrptor 3, but open()
+                # The user could have asked for it to be open on descriptor 3, but open()
                 # already returned 3, e.g. echo 3>out.txt
                 return NO_FD
 
@@ -1260,7 +1260,7 @@ class Pipeline(Job):
 
             pid = proc.StartProcess(trace.PipelinePart)
             if i == 0 and pgid != INVALID_PGID:
-                # Mimick bash and use the PID of the first process as the group for the
+                # Mimic bash and use the PID of the first process as the group for the
                 # whole pipeline.
                 pgid = pid
 
@@ -1528,7 +1528,7 @@ class JobList(object):
         # Counter used to assign IDs to jobs. It is incremented every time a job
         # is created. Once all active jobs are done it is reset to 1. I'm not
         # sure if this reset behavior is mandated by POSIX, but other shells do
-        # it, so we mimick for the sake of compatability.
+        # it, so we mimic for the sake of compatibility.
         self.job_id = 1
 
     def AddJob(self, job):
@@ -1738,7 +1738,7 @@ class JobList(object):
         Used by 'wait' and 'wait -n'.
         """
         count = 0
-        for _, job in iteritems(self.jobs):  # mycpp rewite: from itervalues()
+        for _, job in iteritems(self.jobs):  # mycpp rewrite: from itervalues()
             if job.State() == job_state_e.Running:
                 count += 1
         return count

--- a/core/pyos.py
+++ b/core/pyos.py
@@ -46,7 +46,7 @@ def WaitPid(waitpid_options):
         # - The arg -1 makes it like wait(), which waits for any process.
         # - WUNTRACED is necessary to get stopped jobs.  What about WCONTINUED?
         # - We don't retry on EINTR, because the 'wait' builtin should be
-        #   interruptable.
+        #   interruptible.
         # - waitpid_options can be WNOHANG
         pid, status = posix.waitpid(-1, WUNTRACED | waitpid_options)
     except OSError as e:
@@ -113,7 +113,7 @@ def ReadLine():
     # type: () -> str
     """Read a line from stdin.
 
-    This is a SLOW PYTHON implementation taht calls read(0, 1) too many times.  I
+    This is a SLOW PYTHON implementation that calls read(0, 1) too many times.  I
     tried to write libc.stdin_readline() which uses the getline() function, but
     somehow that makes spec/oil-builtins.test.sh fail.  We use Python's
     f.readline() in frontend/reader.py FileLineReader with f == stdin.
@@ -362,8 +362,8 @@ class SignalSafe(object):
         # `self.pending_signals`. In the worst case the signal handler might write to
         # `new_queue` and the corresponding trap handler won't get executed
         # until the main loop calls this function again.
-        # NOTE: It's important to distinguish between signal-saftey an
-        # thread-saftey here. Signals run in the same process context as the main
+        # NOTE: It's important to distinguish between signal-safety an
+        # thread-safety here. Signals run in the same process context as the main
         # loop, while concurrent threads do not and would have to worry about
         # cache-coherence and instruction reordering.
         new_queue = []  #  type: List[int]

--- a/core/shell.py
+++ b/core/shell.py
@@ -883,7 +883,7 @@ def Main(lang, arg_r, environ, login_shell, loader, readline):
         process.InitInteractiveShell()  # Set signal handlers
 
         # The interactive shell leads a process group which controls the terminal.
-        # It MUST give up the termianl afterward, otherwise we get SIGTTIN /
+        # It MUST give up the terminal afterward, otherwise we get SIGTTIN /
         # SIGTTOU bugs.
         with process.ctx_TerminalControl(job_control, errfmt):
 

--- a/core/state.py
+++ b/core/state.py
@@ -402,7 +402,7 @@ class Hay(object):
         node = self._MakeOutputNode()
         self.result_stack = [node]
 
-        self.output = None  # remove last reuslt
+        self.output = None  # remove last result
 
     def PopEval(self):
         # type: () -> None
@@ -1981,7 +1981,7 @@ class Mem(object):
 
     def GetValue(self, name, which_scopes=scope_e.Shopt):
         # type: (str, scope_t) -> value_t
-        """Used by the WordEvaluator, ArithEvalutor, ysh/expr_eval.py, etc.
+        """Used by the WordEvaluator, ArithEvaluator, ysh/expr_eval.py, etc.
 
         TODO:
         - Many of these should be value.Int, not value.Str

--- a/core/state.py
+++ b/core/state.py
@@ -826,7 +826,7 @@ class MutableOpts(object):
         # type: (List[str]) -> None
         """For 'shopt -p'."""
 
-        # Respect option gropus.
+        # Respect option groups.
         opt_nums = []  # type: List[int]
         for opt_name in opt_names:
             opt_group = consts.OptionGroupNum(opt_name)

--- a/cpp/fanos_shared.h
+++ b/cpp/fanos_shared.h
@@ -5,7 +5,7 @@
 //
 // This library is shared between cpp/ and pyext/.
 
-// Callers should initalize
+// Callers should initialize
 //   FanosError to { 0, NULL }, and
 //   FanosResult to { NULL, FANOS_INVALID_LEN }
 

--- a/cpp/frontend_pyreadline.h
+++ b/cpp/frontend_pyreadline.h
@@ -5,13 +5,13 @@
 
 #include "mycpp/runtime.h"
 
-// hacky foward decl
+// hacky forward decl
 namespace completion {
 class ReadlineCallback;
 Str* ExecuteReadlineCallback(ReadlineCallback*, Str*, int);
 }  // namespace completion
 
-// hacky foward decl
+// hacky forward decl
 namespace comp_ui {
 class _IDisplay;
 void ExecutePrintCandidates(_IDisplay*, Str*, List<Str*>*, int);

--- a/cpp/stdlib.cc
+++ b/cpp/stdlib.cc
@@ -122,7 +122,7 @@ void execve(Str* argv0, List<Str*>* argv, Dict<Str*, Str*>* environ) {
     throw Alloc<OSError>(errno);
   }
 
-  // ::execve() never returns on succcess
+  // ::execve() never returns on success
   FAIL(kShouldNotGetHere);
 }
 
@@ -188,7 +188,7 @@ time_t time() {
 
 // NOTE(Jesse): time_t is specified to be an arithmetic type by C++. On most
 // systems it's a 64-bit integer.  64 bits is used because 32 will overflow in
-// 2038.  Someone on a comittee somewhere thought of that when moving to
+// 2038.  Someone on a committee somewhere thought of that when moving to
 // 64-bit architectures to prevent breaking ABI again; on 32-bit systems it's
 // usually 32 bits.  Point being, using anything but the time_t typedef here
 // could (unlikely, but possible) produce weird behavior.

--- a/data_lang/demo.sh
+++ b/data_lang/demo.sh
@@ -141,7 +141,7 @@ test-errors() {
   grep z "$byte_then_char" || true
   grep z "$char_then_byte" || true
 
-  # python doens't print it smehow?
+  # python doesn't print it somehow?
   banner 'python'
   # BUG: Python prints terminal sequences
   #python "$BOLD" || true

--- a/data_lang/demo.sh
+++ b/data_lang/demo.sh
@@ -84,7 +84,7 @@ test-programs() {
   ls --escape
   echo
   # Test out error message
-  # It's basicallly correct, but ugly.  There are too many segments, and
+  # It's basically correct, but ugly.  There are too many segments, and
   # there's an unnecessary leading ''.
   # QSN is shorter and more consistent.
 

--- a/demo/complete.sh
+++ b/demo/complete.sh
@@ -39,7 +39,7 @@ audit() {
 
   echo
   echo --
-  # Search for special complation var usage
+  # Search for special completion var usage
   grep -E --color 'COMP_[A-Z]+' $file
 
   echo

--- a/demo/coproc.sh
+++ b/demo/coproc.sh
@@ -55,7 +55,7 @@ simple-demo() {
   # In ksh or zsh, the pipes to and from the co-process are accessed with >&p
   # and <&p.
   # But in bash, the file descriptors of the pipe from the co-process and the
-  # other pipe to the co-proccess are returned in the $COPROC array
+  # other pipe to the co-process are returned in the $COPROC array
   # (respectively ${COPROC[0]} and ${COPROC[1]}.
 
   argv ${COPROC[@]}

--- a/demo/old/benchmarks-oheap.sh
+++ b/demo/old/benchmarks-oheap.sh
@@ -37,7 +37,7 @@ encode-all() {
     $0 encode-one
 }
 
-# Out of curiousity, compress oheap and originals.
+# Out of curiosity, compress oheap and originals.
 
 compress-oheap() {
   local c_dir=$BASE_DIR/oheap-compressed

--- a/demo/old/gen_oheap_cpp.py
+++ b/demo/old/gen_oheap_cpp.py
@@ -21,7 +21,7 @@ Technically we don't even need alignment?  I guess the reason is to increase
 address space.  If 1, then we have 16MiB of code.  If 4, then we have 64 MiB.
 
 Everything is decoded on the fly, or is a char*, which I don't think has to be
-aligned (because the natural alignment woudl be 1 byte anyway.)
+aligned (because the natural alignment would be 1 byte anyway.)
 """
 from __future__ import print_function
 

--- a/demo/old/old_code.py
+++ b/demo/old/old_code.py
@@ -68,14 +68,14 @@ class DynamicTdopParser(TdopParser):
 #
 
 
-# Possible optmization for later:
+# Possible optimization for later:
 def _TreeCount(tree_word):
   """Count output size for allocation purposes.
 
   We can count the number of words expanded into, and the max number of parts
   in a word.
 
-  Every word can have a differnt number of parts, e.g. -{'a'b,c}- expands into
+  Every word can have a different number of parts, e.g. -{'a'b,c}- expands into
   words of 4 parts, then 3 parts.
   """
   # TODO: Copy the structure of _BraceExpand and _BraceExpandOne.

--- a/demo/old/ovm.sh
+++ b/demo/old/ovm.sh
@@ -28,7 +28,7 @@ pp-vars() {
 
 # Modify this function to trace imports.  It helped with 're'.
 # Where do codecs.c and codecs.py get imported?
-# codecs.py is from encodings, but I don't nkow where that gets imported.
+# codecs.py is from encodings, but I don't know where that gets imported.
 #
 # I think runpy use encodings.
 blame-import() {

--- a/demo/old/ovm2/main.cc
+++ b/demo/old/ovm2/main.cc
@@ -511,7 +511,7 @@ class OHeap {
 
     // NOTE: This should be a Cell because we want to freeze it!
 
-    // This sould be a pointer to a slab.  TODO: So we need a function to
+    // This should be a pointer to a slab.  TODO: So we need a function to
     // allocate a slab with 3 fields?  code, globals, defaults are essential.
     // THen it could be small.
     //

--- a/demo/old/ovm2/oheap2.py
+++ b/demo/old/ovm2/oheap2.py
@@ -131,7 +131,7 @@ class Encoder(object):
     Write slabs as bytes, and then patch offsets in cells?
     Write all the cells
     Write the root object at the front of the file?  Or do it at the end?
-    OHeap writes it at the beginnig after
+    OHeap writes it at the beginning after
   """
 
   def __init__(self):

--- a/demo/shedskin/const.py
+++ b/demo/shedskin/const.py
@@ -19,7 +19,7 @@ DEFAULT_INT_WIDTH = 3  # 24 bits
 # extension on demand.  (24 bits to 32 or 64).  As far as I can tell, sign
 # extension requires a branch, at least in portable C (on the sign bit).
 #
-# Thes second option is semantically cleaner.  But it needlessly
+# The second option is semantically cleaner.  But it needlessly
 # inflates the size of both the source code and the data.  Instead of having a
 # single "inline" integer, we would need a reference to another value.
 #

--- a/demo/static-vs-dynamic-assignment.sh
+++ b/demo/static-vs-dynamic-assignment.sh
@@ -42,7 +42,7 @@ demo() {
   # Doh, this is parsed by bash and zsh too!  And mksh somewhat supports it.
   #
   # So how do we re-run the parser?  Or should we omit this for now?
-  # Don't allow dynamic a[x] assigments?  But 3 shells all implement it.
+  # Don't allow dynamic a[x] assignments?  But 3 shells all implement it.
 
   local e='array[1+1]=42'
   local "$e"     # This is a SINGLE assignment to a

--- a/devtools/format.sh
+++ b/devtools/format.sh
@@ -9,7 +9,7 @@ REPO_ROOT=$(cd "$(dirname $0)/.."; pwd)
 
 . build/dev-shell.sh  # python3 in $PATH
 
-# Hack to prevent interference.  TODO: Make a seperate wedge for yapf.
+# Hack to prevent interference.  TODO: Make a separate wedge for yapf.
 unset PYTHONPATH
 
 . build/common.sh  # $CLANG_DIR

--- a/devtools/release-note.sh
+++ b/devtools/release-note.sh
@@ -12,7 +12,7 @@ set -o pipefail
 set -o errexit
 
 source build/dev-shell.sh  # PYTHONPATH
-source devtools/release-version.sh  # for escape-segements
+source devtools/release-version.sh  # for escape-segments
 
 readonly OIL_VERSION=$(head -n 1 oil-version.txt)
 readonly PREV_VERSION='0.16.0'

--- a/devtools/services/README.md
+++ b/devtools/services/README.md
@@ -5,5 +5,5 @@ This directory is for integration with cloud services, e.g. code we don't
 control.
 
 Generally it's better to write plain shell scripts and call them from a config
-file (e.g. YAML), rather than embeddeding shell in the config.  Then it can be
+file (e.g. YAML), rather than embedding shell in the config.  Then it can be
 tested separately and ported to different platforms.

--- a/doc/hay.md
+++ b/doc/hay.md
@@ -598,7 +598,7 @@ control over error messages.
     oil --location-str 'foo.hay' --location-start-line 42 -- stage2.oil
 
 Set them to the values of fields `location_str` and `location_start_line` in
-the result of `SHELL` node evalution.
+the result of `SHELL` node evaluation.
 
 ### Debian `.d` Dirs
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -59,7 +59,7 @@ These docs are for advanced users:
 
 ### Comparisons
 
-- [YSH vs. Shell Idioms](idioms.html).  A list of code snipets.
+- [YSH vs. Shell Idioms](idioms.html).  A list of code snippets.
 - [YSH vs. Shell](ysh-vs-shell.html) &dagger;.  High-level descriptions: how does YSH
   differ from Bourne/POSIX shell?
 - [YSH vs. Python](ysh-vs-python.html) &dagger;.  How do YSH expressions differ

--- a/doc/interpreter-state.md
+++ b/doc/interpreter-state.md
@@ -103,7 +103,7 @@ TODO
 later: Oil adds references to data structures on the heap, which may be recurisve.
 -->
 
-### Enviroment Variables Become Global Variables
+### Environment Variables Become Global Variables
 
 On initialization, environment variables like `PYTHONPATH=.` are copied into
 the shell's memory as global variables, with the `export` flag set.

--- a/doc/old/modules.md
+++ b/doc/old/modules.md
@@ -66,7 +66,7 @@ Executable file.  Top level the same 4, plus `oil-main` at the bottom.
 
     oil-main  # dispatch to arguments in this module, except ones beginning with .
 
-## Usage Guidlines
+## Usage Guidelines
 
 - Distinguish between `.oil` files that are executable programs, and those that
   are libraries

--- a/doc/old/ysh-builtins.md
+++ b/doc/old/ysh-builtins.md
@@ -6,7 +6,7 @@ default_highlighter: oil-sh
 Oil Builtins
 ============
 
-<!-- TODO: This doc could be an alternative categorization to the auto-genrated
+<!-- TODO: This doc could be an alternative categorization to the auto-generated
      builtin-index.md ? -->
 
 This is an **overview** of [shell builtins]($xref:shell-builtin) that are

--- a/doc/osh.1
+++ b/doc/osh.1
@@ -26,7 +26,7 @@ The
 .Nm
 utility is a
 .Xr bash 1 Ns -compatible
-command language intepreter:
+command language interpreter:
 it reads commands either from standard input, a
 .Ar script
 file or command-line arguments and executes them.

--- a/doc/ref/chap-data-lang.md
+++ b/doc/ref/chap-data-lang.md
@@ -53,7 +53,7 @@ optional J prefix.
 
 ## TSV8
 
-These are the J8 Primtives (Bool, Int, Float, Str), separated by tabs.
+These are the J8 Primitives (Bool, Int, Float, Str), separated by tabs.
 
 
 ### column-attrs   

--- a/doc/syntactic-concepts.md
+++ b/doc/syntactic-concepts.md
@@ -58,7 +58,7 @@ shell, which evolved over many decades.
 For example, `:` means something different in each of these lines:
 
     PATH=/bin:/usr/bin          # Literal string
-    echo ${x:-default}          # Part of an opeartor
+    echo ${x:-default}          # Part of an operator
     echo $(( x > y ? 42 : 0 ))  # Arithmetic Operator
     var myslice = a[3:5]        # Oil expression
 

--- a/doc/word-eval.txt
+++ b/doc/word-eval.txt
@@ -220,7 +220,7 @@ FOR EACH WORD
 
    
 4. Elide certain frames.  IFS is whitespace && everything is unquoted and
-everythign is IFS
+everything is IFS
 
   $a$b
 

--- a/doctools/cmark.py
+++ b/doctools/cmark.py
@@ -174,7 +174,7 @@ class TocExtractor(HTMLParser.HTMLParser):
       self._AppendText(data)
 
   def _AppendText(self, text):
-    """Accumlate text of the last heading."""
+    """Accumulate text of the last heading."""
     _, _, _, _, text_parts = self.headings[-1]
     text_parts.append(text)
 

--- a/doctools/help_gen.py
+++ b/doctools/help_gen.py
@@ -82,7 +82,7 @@ _NOT_A_TOPIC = ['compatible', 'egrep']
 
 # BUGS:
 # - Continuation lines: hacked with ...
-# - Some X before puncutation aren't highlighted
+# - Some X before punctuation aren't highlighted
 
 X_LEFT_SPAN = '<span style="color: darkred">'
 

--- a/doctools/help_gen_test.py
+++ b/doctools/help_gen_test.py
@@ -29,7 +29,7 @@ class MakeHelpTest(unittest.TestCase):
 
   def testSplitIntoCards(self):
     contents = """
-<h2>Oil Expression Langauge</h2>
+<h2>Oil Expression Language</h2>
 
 expr
 

--- a/doctools/spelling.py
+++ b/doctools/spelling.py
@@ -124,7 +124,7 @@ def main(argv):
     # - Does it appear in the dictionary?  Problem: most computer terms
     # - Does it appear only once or twice in the whole corpus?
     # - Is the edit distance very close to a dictinoary word?
-    #   - e.g. subsitutions is a typo
+    #   - e.g. substitutions is a typo
 
   else:
     raise RuntimeError('Invalid action %r' % action)

--- a/doctools/spelling.sh
+++ b/doctools/spelling.sh
@@ -82,7 +82,7 @@ check-tree() {
   echo 'Word Counts'
   echo
 
-  # For curiousity: word count by file
+  # For curiosity: word count by file
   find $BASE_DIR/$subdir -name '*.words' | xargs wc -l | sort -n
 
   # Use alphabetical order

--- a/frontend/lexer_def.py
+++ b/frontend/lexer_def.py
@@ -23,7 +23,7 @@ generator adds and extra rule for \0.
 
 For example, use [^'\0]+ instead of [^']+ .
 
-If this rule isn't followed, we would read unitialized memory past the
+If this rule isn't followed, we would read uninitialized memory past the
 sentinel.  Python's regex engine knows where the end of the input string is, so
 it doesn't require need a sentinel like \0.
 """
@@ -398,7 +398,7 @@ LEXER_DEF[lex_mode_e.BashRegex] = _LEFT_SUBS + _LEFT_UNQUOTED + _VARS + [
     _TILDE_LIKE,  # bash weirdness: RHS of [[ x =~ ~ ]] is expanded
     _SIGNIFICANT_SPACE,
 
-    # Normally, \x evalutes to x.  But quoted regex metacharacters like \* should
+    # Normally, \x evaluates to x.  But quoted regex metacharacters like \* should
     # evaluate to \*.  Compare with ( | ).
     R(r'\\[*+?.^$\[\]]', Id.Lit_RegexMeta),
 
@@ -834,7 +834,7 @@ LOOKS_LIKE_INTEGER = _WHITESPACE + '-?' + _DECIMAL_INT_RE + _WHITESPACE
 # This is the same as far as I can tell?
 
 # This is a hand-written re2c rule to "refine" the _SIMPLE_FLOAT_RE token to
-# include undescores: 1_000.234_567
+# include underscores: 1_000.234_567
 
 LEXER_REFINEMENTS = {
     (lex_mode_e.Expr, Id.Expr_Float):

--- a/frontend/parse_lib.py
+++ b/frontend/parse_lib.py
@@ -187,7 +187,7 @@ if TYPE_CHECKING:
 class ParseContext(object):
     """Context shared between the mutually recursive Command and Word parsers.
 
-    In constrast, STATE is stored in the CommandParser and WordParser
+    In contrast, STATE is stored in the CommandParser and WordParser
     instances.
     """
 

--- a/frontend/syntax.asdl
+++ b/frontend/syntax.asdl
@@ -271,7 +271,7 @@ module syntax
       Token? right
   )
 
-  # The argument to match agains in a case command
+  # The argument to match against in a case command
   # In YSH-style case commands we match against an `expr`, but in sh-style case
   # commands we match against a word.
   case_arg =

--- a/lazylex/README.md
+++ b/lazylex/README.md
@@ -108,7 +108,7 @@ HTML has two levels:
   - Although it should generate arbitrary `<div name="val">` instead.  This
     allow natural plugins.  You can write `<div>` in Markdown, but it's
     annoying to manually escape `<` to `&gt;`, e.g. in graphviz or TeX.
-  HTML is analgous to shell.  A web site is a directory tree of text files!
+  HTML is analogous to shell.  A web site is a directory tree of text files!
   - It's better than the Snip `-->` syntax, which didn't play well with syntax
     highlighting.
 - Composable grammars: Is this the basis for Pulp?

--- a/lazylex/html.py
+++ b/lazylex/html.py
@@ -123,7 +123,7 @@ def MakeLexer(rules):
 
 
 LEXER = [
-  # TODO: instead of nongreedy matches, the loop can just fo .find('-->') and
+  # TODO: instead of nongreedy matches, the loop can just do .find('-->') and
   # .find('?>')
 
   # Actually non-greedy matches are regular and can be matched in linear time

--- a/library/func_hay.py
+++ b/library/func_hay.py
@@ -101,7 +101,7 @@ class EvalHay(vm._Callable):
 
         return self.hay_state.Result()
 
-        # Note: we should discourage the unvalidated top namesapce for files?  It
+        # Note: we should discourage the unvalidated top namespace for files?  It
         # needs more validation.
 
     def Call(self, pos_args, named_args):

--- a/metrics/native-code.sh
+++ b/metrics/native-code.sh
@@ -30,7 +30,7 @@ print-symbols() {
   echo
 
   # Top symbols
-  # fastlex_MatchToken is 21.2 KiB.  That doesn't seem to large compared ot
+  # fastlex_MatchToken is 21.2 KiB.  That doesn't seem to large compared to
   # the 14K line output?
   bloaty -d symbols $obj
   echo
@@ -95,7 +95,7 @@ collect-and-report() {
 
   symbols $opt > $base_dir/symbols.tsv
 
-  # Really 'transation units', but bloaty gives it that name.
+  # Really 'translation units', but bloaty gives it that name.
   compileunits $dbg > $base_dir/compileunits.tsv
 
   head $base_dir/symbols.tsv $base_dir/compileunits.tsv

--- a/mycpp/common.sh
+++ b/mycpp/common.sh
@@ -16,7 +16,7 @@ source mycpp/common-vars.sh
 maybe-our-python3() {
   ### Run a command line with Python 3
 
-  # Use Python 3.10 from deps/from-tar if available.  Otherwise use the sytsem
+  # Use Python 3.10 from deps/from-tar if available.  Otherwise use the system
   # python3.
 
   local py3_ours='../oil_DEPS/python3'

--- a/mycpp/cppgen_pass.py
+++ b/mycpp/cppgen_pass.py
@@ -1493,7 +1493,7 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
             if self.current_method_name in ('__init__', 'Reset'):
                 # Collect statements that look like self.foo = 1
                 # Only do this in __init__ so that a derived class mutating a field
-                # from the base calss doesn't cause duplicate C++ fields.  (C++
+                # from the base class doesn't cause duplicate C++ fields.  (C++
                 # allows two fields of the same name!)
                 #
                 # HACK for WordParser: also include Reset().  We could change them

--- a/mycpp/cppgen_pass.py
+++ b/mycpp/cppgen_pass.py
@@ -1127,7 +1127,7 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
         if o.begin_index:
             self.accept(o.begin_index)
         else:
-            self.write('0')  # implicit begining
+            self.write('0')  # implicit beginning
 
         if o.end_index:
             self.write(', ')

--- a/mycpp/demo/mypy_subtype.py
+++ b/mycpp/demo/mypy_subtype.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python2
 """
-Example of MyPy's ability to downcast a var under the same name in a functino.
+Example of MyPy's ability to downcast a var under the same name in a function.
 
 Our ASDL code gen will rely on this.
 """

--- a/mycpp/gc_obj.h
+++ b/mycpp/gc_obj.h
@@ -36,7 +36,7 @@ const unsigned kZeroMask = 0;  // for types with no pointers
 const int kMaxObjId = (1 << 30) - 1;  // 30 bit object ID
 const int kIsGlobal = kMaxObjId;      // for debugging, not strictly needed
 
-const int kUndefinedId = 0;  // Unitialized object ID
+const int kUndefinedId = 0;  // Uninitialized object ID
 
 // Every GC-managed object is preceded in memory by an ObjHeader.
 // TODO: ./configure could detect endian-ness, and reorder the fields in
@@ -48,7 +48,7 @@ struct ObjHeader {
   // Depending on heap_tag, up to 24 fields or 2**24 = 16 Mi pointers to scan
   unsigned u_mask_npointers : 24;
 #else
-  unsigned field_mask : 24;  // Cheney needs field_maks AND obj_len
+  unsigned field_mask : 24;  // Cheney needs field_mask AND obj_len
 #endif
 
 #if defined(MARK_SWEEP) || defined(BUMP_LEAK)

--- a/mycpp/gc_str.h
+++ b/mycpp/gc_str.h
@@ -95,7 +95,7 @@ inline void Str::MaybeShrink(int str_len) {
 inline int len(const Str* s) {
   return s->len_;
 
-  // For Cheney, it's possible we could use this startegy of computing it from
+  // For Cheney, it's possible we could use this strategy of computing it from
   // the object length.
 #if 0
   DCHECK(s->header_.obj_len >= kStrHeaderSize - 1);

--- a/mycpp/mark_sweep_heap_test.cc
+++ b/mycpp/mark_sweep_heap_test.cc
@@ -99,7 +99,7 @@ TEST string_collection_test() {
 
   // NOTE(Jesse): Technically UB.  If the collector hits between when the roots
   // go out of scope in the above block we'll get a UAF here.  ASAN should
-  // detect this but we currently have no way of programatically verifying that
+  // detect this but we currently have no way of programmatically verifying that
   // ASAN detects bugs.  AFAIK asan is not 100% reliable, so maybe that's a
   // path fraught with peril anyhow.
   //

--- a/mycpp/mylib_test.py
+++ b/mycpp/mylib_test.py
@@ -43,7 +43,7 @@ class MylibTest(unittest.TestCase):
         self.assertEqual(2, u.Get(d))
         self.assertEqual(-1, u.Get('zzz'))
 
-        # Can't add it twice, caller is repsonsible for checking
+        # Can't add it twice, caller is responsible for checking
         try:
             u.Add(foo)
         except AssertionError:

--- a/opy/_regtest/benchmarks.txt
+++ b/opy/_regtest/benchmarks.txt
@@ -33,7 +33,7 @@ Slower than OSH parser!
 ----------
 
 Did a bunch of major simplifications.  Hm seems to be no faster?  Slightly
-slower.  Not sure if this is signifiant.
+slower.  Not sure if this is significant.
 
 Lisa.
 

--- a/opy/_regtest/src/asdl/arith_ast_test.py
+++ b/opy/_regtest/src/asdl/arith_ast_test.py
@@ -14,7 +14,7 @@ from asdl import encode
 
 from asdl import arith_ast  # module under test
 
-# Sanity check.  Doesn't pass because this unit test exposes implementatio
+# Sanity check.  Doesn't pass because this unit test exposes implementation
 # details, like the concrete classes.
 #from _tmp import arith_ast_asdl as arith_ast
 

--- a/opy/_regtest/src/asdl/const.py
+++ b/opy/_regtest/src/asdl/const.py
@@ -20,7 +20,7 @@ DEFAULT_INT_WIDTH = 3  # 24 bits
 # extension on demand.  (24 bits to 32 or 64).  As far as I can tell, sign
 # extension requires a branch, at least in portable C (on the sign bit).
 #
-# Thes second option is semantically cleaner.  But it needlessly
+# The second option is semantically cleaner.  But it needlessly
 # inflates the size of both the source code and the data.  Instead of having a
 # single "inline" integer, we would need a reference to another value.
 #

--- a/opy/_regtest/src/asdl/format_test.py
+++ b/opy/_regtest/src/asdl/format_test.py
@@ -24,7 +24,7 @@ class FormatTest(unittest.TestCase):
     fmt.PrintTree(tree, ast_f)
 
     # Hm this prints 'Plus'.  Doesn't print the class or the number.
-    # But those aren't intrinsic.  These are mostly used for ther IDENTITY.
+    # But those aren't intrinsic.  These are mostly used for their IDENTITY.
     # I think the ASDL_TYPE field contains the relevant info.  Yes!
     pretty_str = f.getvalue()
     print(pretty_str)

--- a/opy/_regtest/src/asdl/gen_cpp.py
+++ b/opy/_regtest/src/asdl/gen_cpp.py
@@ -22,7 +22,7 @@ Technically we don't even need alignment?  I guess the reason is to increase
 address space.  If 1, then we have 16MiB of code.  If 4, then we have 64 MiB.
 
 Everything is decoded on the fly, or is a char*, which I don't think has to be
-aligned (because the natural alignment woudl be 1 byte anyway.)
+aligned (because the natural alignment would be 1 byte anyway.)
 """
 
 import sys

--- a/opy/_regtest/src/build/quick_ref.py
+++ b/opy/_regtest/src/build/quick_ref.py
@@ -140,7 +140,7 @@ def TableOfContents(f):
   # case
   # if
 
-  # Basically any line that begins with ^# ^### or ^##### is speical?
+  # Basically any line that begins with ^# ^### or ^##### is special?
   # <h1> <h2> <h3>
   # Still need links
 

--- a/opy/_regtest/src/core/braces.py
+++ b/opy/_regtest/src/core/braces.py
@@ -64,7 +64,7 @@ def _BraceDetect(w):
 
   Yeah just go through and when you see {, push another list.
   When you get ,  append to list
-  When you get } and at least one ',', appendt o list
+  When you get } and at least one ',', append o list
   When you get } without, then pop
 
   If there is no matching }, then abort with error
@@ -156,14 +156,14 @@ def BraceDetectAll(words):
   return out
 
 
-# Possible optmization for later:
+# Possible optimization for later:
 def _TreeCount(tree_word):
   """Count output size for allocation purposes.
 
   We can count the number of words expanded into, and the max number of parts
   in a word.
 
-  Every word can have a differnt number of parts, e.g. -{'a'b,c}- expands into
+  Every word can have a different number of parts, e.g. -{'a'b,c}- expands into
   words of 4 parts, then 3 parts.
   """
   # TODO: Copy the structure of _BraceExpand and _BraceExpandOne.

--- a/opy/_regtest/src/core/builtin.py
+++ b/opy/_regtest/src/core/builtin.py
@@ -281,7 +281,7 @@ def Wait(argv, waiter, job_state, mem):
 
   # Get list of jobs.  Then we need to check if they are ALL stopped.
   # Returns the exit code of the last one on the COMMAND LINE, not the exit
-  # code of last one to FINSIH.
+  # code of last one to FINISH.
 
   status = 1  # error
   for pid in pids:

--- a/opy/_regtest/src/core/cmd_exec.py
+++ b/opy/_regtest/src/core/cmd_exec.py
@@ -65,7 +65,7 @@ e_die = util.e_die
 
 
 class _ControlFlow(RuntimeError):
-  """Internal execption for control flow.
+  """Internal exception for control flow.
 
   break and continue are caught by loops, return is caught by functions.
   """
@@ -468,7 +468,7 @@ class Executor(object):
         raise AssertionError('Unknown redirect op')
 
     elif n.tag == redir_e.HereDoc:
-      # TODO: decay shoudl be controlled by an option
+      # TODO: decay should be controlled by an option
       val = self.word_ev.EvalWordToString(n.body, decay=True)
       if val.tag != value_e.Str:   # TODO: This error never fires
         util.warn("Here doc body should be a string, got %s", val)

--- a/opy/_regtest/src/core/completion.py
+++ b/opy/_regtest/src/core/completion.py
@@ -458,7 +458,7 @@ def _GetCompletionType(w_parser, c_parser, ev, status_out):
       # CommandSub.  Or honestly you can just reuse it for now.  Can you pass
       # the same cmd_exec in?  What about side effects?  I guess it can't
       # really have any.  It can only have them on the file system.  Hm.
-      # Defining funcitons?  Yeah if you complete partial functions that could
+      # Defining functions?  Yeah if you complete partial functions that could
       # be bad.  That is, you could change the name of the function.
 
       argv = []
@@ -521,7 +521,7 @@ def _GetCompletionType(w_parser, c_parser, ev, status_out):
   #   1. Look at c_parser.LastCompletionState()
   #   2. If it is $ or ${, complete var names
   #
-  #   Is there any case where we shoudl fall back on buf.split()?
+  #   Is there any case where we should fall back on buf.split()?
 
   # Now parse it.  And then look at the AST, but don't eval?  Or actually we
   # CAN eval, but we probably don't want to.

--- a/opy/_regtest/src/core/expr_eval.py
+++ b/opy/_regtest/src/core/expr_eval.py
@@ -45,7 +45,7 @@ def _StringToInteger(s, word=None):
 
   0xAB -- hex constant
   010 -- octable constant
-  64#z -- arbitary base constant
+  64#z -- arbitrary base constant
   bare word: variable
   quoted word: string
 
@@ -544,7 +544,7 @@ class BoolEvaluator(_ExprEvaluator):
       op_id = node.op_id
 
       s1 = self._EvalCompoundWord(node.left)
-      # Whehter to glob escape
+      # Whether to glob escape
       do_fnmatch = op_id in (Id.BoolBinary_GlobEqual, Id.BoolBinary_GlobDEqual,
                              Id.BoolBinary_GlobNEqual)
       s2 = self._EvalCompoundWord(node.right, do_fnmatch=do_fnmatch)

--- a/opy/_regtest/src/core/lexer_test.py
+++ b/opy/_regtest/src/core/lexer_test.py
@@ -38,7 +38,7 @@ class TokenTest(unittest.TestCase):
 
   def testLineId(self):
     # TODO: Test that the lexer gives line_ids when passed an arena.
-    # This might be more relevant if we start deallocating memroy.
+    # This might be more relevant if we start deallocating memory.
     pass
 
 

--- a/opy/_regtest/src/core/libstr.py
+++ b/opy/_regtest/src/core/libstr.py
@@ -38,7 +38,7 @@ e_die = util.e_die
 #
 # - # shortest prefix - [:1], [:2], [:3] until it matches
 # - ## longest prefix - [:-1] [:-2], [:3].  Works because fnmatch does not
-#                       match prefixes, it matches EXATLY.
+#                       match prefixes, it matches EXACTLY.
 # - % shortest suffix - [-1:] [-2:] [-3:] ...
 # - %% longest suffix - [1:] [2:] [3:]
 #

--- a/opy/_regtest/src/core/word.py
+++ b/opy/_regtest/src/core/word.py
@@ -149,7 +149,7 @@ def LeftMostSpanForPart(part):
     return part.spids[0]
 
   elif part.tag == word_part_e.ExtGlobPart:
-    # This is the smae as part.op.span_id, but we want to be consistent with
+    # This is the same as part.op.span_id, but we want to be consistent with
     # left/right.  Not sure I want to add a right token just for the spid.
     return part.spids[0]
     #return part.op.span_id  # e.g. @( is the left-most token
@@ -384,7 +384,7 @@ def AsArithVarName(w):
 
   NOTE: This can't be combined with LooksLikeAssignment because VarLike and
   ArithVarLike must be different tokens.  Otherwise _ReadCompoundWord will be
-  confused between array assigments foo=(1 2) and function calls foo(1, 2).
+  confused between array assignments foo=(1 2) and function calls foo(1, 2).
   """
   assert w.tag == word_e.CompoundWord
 
@@ -558,7 +558,7 @@ def CommandKind(w):
   if w.tag == word_e.TokenWord:
     return LookupKind(w.token.id)
 
-  # NOTE: This is a bit inconsistent with CommandId, because we never retur
+  # NOTE: This is a bit inconsistent with CommandId, because we never return
   # Kind.KW (or Kind.Lit).  But the CommandParser is easier to write this way.
   return Kind.Word
 

--- a/opy/_regtest/src/core/word_eval.py
+++ b/opy/_regtest/src/core/word_eval.py
@@ -108,7 +108,7 @@ def _MakeWordFrames(part_vals):
   return frames
 
 
-# TODO: This could be _MakeWordFrames and then sep.join().  It's redunant.
+# TODO: This could be _MakeWordFrames and then sep.join().  It's redundant.
 def _DecayPartValuesToString(part_vals, join_char):
   # Decay ${a=x"$@"x} to string.
   out = []

--- a/opy/_regtest/src/core/word_eval.py
+++ b/opy/_regtest/src/core/word_eval.py
@@ -769,7 +769,7 @@ class _WordEvaluator(object):
       #log('ARRAY LITERAL EVALUATED TO -> %s', strs)
       return runtime.StrArray(strs)
 
-    # If RHS doens't look like a=( ... ), then it must be a string.
+    # If RHS doesn't look like a=( ... ), then it must be a string.
     return self.EvalWordToString(word)
 
   def _EvalWordFrame(self, frame, argv):

--- a/opy/_regtest/src/encodings/__init__.py
+++ b/opy/_regtest/src/encodings/__init__.py
@@ -12,7 +12,7 @@
     * getregentry() -> codecs.CodecInfo object
     The getregentry() API must a CodecInfo object with encoder, decoder,
     incrementalencoder, incrementaldecoder, streamwriter and streamreader
-    atttributes which adhere to the Python Codec Interface Standard.
+    attributes which adhere to the Python Codec Interface Standard.
 
     In addition, a module may optionally also define the following
     APIs which are then used by the package's codec search function:

--- a/opy/_regtest/src/opy/callgraph.py
+++ b/opy/_regtest/src/opy/callgraph.py
@@ -391,7 +391,7 @@ class Symbols(object):
     #return
 
     # Still missing: non-enum ASDL types?  Why?  CompoundObj?
-    # command_e is there, but command and SimpleCommmand aren't.
+    # command_e is there, but command and SimpleCommand aren't.
     # it's because we do 
     # ast.command_e vs. ast.SimpleCommand
     # in both cases ast is a osh/meta _AsdlModule?

--- a/opy/_regtest/src/opy/compiler2/pyassem.py
+++ b/opy/_regtest/src/opy/compiler2/pyassem.py
@@ -42,7 +42,7 @@ class FlowGraph:
             block = self.newBlock()
 
         # Note: If the current block ends with an unconditional control
-        # transfer, then it is techically incorrect to add an implicit
+        # transfer, then it is technically incorrect to add an implicit
         # transfer to the block graph. Doing so results in code generation
         # for unreachable blocks.  That doesn't appear to be very common
         # with Python code and since the built-in compiler doesn't optimize

--- a/opy/_regtest/src/opy/compiler2/pycodegen.py
+++ b/opy/_regtest/src/opy/compiler2/pycodegen.py
@@ -1487,7 +1487,7 @@ def generateArgList(arglist):
             extra.extend(misc.flatten(elt))
             count = count + 1
         else:
-            raise ValueError, "unexpect argument type:", elt
+            raise ValueError, "unexpected argument type:", elt
     return args + extra, count
 
 def findOp(node):

--- a/opy/_regtest/src/opy/compiler2/transformer.py
+++ b/opy/_regtest/src/opy/compiler2/transformer.py
@@ -141,7 +141,7 @@ def _InitGlobals():
     symbol.factor,
     ])
 
-  # Do this first beause NT_OFFSET (non-terminal offset) conflicts with
+  # Do this first because NT_OFFSET (non-terminal offset) conflicts with
   # file_input.
   for k, v in token.tok_name.items():
       _names[k] = v
@@ -1398,13 +1398,13 @@ class Transformer:
 
             if node[0]==token.STAR:
                 if star_node is not None:
-                    raise SyntaxError, 'already have the varargs indentifier'
+                    raise SyntaxError, 'already have the varargs identifier'
                 star_node = self.com_node(nodelist[i+1])
                 i = i + 3
                 continue
             elif node[0]==token.DOUBLESTAR:
                 if dstar_node is not None:
-                    raise SyntaxError, 'already have the kwargs indentifier'
+                    raise SyntaxError, 'already have the kwargs identifier'
                 dstar_node = self.com_node(nodelist[i+1])
                 i = i + 3
                 continue

--- a/opy/_regtest/src/opy/pgen2/tokenize.py
+++ b/opy/_regtest/src/opy/pgen2/tokenize.py
@@ -336,7 +336,7 @@ def untokenize(iterable):
     Round-trip invariant for full input:
         Untokenized source will match input source exactly
 
-    Round-trip invariant for limited intput:
+    Round-trip invariant for limited input:
         # Output text will tokenize the back to the input
         t1 = [tok[:2] for tok in generate_tokens(f.readline)]
         newcode = untokenize(t1)

--- a/opy/_regtest/src/opy/tools/astgen.py
+++ b/opy/_regtest/src/opy/tools/astgen.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 """Generate ast module from specification
 
 This script generates the ast module from a simple specification,
-which makes it easy to accomodate changes in the grammar.  This
+which makes it easy to accommodate changes in the grammar.  This
 approach would be quite reasonable if the grammar changed often.
 Instead, it is rather complex to generate the appropriate code.  And
 the Node interface has changed more often than the grammar.

--- a/opy/_regtest/src/opy/util_opy.py
+++ b/opy/_regtest/src/opy/util_opy.py
@@ -11,7 +11,7 @@ PY2 = sys.version[0] == '2'
 # This uses Python3 keyword-only syntax!
 #def log(msg, *args, file=sys.stdout):
 #
-# WHY oh WHY didn't they rename print to something else, like say().  You haev
+# WHY oh WHY didn't they rename print to something else, like say().  You have
 # to do something like this to hide "if PY2" because it doesn't even parse.
 
 #s = getattr(__builtins__, 'print')

--- a/opy/_regtest/src/osh/arith_parse.py
+++ b/opy/_regtest/src/osh/arith_parse.py
@@ -107,7 +107,7 @@ def MakeShellSpec():
   http://en.cppreference.com/w/c/language/operator_precedence
 
   Bash has a table in expr.c, but it's not as cmoplete (missing grouping () and
-  array[1]).  Although it has the ** exponentation operator, not in C.
+  array[1]).  Although it has the ** exponentiation operator, not in C.
 
   - Extensions:
     - function calls f(a,b)

--- a/opy/_regtest/src/osh/arith_parse_test.py
+++ b/opy/_regtest/src/osh/arith_parse_test.py
@@ -113,7 +113,7 @@ class ArithTest(unittest.TestCase):
     #testEvalExpr(['2', '-', '5', '<', '-3-'], True)
     #testEvalExpr(['2', '-', '5', '<', '-2-'], False)
 
-    # Arithemetic compare
+    # Arithmetic compare
     testEvalExpr(['-3', '<', '-2'], True)
     # String compare
     #testEvalExpr(['-3', '<', '-2-'], False)

--- a/opy/_regtest/src/osh/cmd_parse.py
+++ b/opy/_regtest/src/osh/cmd_parse.py
@@ -474,7 +474,7 @@ class CommandParser(object):
 
     assign_kw      : Declare | Export | Local | Readonly
 
-    # Without any words it is parsed as a command, not an assigment
+    # Without any words it is parsed as a command, not an assignment
     assign_listing : assign_kw
 
     # Now we have something to do (might be changing assignment flags too)
@@ -1097,7 +1097,7 @@ class CommandParser(object):
       return None
     self._Next()  # skip function name
 
-    # Must be true beacuse of lookahead
+    # Must be true because of lookahead
     if not self._Peek(): return None
     assert self.c_id == Id.Op_LParen, self.cur_word
 
@@ -1310,7 +1310,7 @@ class CommandParser(object):
       child = self.ParseCommand()
       if not child:
         self.AddErrorContext('Error parsing command after pipe')
-        # TODO: Return partial pipeline here?  All signatures shouldbe (ok,
+        # TODO: Return partial pipeline here?  All signatures should (ok,
         # node).  Only the completion uses the node when ok is False.
         return None
       children.append(child)

--- a/opy/_regtest/src/osh/cmd_parse.py
+++ b/opy/_regtest/src/osh/cmd_parse.py
@@ -511,7 +511,7 @@ class CommandParser(object):
         ls
         >out.txt
 
-        >out.txt FOO=bar   # this touches the file, and hten
+        >out.txt FOO=bar   # this touches the file, and then
 
     Or any sequence:
         ls foo bar

--- a/opy/_regtest/src/osh/cmd_parse_test.py
+++ b/opy/_regtest/src/osh/cmd_parse_test.py
@@ -1286,7 +1286,7 @@ EOF
     """)
 
   def testHereDocCommandSub(self):
-    # Originall from spec/09-here-doc.sh.
+    # Originally from spec/09-here-doc.sh.
     err = _assertParseCommandListError(self, """\
 for x in 1 2 $(cat <<EOF
 THREE

--- a/opy/_regtest/src/osh/lex.py
+++ b/opy/_regtest/src/osh/lex.py
@@ -36,7 +36,7 @@ That means:
     core/lexer_gen.py for re2c.
 
 For example, [^']+ is not valid.  [^'\0]+ is correct.  Otherwise we would read
-unitialized memory past the sentinel.
+uninitialized memory past the sentinel.
 
 Python's regex engine knows where the end of the input string is, so it
 doesn't require need a sentinel like \0.

--- a/opy/_regtest/src/osh/parse_lib.py
+++ b/opy/_regtest/src/osh/parse_lib.py
@@ -77,7 +77,7 @@ def InitLexer(s, arena):
 # - MakeParserForCommandSub(reader, lexer) -- arena is inside lexer/reader
 # - MakeParserForCompletion(code_str)  # no arena?  no errors?
 # - MakeWordParserForHereDoc(lines, arena)  # arena is lost
-#   - althoguh you want to AddLine
+#   - although you want to AddLine
 #   - line_id = arena.AddLine()
 
 

--- a/opy/_regtest/src/osh/word_parse.py
+++ b/opy/_regtest/src/osh/word_parse.py
@@ -716,7 +716,7 @@ class WordParser(object):
       error_stack = c_parser.Error()
       self.error_stack.extend(error_stack)
       print(self.error_stack)
-      self.AddErrorContext('Error parsing commmand list in command sub')
+      self.AddErrorContext('Error parsing command list in command sub')
       return None
 
     # Hm this creates its own word parser, which is thrown away?

--- a/opy/_regtest/src/platform.py
+++ b/opy/_regtest/src/platform.py
@@ -75,7 +75,7 @@
 #            type information
 #    0.4.0 - added win32_ver() and modified the platform() output for WinXX
 #    0.3.4 - fixed a bug in _follow_symlinks()
-#    0.3.3 - fixed popen() and "file" command invokation bugs
+#    0.3.3 - fixed popen() and "file" command invocation bugs
 #    0.3.2 - added architecture() API and support for it in platform()
 #    0.3.1 - fixed syscmd_ver() RE to support Windows NT
 #    0.3.0 - added system alias support
@@ -975,7 +975,7 @@ def _syscmd_file(target,default=''):
     """ Interface to the system's file command.
 
         The function uses the -b option of the file command to have it
-        ommit the filename in its output and if possible the -L option
+        omit the filename in its output and if possible the -L option
         to have the command follow symlinks. It returns default in
         case the command should fail.
 

--- a/opy/_regtest/src/test/sh_spec.py
+++ b/opy/_regtest/src/test/sh_spec.py
@@ -512,7 +512,7 @@ def RunCases(cases, case_predicate, shells, env, out):
       result_row.append(cell_result)
 
       if cell_result == Result.FAIL:
-        # Special logic: don't count osh_ALT beacuse its failures will be
+        # Special logic: don't count osh_ALT because its failures will be
         # counted in the delta.
         if sh_label != 'osh_ALT':
           stats['num_failed'] += 1

--- a/opy/_regtest/src/tools/deps.py
+++ b/opy/_regtest/src/tools/deps.py
@@ -43,7 +43,7 @@ class Visitor(object):
         #log('Visiting child array %s', name)
         for item in child:
           # We have to check for compound objects on an INSTANCE basis, not a
-          # type basis, because sums can look liek this:
+          # type basis, because sums can look like this:
           # iterable = IterArgv | IterArray(word* words)
           # We visit the latter but not the former.
           if isinstance(item, py_meta.CompoundObj):

--- a/opy/_regtest/src/tools/osh2oil.py
+++ b/opy/_regtest/src/tools/osh2oil.py
@@ -762,7 +762,7 @@ class OilPrinter(object):
 
         self.cursor.PrintUntil(left_spid)
         # Hm maybe keep | because it's semi-deprecated?  You acn use
-        # reload|force-relaod {
+        # reload|force-reload {
         # }
         # e/reload|force-reload/ {
         # }
@@ -836,7 +836,7 @@ class OilPrinter(object):
       # NOTE: ArithSub with $(1 +2 ) is different than 1 + 2 because of
       # conversion to string.
 
-      # For now, jsut stub it out
+      # For now, just stub it out
       self.DoWordInCommand(node, local_symbols)
 
   def DoWordInCommand(self, node, local_symbols):

--- a/opy/_regtest/src/tools/osh2oil.py
+++ b/opy/_regtest/src/tools/osh2oil.py
@@ -761,7 +761,7 @@ class OilPrinter(object):
         #print(left_spid, rparen_spid, dsemi_spid)
 
         self.cursor.PrintUntil(left_spid)
-        # Hm maybe keep | because it's semi-deprecated?  You acn use
+        # Hm maybe keep | because it's semi-deprecated?  You can use
         # reload|force-reload {
         # }
         # e/reload|force-reload/ {
@@ -1063,7 +1063,7 @@ class OilPrinter(object):
         self.cursor.PrintUntil(spid + 1)
 
       elif op_id == Id.VSub_Bang:  # $!
-        self.f.write('$BgPid')  # Job most recently placed in backgroudn
+        self.f.write('$BgPid')  # Job most recently placed in background
         self.cursor.SkipUntil(spid + 1)
 
       elif op_id == Id.VSub_At:  # $@

--- a/opy/byterun/ovm.py
+++ b/opy/byterun/ovm.py
@@ -4,7 +4,7 @@ ovm.py
 
 TODO:
 
-  Define a VM that doens't use exceptions for control flow!
+  Define a VM that doesn't use exceptions for control flow!
 """
 
 import operator  # for + - * / etc.

--- a/opy/byterun/pyvm2.py
+++ b/opy/byterun/pyvm2.py
@@ -926,7 +926,7 @@ class VirtualMachine(object):
         #    We should do something smarter.
 
         # This check is broken!
-        # next() and send()  that is a native python function.  We dO NOt need
+        # next() and send()  that is a native python function.  We DO NOT need
         # to wrap it.
 
         do_wrap = False

--- a/opy/callgraph.py
+++ b/opy/callgraph.py
@@ -404,7 +404,7 @@ class Symbols(object):
     #return
 
     # Still missing: non-enum ASDL types?  Why?  CompoundObj?
-    # command_e is there, but command and SimpleCommmand aren't.
+    # command_e is there, but command and SimpleCommand aren't.
     # it's because we do
     # ast.command_e vs. ast.SimpleCommand
     # in both cases ast is a core.meta _AsdlModule?

--- a/opy/common.sh
+++ b/opy/common.sh
@@ -31,7 +31,7 @@ opy_() {
 # NOTES:
 # - Exclude _devbuild/cpython-full, but include _devbuild/gen.
 # - must exclude opy/testdata/, because some of it can't be compiled
-# Has some similiarity to test/lint.sh, but not the same.
+# Has some similarity to test/lint.sh, but not the same.
 oil-python-sources() {
   local repo_root=$1
   local fmt=${2:-'%P\n'}

--- a/opy/compiler2/pyassem.py
+++ b/opy/compiler2/pyassem.py
@@ -243,7 +243,7 @@ class FlowGraph(object):
             block = self.newBlock()
 
         # Note: If the current block ends with an unconditional control
-        # transfer, then it is techically incorrect to add an implicit
+        # transfer, then it is technically incorrect to add an implicit
         # transfer to the block graph. Doing so results in code generation
         # for unreachable blocks.  That doesn't appear to be very common
         # with Python code and since the built-in compiler doesn't optimize

--- a/opy/compiler2/transformer.py
+++ b/opy/compiler2/transformer.py
@@ -141,7 +141,7 @@ def _InitGlobals():
     symbol.factor,
     ])
 
-  # Do this first beause NT_OFFSET (non-terminal offset) conflicts with
+  # Do this first because NT_OFFSET (non-terminal offset) conflicts with
   # file_input.
   for k, v in token.tok_name.items():
       _names[k] = v
@@ -1350,13 +1350,13 @@ class Transformer(object):
 
             if node[0]==token.STAR:
                 if star_node is not None:
-                    raise SyntaxError, 'already have the varargs indentifier'
+                    raise SyntaxError, 'already have the varargs identifier'
                 star_node = self.com_node(nodelist[i+1])
                 i = i + 3
                 continue
             elif node[0]==token.DOUBLESTAR:
                 if dstar_node is not None:
-                    raise SyntaxError, 'already have the kwargs indentifier'
+                    raise SyntaxError, 'already have the kwargs identifier'
                 dstar_node = self.com_node(nodelist[i+1])
                 i = i + 3
                 continue

--- a/opy/doc/opcodes.md
+++ b/opy/doc/opcodes.md
@@ -81,7 +81,7 @@ Dynamic bytecodes that will go away, because names are statically resolved:
 
 Other Removed:
 
-- `DELETE_NAME`: Namesapces are static
+- `DELETE_NAME`: Namespaces are static
 - Might be unnecessary for our purposes: `YIELD_FROM`
 - `EXEC_STMT`: I want a different interface to the compiler, for
   metaprogramming purposes.

--- a/opy/gold/all_name_lookups.py
+++ b/opy/gold/all_name_lookups.py
@@ -29,7 +29,7 @@ def myfunc():
   # CALL_FUNCTION -- should be INIT_INSTANCE
   obj = class_vs_closure.Adder(42)
 
-  obj.method(5)  # LOAD_FAST and hten LOAD_ATTR for method
+  obj.method(5)  # LOAD_FAST and then LOAD_ATTR for method
                  # CALL_FUNCTION (should be CALL_METHOD)
 
 

--- a/opy/gold/class_vs_closure.py
+++ b/opy/gold/class_vs_closure.py
@@ -13,7 +13,7 @@ Class is implemented with type(), and then the constructor creates a namespace
 with __dict__ and so forth.  Access through 'self'.  LOAD_FAST self, where self
 is a local variable.
 
-There was one language that made it explicit.  Skew lanaguage?
+There was one language that made it explicit.  Skew language?
 
 
 # {} is for static language of types/data.  : is for language of

--- a/opy/gold/fib_iterative.py
+++ b/opy/gold/fib_iterative.py
@@ -9,7 +9,7 @@ b = 1
 
 while 1:  # Slightly easier to compile than 'while True:'
 
-  # Artifical change to test 'continue'
+  # Artificial change to test 'continue'
   if i == 0:
     i = i + 1
     continue

--- a/opy/misc/pgen.asdl
+++ b/opy/misc/pgen.asdl
@@ -1,5 +1,5 @@
 -- AST for pgen grammar.
--- Constrast with asdl.asdl
+-- Contrast with asdl.asdl
 
 module pgen
 {

--- a/opy/old/run.sh
+++ b/opy/old/run.sh
@@ -135,7 +135,7 @@ compare-opy-tree() {
   #diff -u _tmp/opy-{stdlib,stdlib2}/MD5.txt || true
 
   # Hm even two stdlib runs are different!
-  # TODO: find the smallest ones that are differet
+  # TODO: find the smallest ones that are different
 
   # Same strings output
   compare-files _tmp/opy-{stdlib,stdlib2}/pytree.pyc

--- a/opy/skeleton.py
+++ b/opy/skeleton.py
@@ -31,7 +31,7 @@ class _ModuleContext(object):
 
   def __init__(self, filename, comp_opt, scopes, futures=()):
     self.filename = filename
-    self.comp_opt = comp_opt  # copmilation options
+    self.comp_opt = comp_opt  # compilation options
     self.scopes = scopes
     self.futures = futures
 

--- a/opy/testdata/tuple_args.py
+++ b/opy/testdata/tuple_args.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 """
 tuple_args.py: Testing out this little-known feature of Python, which compiler2
-suppports.
+supports.
 """
 
 # Python 3 no longer supports this!

--- a/opy/tools/astgen.py
+++ b/opy/tools/astgen.py
@@ -2,7 +2,7 @@
 """Generate ast module from specification
 
 This script generates the ast module from a simple specification,
-which makes it easy to accomodate changes in the grammar.  This
+which makes it easy to accommodate changes in the grammar.  This
 approach would be quite reasonable if the grammar changed often.
 Instead, it is rather complex to generate the appropriate code.  And
 the Node interface has changed more often than the grammar.

--- a/osh/arith_parse.py
+++ b/osh/arith_parse.py
@@ -100,7 +100,7 @@ if mylib.PYTHON:
         http://en.cppreference.com/w/c/language/operator_precedence.
 
         Bash has a table in expr.c, but it's not as cmoplete (missing grouping () and
-        array[1]).  Although it has the ** exponentation operator, not in C.
+        array[1]).  Although it has the ** exponentiation operator, not in C.
 
         - Extensions:
           - function calls f(a,b)

--- a/osh/arith_parse_test.py
+++ b/osh/arith_parse_test.py
@@ -121,7 +121,7 @@ class ArithTest(unittest.TestCase):
         #testEvalExpr(['2', '-', '5', '<', '-3-'], True)
         #testEvalExpr(['2', '-', '5', '<', '-2-'], False)
 
-        # Arithemetic compare
+        # Arithmetic compare
         testEvalExpr(['-3', '<', '-2'], True)
         # String compare
         #testEvalExpr(['-3', '<', '-2-'], False)

--- a/osh/builtin_assign.py
+++ b/osh/builtin_assign.py
@@ -501,7 +501,7 @@ class Unset(vm._Builtin):
         try:
             found = self.mem.Unset(lval, scope_e.Shopt)
         except error.Runtime as e:
-            # note: in bash, myreadonly=X fails, but declare myreadonly=X doens't
+            # note: in bash, myreadonly=X fails, but declare myreadonly=X doesn't
             # fail because it's a builtin.  So I guess the same is true of 'unset'.
             msg = e.UserErrorString()
             self.errfmt.Print_(msg, blame_loc=location)

--- a/osh/builtin_comp.py
+++ b/osh/builtin_comp.py
@@ -31,6 +31,21 @@ if TYPE_CHECKING:
     from osh.split import SplitContext
     from osh.word_eval import NormalWordEvaluator
 
+HELP_TOPICS = []  # type: List[str]
+
+from mycpp import mylib
+if mylib.PYTHON:
+    # - Catch ImportError because we don't want libcmark.so dependency for
+    #   build/py.sh minimal
+    # - For now, ignore a type error in minimal build.
+    # - TODO: Rewrite help builtin and remove dep on CommonMark
+    try:
+        from _devbuild.gen import help_  # type: ignore
+        HELP_TOPICS = help_.TOPICS
+    except ImportError:
+        pass
+
+
 class _FixedWordsAction(completion.CompletionAction):
     def __init__(self, d):
         # type: (List[str]) -> None

--- a/osh/builtin_lib_test.py
+++ b/osh/builtin_lib_test.py
@@ -53,7 +53,7 @@ echo bye
 """)
 
         # Delete single history item.
-        # This functionlity is *silent*
+        # This functionality is *silent*
         # so call history again after
         # this to feed the test assertion
 
@@ -71,7 +71,7 @@ echo bye
 """)
 
         # Clear history
-        # This functionlity is *silent*
+        # This functionality is *silent*
         # so call history again after
         # this to feed the test assertion
 

--- a/osh/cmd_parse.py
+++ b/osh/cmd_parse.py
@@ -847,7 +847,7 @@ class CommandParser(object):
         echo 3'
         MULTILINE
 
-        NOTE: dash handles aliases in a totally diferrent way.  It has a global
+        NOTE: dash handles aliases in a totally different way.  It has a global
         variable checkkwd in parser.c.  It assigns it all over the grammar, like
         this:
 
@@ -977,7 +977,7 @@ class CommandParser(object):
 
         assign_kw      : Declare | Export | Local | Readonly
 
-        # Without any words it is parsed as a command, not an assigment
+        # Without any words it is parsed as a command, not an assignment
         assign_listing : assign_kw
 
         # Now we have something to do (might be changing assignment flags too)
@@ -1706,7 +1706,7 @@ class CommandParser(object):
         I think we might need strict_brace so that foo{ is disallowed.  It has to
         be foo\{ or foo{a,b}.  Or just turn that on with parse_brace?  After you
         form ANY CompoundWord, make sure it's balanced for Lit_LBrace and
-        Lit_RBrace?  Maybe this is pre-parsing step in teh WordParser?
+        Lit_RBrace?  Maybe this is pre-parsing step in the WordParser?
         """
         if_node = command.If.CreateNull(alloc_lists=True)
         if_node.if_kw = if_kw
@@ -2196,7 +2196,7 @@ class CommandParser(object):
                          Id.KW_If, Id.KW_Case, Id.KW_Time):
             return self.ParseCompoundCommand()
 
-        # Sytnax error for '}' starting a line, which all shells disallow.
+        # Syntax error for '}' starting a line, which all shells disallow.
         if self.c_id == Id.Lit_RBrace:
             p_die('Unexpected right brace', loc.Word(self.cur_word))
 

--- a/osh/cmd_parse.py
+++ b/osh/cmd_parse.py
@@ -1014,7 +1014,7 @@ class CommandParser(object):
             ls
             >out.txt
 
-            >out.txt FOO=bar   # this touches the file, and hten
+            >out.txt FOO=bar   # this touches the file, and then
 
         Or any sequence:
             ls foo bar

--- a/osh/cmd_parse_test.py
+++ b/osh/cmd_parse_test.py
@@ -1401,7 +1401,7 @@ EOF
     """)
 
     def testHereDocCommandSub(self):
-        # Originall from spec/09-here-doc.sh.
+        # Originally from spec/09-here-doc.sh.
         err = _assert_ParseCommandListError(
             self, """\
 for x in 1 2 $(cat <<EOF

--- a/osh/glob_.py
+++ b/osh/glob_.py
@@ -158,7 +158,7 @@ class _GlobParser(object):
         # type: () -> List[glob_part_t]
         """
     Returns:
-      a CharClass if the parse suceeds, or a Literal if fails.  In the latter
+      a CharClass if the parse succeeds, or a Literal if fails.  In the latter
       case, we also append a warning.
     """
         first_token = glob_part.Literal(self.token_type, self.token_val)

--- a/osh/sh_expr_eval.py
+++ b/osh/sh_expr_eval.py
@@ -308,7 +308,7 @@ class ArithEvaluator(object):
         0xAB -- hex constant
         042  -- octal constant
         42   -- decimal constant
-        64#z -- arbitary base constant
+        64#z -- arbitrary base constant
 
         bare word: variable
         quoted word: string (not done?)

--- a/osh/split.py
+++ b/osh/split.py
@@ -180,7 +180,7 @@ class SplitContext(object):
         # type: (str, Optional[str]) -> List[str]
         """Split used by word evaluation.
 
-        Also used by the explicit @split() functino.
+        Also used by the explicit @split() function.
         """
         sp = self._GetSplitter(ifs=ifs)
         spans = sp.Split(s, True)

--- a/osh/string_ops.py
+++ b/osh/string_ops.py
@@ -216,7 +216,7 @@ def AdvanceUtf8Chars(s, num_chars, byte_offset):
 #
 # - # shortest prefix - [:1], [:2], [:3] until it matches
 # - ## longest prefix - [:-1] [:-2], [:3].  Works because fnmatch does not
-#                       match prefixes, it matches EXATLY.
+#                       match prefixes, it matches EXACTLY.
 # - % shortest suffix - [-1:] [-2:] [-3:] ...
 # - %% longest suffix - [1:] [2:] [3:]
 #

--- a/osh/tdop.py
+++ b/osh/tdop.py
@@ -117,7 +117,7 @@ def LeftError(p, t, left, rbp):
 def LeftBinaryOp(p, w, left, rbp):
     # type: (TdopParser, word_t, arith_expr_t, int) -> arith_expr_t
     """Normal binary operator like 1+2 or 2*3, etc."""
-    # TODO: w shoudl be a Token, and we should extract the token from it.
+    # TODO: w should be a Token, and we should extract the token from it.
     return arith_expr.Binary(word_.ArithId(w), left, p.ParseUntil(rbp))
 
 

--- a/osh/word_.py
+++ b/osh/word_.py
@@ -338,7 +338,7 @@ def LooksLikeArithVar(UP_w):
 
     NOTE: This can't be combined with DetectShAssignment because VarLike and
     ArithVarLike must be different tokens.  Otherwise _ReadCompoundWord will be
-    confused between array assigments foo=(1 2) and function calls foo(1, 2).
+    confused between array assignments foo=(1 2) and function calls foo(1, 2).
     """
     if UP_w.tag() != word_e.Compound:
         return None

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -679,7 +679,7 @@ class AbstractWordEvaluator(StringWordEvaluator):
 
         elif tok.id in (Id.VTest_ColonQMark, Id.VTest_QMark):
             if is_falsey:
-                # The arg is the error mesage
+                # The arg is the error message
                 error_part_vals = []  # type: List[part_value_t]
                 self._EvalRhsWordToParts(op.arg_word, error_part_vals,
                                          eval_flags)

--- a/osh/word_parse.py
+++ b/osh/word_parse.py
@@ -600,7 +600,7 @@ class WordParser(WordEmitter):
 
     def _ReadSingleQuoted(self, left_token, lex_mode):
         # type: (Token, lex_mode_t) -> SingleQuoted
-        """Interal method to read a word_part."""
+        """Internal method to read a word_part."""
         tokens = []  # type: List[Token]
         # In command mode, we never disallow backslashes like '\'
         self.ReadSingleQuoted(lex_mode, left_token, tokens, False)

--- a/pgen2/tokenize.py
+++ b/pgen2/tokenize.py
@@ -336,7 +336,7 @@ def untokenize(iterable):
     Round-trip invariant for full input:
         Untokenized source will match input source exactly
 
-    Round-trip invariant for limited intput:
+    Round-trip invariant for limited input:
         # Output text will tokenize the back to the input
         t1 = [tok[:2] for tok in generate_tokens(f.readline)]
         newcode = untokenize(t1)

--- a/pyext/fanos_test.py
+++ b/pyext/fanos_test.py
@@ -141,7 +141,7 @@ class FanosTest(unittest.TestCase):
     left, right = socket.socketpair()
 
     # TODO: test invalid netstring cases
-    # Instead of RuntimeError they sould be fanos.error?
+    # Instead of RuntimeError they should be fanos.error?
     # Instead of 'OK' you return
     # 'fanos ERROR: Invalid netstring'
 

--- a/pyext/libc.c
+++ b/pyext/libc.c
@@ -168,7 +168,7 @@ func_regex_parse(PyObject *self, PyObject *args) {
   }
   regex_t pat;
   // This is an extended regular expression rather than a basic one, i.e. we
-  // use 'a*' instaed of 'a\*'.
+  // use 'a*' instead of 'a\*'.
   int status = regcomp(&pat, pattern, REG_EXTENDED);
   if (status != 0) {
     char error_string[80];

--- a/pyext/libc_test.py
+++ b/pyext/libc_test.py
@@ -43,7 +43,7 @@ class LibcTest(unittest.TestCase):
         ('\\!', '!', 1),
 
         # What if we also escape extended glob chars?
-        # Extra escaping is OK, so we shoudl ALWAYS escape them.
+        # Extra escaping is OK, so we should ALWAYS escape them.
         ('\\(', '(', 1),
         ('\\(', 'x', 0),
         ('\\(', '\\', 0),

--- a/pylib/cgi.py
+++ b/pylib/cgi.py
@@ -5,7 +5,7 @@ We don't want the side effects of importing tempfile, which imports random,
 which opens /dev/urandom!
 """
 
-# Removed quote arg since C++ doesn't suport keyword args, and we don't use it
+# Removed quote arg since C++ doesn't support keyword args, and we don't use it
 # in Oil proper.
 
 def escape(s):

--- a/spec/TODO-deprecate.test.sh
+++ b/spec/TODO-deprecate.test.sh
@@ -1,4 +1,4 @@
-# TODO-depreate: Code we want to get rid of!
+# TODO-deprecate: Code we want to get rid of!
 
 
 #### oil:upgrade as alias for ysh:upgrade

--- a/spec/arith-context.test.sh
+++ b/spec/arith-context.test.sh
@@ -55,7 +55,7 @@ echo ${s:zero} ${s:zero+0} ${s:zero+1:zero+1}
 
 #### Ambiguous colon in slice
 s='abcd'
-echo $(( 0 < 1 ? 2 : 0 ))  # evalutes to 2
+echo $(( 0 < 1 ? 2 : 0 ))  # evaluates to 2
 echo ${s: 0 < 1 ? 2 : 0 : 1}  # 2:1 -- TRICKY THREE COLONS
 ## stdout-json: "2\nc\n"
 ## BUG mksh stdout-json: "2\n"
@@ -75,7 +75,7 @@ echo $a $((1 + (2*3)))
 echo $a $((1 + (2 * (3+4))))
 ## stdout: 15 15
 
-#### ExprSub $[] happpens to behave the same on simple cases
+#### ExprSub $[] happens to behave the same on simple cases
 echo $[1 + 2] "$[3 * 4]"
 ## stdout: 3 12
 ## N-I mksh stdout: $[1 + 2] $[3 * 4]

--- a/spec/array-compat.test.sh
+++ b/spec/array-compat.test.sh
@@ -156,7 +156,7 @@ status=1
 ## N-I mksh STDOUT:
 ## END
 
-#### value.BashArray internal represention - Assoc (ordering is a problem)
+#### value.BashArray internal representation - Assoc (ordering is a problem)
 
 case $SH in mksh) exit ;; esac
 

--- a/spec/assoc.test.sh
+++ b/spec/assoc.test.sh
@@ -8,7 +8,7 @@
 #
 # Associtative Arrays are COMPLETELY bash-specific.  mksh doesn't even come
 # close.  So I will probably not implement them, or implement something
-# slightly different, because the semantics are just wierd.
+# slightly different, because the semantics are just weird.
 
 # http://www.gnu.org/software/bash/manual/html_node/Arrays.html
 # TODO: Need a SETUP section.
@@ -459,7 +459,7 @@ echo ${a["k2"]}
 [k2]=-a-
 ## END
 
-#### declare -A A=() alowed
+#### declare -A A=() allowed
 set -o nounset
 shopt -s strict_arith || true
 

--- a/spec/builtin-io.test.sh
+++ b/spec/builtin-io.test.sh
@@ -690,7 +690,7 @@ find . -type f -a -print0 | { read -r -d ''; echo "[$REPLY]"; }
 
 #### redirection from directory is non-fatal error)
 
-# This tickles an infinite loop bug in our version of mksh!  TODO: ugprade the
+# This tickles an infinite loop bug in our version of mksh!  TODO: upgrade the
 # version and enable this
 case $SH in (mksh) return ;; esac
 

--- a/spec/builtin-trap-bash.test.sh
+++ b/spec/builtin-trap-bash.test.sh
@@ -456,7 +456,7 @@ f() {
   g
 }
 # RETURN trap doesn't fire when a function returns, only when a script returns?
-# That's not what the manual syas.
+# That's not what the manual says.
 trap 'profile x y' RETURN
 f
 . $REPO_ROOT/spec/testdata/return-helper.sh

--- a/spec/builtins.test.sh
+++ b/spec/builtins.test.sh
@@ -47,7 +47,7 @@ echo $PWD
 
 # Odd divergence in shells: dash and mksh normalize the path and don't check
 # this error.
-# TODO: I would like OSH to behave like bash and zsh, but it separting chdir_arg and
+# TODO: I would like OSH to behave like bash and zsh, but it separating chdir_arg and
 # pwd_arg breaks case 17.
 
 cd nonexistent_ZZ/..

--- a/spec/errexit.test.sh
+++ b/spec/errexit.test.sh
@@ -124,7 +124,7 @@ done
 ## status: 0
 
 #### errexit with (( ))
-# from http://mywiki.wooledge.org/BashFAQ/105, this changed between verisons.
+# from http://mywiki.wooledge.org/BashFAQ/105, this changed between versions.
 # ash says that 'i++' is not found, but it doesn't exit.  I guess this is the 
 # subshell problem?
 set -o errexit

--- a/spec/extglob-match.test.sh
+++ b/spec/extglob-match.test.sh
@@ -298,7 +298,7 @@ TRUE
 TRUE
 ## END
 
-#  osh fails wth runtime error
+#  osh fails with runtime error
 ## OK osh status: 1
 ## OK osh STDOUT:
 ## END

--- a/spec/here-doc.test.sh
+++ b/spec/here-doc.test.sh
@@ -12,7 +12,7 @@ cat <<< $'one\ntwo\n'
 ## N-I dash status: 2
 
 #### Here redirect with explicit descriptor
-# A space betwen 0 and <<EOF causes it to pass '0' as an arg to cat.
+# A space between 0 and <<EOF causes it to pass '0' as an arg to cat.
 cat 0<<EOF
 one
 EOF

--- a/spec/redirect.test.sh
+++ b/spec/redirect.test.sh
@@ -597,7 +597,7 @@ status=0
 
 #### can't mention big file descriptor
 echo hi 9>&1
-# 23 is the max descriptor fo rmksh
+# 23 is the max descriptor for mksh
 #echo hi 24>&1
 echo hi 99>&1
 echo hi 100>&1

--- a/spec/serialize.test.sh
+++ b/spec/serialize.test.sh
@@ -192,7 +192,7 @@ case $SH in (zsh|ash) exit ;; esac
 
 zz=$'one\ntwo \u03bc'
 
-# wierdly, quoted and unquoted aren't different
+# weirdly, quoted and unquoted aren't different
 echo ${zz@Q}
 echo "${zz@Q}"
 ## STDOUT:

--- a/spec/sh-options.test.sh
+++ b/spec/sh-options.test.sh
@@ -347,7 +347,7 @@ echo "$@"
 set -- --
 echo "$@"
 
-# note: zsh is diffferent, and yash is totally different
+# note: zsh is different, and yash is totally different
 ## STDOUT:
 a b
 a b

--- a/spec/stateful/job_control.py
+++ b/spec/stateful/job_control.py
@@ -288,10 +288,10 @@ def no_spurious_tty_take(sh):
   time.sleep(0.1) # TODO: need to wait a bit for jobs to get SIGTTIN. can we be more precise?
   sh.sendline(PYCAT % 'bar')
   if 'osh' in sh.shell_label:
-    # Quirk of osh. TODO: supress this print for background jobs?
+    # Quirk of osh. TODO: suppress this print for background jobs?
     sh.expect('.*Stopped.*')
 
-  # foreground procoess should not have been stopped.
+  # foreground process should not have been stopped.
   sh.sendline('foo')
   sh.expect('foobar')
 

--- a/spec/testdata/config/osh-hay.osh
+++ b/spec/testdata/config/osh-hay.osh
@@ -16,7 +16,7 @@ Foo {
   echo `echo backticks`
   eval 'echo eval'
 
-  # At parse time, all the lines must be contigous
+  # At parse time, all the lines must be contiguous
 
   TASK {
     echo `echo task backticks`

--- a/spec/ysh-assign.test.sh
+++ b/spec/ysh-assign.test.sh
@@ -221,7 +221,7 @@ x=xx
 
 #### var x, y = 1, 2 is NOT allowed
 
-# The syntax consistent with JavaScript woudl be
+# The syntax consistent with JavaScript would be
 # var x = 1, y = 2;
 
 var x, y = 1, 2

--- a/spec/ysh-methods.test.sh
+++ b/spec/ysh-methods.test.sh
@@ -37,7 +37,7 @@ setvar en2fr["cat"] = "chat"
 (List)   ['hello', 'friend', 'cat']
 ## END
 
-#### Seperation of -> attr and () calling
+#### Separation of -> attr and () calling
 const check = "abc"->startswith
 = check("a")
 ## status: 0

--- a/spec/ysh-multiline.test.sh
+++ b/spec/ysh-multiline.test.sh
@@ -127,7 +127,7 @@ comment is OK
 
 
 # Notes:
-# - MakeParserForCommandSub() instantiates a new WordParser, so we can safetly
+# - MakeParserForCommandSub() instantiates a new WordParser, so we can safely
 # change state in the top-level one only
 # - BoolParser is called for [[ ]] and uses the same self.w_parser.  I think
 # that's OK?

--- a/spec/ysh-options.test.sh
+++ b/spec/ysh-options.test.sh
@@ -334,7 +334,7 @@ if test -z foo { echo if } elif test -z '' { echo 1 }; if test -n foo { echo 2 }
 echo 'sh syntax'
 if test -z foo; then echo if; elif test -z ''; then echo 1; fi; if test -n foo { echo 2 };
 
-# NOTE: This is not alowed because it's like a brace group!
+# NOTE: This is not allowed because it's like a brace group!
 # if test -n foo; { 
 
 ## STDOUT:

--- a/spec/ysh-slice-range.test.sh
+++ b/spec/ysh-slice-range.test.sh
@@ -40,7 +40,7 @@ echo 'out of bounds'
 # Stride not supported
 #= myarray[1:4:2]
 
-# Now try omitting smoe
+# Now try omitting some
 #= myarray[1:4:2]
 ## STDOUT:
 (Str)   '2'
@@ -93,7 +93,7 @@ echo $val
 3
 ## END
 
-#### Copy wtih a[:]
+#### Copy with a[:]
 var a = [1,2,3]
 var b = a[:]
 = b

--- a/test/baseline.spec-cpp.sh
+++ b/test/baseline.spec-cpp.sh
@@ -41,7 +41,7 @@ done
 [ -f $tmp_file_1 ] && rm $tmp_file_1
 grep "Assertion.*failed\." _tmp/spec/cpp/* > $tmp_file_0
 
-echo "Recording Assertion Failuers"
+echo "Recording Assertion Failures"
 while read -r line; do
   assert_fail=$(echo -n "$line" | grep -o -P "oils-for-unix: \K.*") || allow_errors
   test_fail=$(echo "$line" | cut -d: -f1) || allow_errors

--- a/test/jsontemplate.py
+++ b/test/jsontemplate.py
@@ -1550,7 +1550,7 @@ class Trace(object):
 
 
 def _MakeGroupFromRootSection(root_section, undefined_str):
-  """Construct a dictinary { template name -> Template() instance }
+  """Construct a dictionary { template name -> Template() instance }
 
   Args:
     root_section: _Section instance -- root of the original parse tree

--- a/test/osh-usage.sh
+++ b/test/osh-usage.sh
@@ -111,7 +111,7 @@ test-osh-interactive() {
   echo ';echo OIL OIL' | $OSH -i
   assert $? -eq 2
 
-  # Bug fix: c_parser.Peek() in main_loop.InteractiveLoop can raise execptions
+  # Bug fix: c_parser.Peek() in main_loop.InteractiveLoop can raise exceptions
   echo 'v=`echo \"`' | $OSH -i
   assert $? -eq 0
 }

--- a/test/parse-errors.sh
+++ b/test/parse-errors.sh
@@ -1649,7 +1649,7 @@ oils_issue_1118() {
       echo hi
     }
 
-    # The $ causes a wierd error
+    # The $ causes a weird error
     if ($snippet["status"] === 0) {
       echo hi
     }
@@ -1695,7 +1695,7 @@ trap_parse_error() {
   '
 }
 
-# Note: PROMPT_COMAND and PS1 are hard to trigger in this framework
+# Note: PROMPT_COMMAND and PS1 are hard to trigger in this framework
 
 cases-in-strings() {
   set +o errexit

--- a/test/process_table.py
+++ b/test/process_table.py
@@ -64,7 +64,7 @@ def parse_process_tree(f, runner_pid):
     print('malformed ps output', file=sys.stderr)
     sys.exit(1)
 
-  # first proceses is the test harness
+  # first process is the test harness
   root = procs[runner_pid]
   root.assert_child_count(1)
   return root.children[0]

--- a/test/sh_spec.py
+++ b/test/sh_spec.py
@@ -558,7 +558,7 @@ class Stats(object):
     if cell_result == Result.TIMEOUT:
       c['num_timeout'] += 1
     elif cell_result == Result.FAIL:
-      # Special logic: don't count osh_ALT beacuse its failures will be
+      # Special logic: don't count osh_ALT because its failures will be
       # counted in the delta.
       if sh_label not in OTHER_OSH + OTHER_YSH:
         c['num_failed'] += 1

--- a/test/spec-py.sh
+++ b/test/spec-py.sh
@@ -2,7 +2,7 @@
 #
 # Compare Python implementation with other shells.
 #
-# Contrast with test/spec-cpp.sh, which compares the Python adn C++ version.
+# Contrast with test/spec-cpp.sh, which compares the Python and C++ version.
 #
 # Usage:
 #   test/spec-py.sh <function name>
@@ -71,7 +71,7 @@ interactive-osh() {
   ### Run spec files tagged 'interactive' in soil/interactive, which uses a terminal
   # This repeats what 'compare-py' does.
 
-  # Doesn't seem to triggger "Stopped" bug, but it hangs in the CI unless serial
+  # Doesn't seem to trigger "Stopped" bug, but it hangs in the CI unless serial
 
   # pass '1' to make it serial.  default is N-1 CPUS in test/spec-common.sh
   local max_procs=${1:-1}

--- a/test/tools-deps.sh
+++ b/test/tools-deps.sh
@@ -19,7 +19,7 @@ assert-deps() {
 }
 
 test-ourselves() {
-  ### This shows an errror but doesn't exit 0
+  ### This shows an error but doesn't exit 0
   bin/osh --tool deps $0
   test $? -eq 0 || fail
 }

--- a/test/tsv-lib.sh
+++ b/test/tsv-lib.sh
@@ -1,4 +1,4 @@
-# TSV utilties
+# TSV utilities
 #
 # Usage:
 #   source test/tsv-lib.sh

--- a/test/wild_report.py
+++ b/test/wild_report.py
@@ -668,7 +668,7 @@ def SumStats(stdin, in_dir, not_shell, not_osh, root_node, failures):
     osh2oil_failed, st['osh2oil_proc_secs'] = _ReadTaskFile(
         osh2oil_task_path)
 
-    # Only count translation failures if the parse suceeded!
+    # Only count translation failures if the parse succeeded!
     st['osh2oil_failed'] = osh2oil_failed if not parse_failed else 0
 
     with open(raw_base + '__osh2oil.stderr.txt') as f:

--- a/testdata/completion/bash_oracle.sh
+++ b/testdata/completion/bash_oracle.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Test our _init_completion builtin against the bash_completion implementaiton.
+# Test our _init_completion builtin against the bash_completion implementation.
 #
 # Usage:
 #   testdata/completion/bash_oracle.sh <function name>

--- a/testdata/completion/git-completion.bash
+++ b/testdata/completion/git-completion.bash
@@ -438,7 +438,7 @@ __gitcomp_nl ()
 # Callers must take care of providing only paths that match the current path
 # to be completed and adding any prefix path components, if necessary.
 # 1: List of newline-separated matching paths, complete with all prefix
-#    path componens.
+#    path components.
 __gitcomp_file_direct ()
 {
 	local IFS=$'\n'
@@ -522,7 +522,7 @@ __git_index_files ()
 			# Even when a directory name itself does not contain
 			# any special characters, it will still be quoted if
 			# any of its (stripped) trailing path components do.
-			# Because of this we may have seen the same direcory
+			# Because of this we may have seen the same directory
 			# both quoted and unquoted.
 			if (p in paths)
 				# We have seen the same directory unquoted,

--- a/testdata/completion/osh-unit.bash
+++ b/testdata/completion/osh-unit.bash
@@ -175,7 +175,7 @@ op_chars() { argv "$@"; }
 complete -F complete_op_chars op_chars
 
 # Aha but this does the right thing!  I think OSH should do this all the time!
-# User-defined functions shouldn't be repsonsible for quoting.
+# User-defined functions shouldn't be responsible for quoting.
 op_chars_filenames() { argv "$@"; }
 complete -F complete_op_chars -o filenames op_chars_filenames
 

--- a/testdata/osh-runtime/abuild
+++ b/testdata/osh-runtime/abuild
@@ -115,7 +115,7 @@ print_version() {
 	msg "$program $program_version"
 }
 
-# check if apkbuild is basicly sane
+# check if apkbuild is basically sane
 default_sanitycheck() {
 	local i= j= suggestion=
 	msg "Checking sanity of $APKBUILD..."
@@ -190,7 +190,7 @@ default_sanitycheck() {
 				|| die "${i##*/} is missing in checksums"
 
 			# verify that our source does not have git tag version
-			# name as tarball (typicallly github)
+			# name as tarball (typically github)
 			if is_remote "$i" && [ "${i#*::}" = "$i" ]; then
 				case ${i##*/} in
 				v$pkgver.tar.*|$pkgver.tar.*)

--- a/tools/deps.py
+++ b/tools/deps.py
@@ -35,7 +35,7 @@ class Visitor(object):
                 #log('Visiting child array %s', name)
                 for item in child:
                     # We have to check for compound objects on an INSTANCE basis, not a
-                    # type basis, because sums can look liek this:
+                    # type basis, because sums can look like this:
                     # iterable = IterArgv | IterArray(word* words)
                     # We visit the latter but not the former.
                     if isinstance(item, pybase.CompoundObj):

--- a/tools/ysh_ify.py
+++ b/tools/ysh_ify.py
@@ -668,7 +668,7 @@ class OilPrinter(object):
 
                 if node.cond.tag() == condition_e.Shell:
                     commands = cast(condition.Shell, node.cond).commands
-                    # Skip the semi-colon in the condition, which is ususally a Sentence
+                    # Skip the semi-colon in the condition, which is usually a Sentence
                     if len(commands) == 1 and commands[0].tag(
                     ) == command_e.Sentence:
                         sentence = cast(command.Sentence, commands[0])
@@ -880,7 +880,7 @@ class OilPrinter(object):
                     # NOTE: ArithSub with $(1 +2 ) is different than 1 + 2 because of
                     # conversion to string.
 
-                    # For now, jsut stub it out
+                    # For now, just stub it out
                     self.DoWordInCommand(node, local_symbols)
 
     def DoWordInCommand(self, node, local_symbols):

--- a/web/release-index.css
+++ b/web/release-index.css
@@ -29,7 +29,7 @@ code {
 /* END COMMON */
 
 
-/* Downlad links are in both releases.html and /release/$VERSION/index.html */
+/* Download links are in both releases.html and /release/$VERSION/index.html */
 
 .release-table {
   padding: 1em;

--- a/ysh/expr_parse.py
+++ b/ysh/expr_parse.py
@@ -346,7 +346,7 @@ class ExprParser(object):
             # - Id.Unknown_Tok could say "This character is invalid"
 
             # ParseError has a "too much input" case but I haven't been able to
-            # tickle it.  Mabye it's because of the Eof tokens?
+            # tickle it.  Maybe it's because of the Eof tokens?
 
             p_die(
                 'Syntax error in expression (near %s)' % ui.PrettyId(e.tok.id),

--- a/ysh/grammar.pgen2
+++ b/ysh/grammar.pgen2
@@ -468,7 +468,7 @@ import_names: import_name (comma_newline import_name)* [import_name]
 tea_import: sq_string [ 'as' Expr_Name ] ['(' [Op_Newline] [import_names] ')'] end_import
 
 # Top level:
-# delarations of constants -- with const only?
+# declarations of constants -- with const only?
 # maybe only const?
 # use, data, enum, class, func.  That's it?  OK.
 

--- a/ysh/testdata/tour.ysh
+++ b/ysh/testdata/tour.ysh
@@ -147,7 +147,7 @@ if (_status !== 0) {
 
 ### general
 
-### use command subsitution to assign the result of a command to a variable
+### use command substitution to assign the result of a command to a variable
 var year = $(date -u +"%Y")
 echo $year
 


### PR DESCRIPTION
This is the followup PR for #1691 (the first commit here actually belongs to that other PR, this PR will be rebased once that other PR has been merged).

The typos were found with the [typos spell checker](https://github.com/crate-ci/typos).
The 1st fix commit was created manually, the fixes in the 2nd fix commit were done by `typos -w` (but all manually reviewed), the fixes in the 3rd fix commit were again done  manually.

I'm planning on introducing the `typos` spell checker into the CI in a followup PR to prevent the accidental introduction of known typos in the future.