### PR TITLE
[ysh] implement len() as vm.Callable

### DIFF
--- a/core/shell.py
+++ b/core/shell.py
@@ -675,6 +675,7 @@ def Main(lang, arg_r, environ, login_shell, loader, readline):
     func_init.SetGlobalFunc(mem, 'eval_hay', eval_hay)
     func_init.SetGlobalFunc(mem, 'block_as_str', block_as_str)
     func_init.SetGlobalFunc(mem, '_hay', hay_func)
+    func_init.SetGlobalFunc(mem, 'len', func_misc.Len())
 
     # PromptEvaluator rendering is needed in non-interactive shells for @P.
     prompt_ev = prompt.Evaluator(lang, version_str, parse_ctx, mem)

--- a/core/state.py
+++ b/core/state.py
@@ -14,7 +14,7 @@ from _devbuild.gen.option_asdl import option_i
 from _devbuild.gen.runtime_asdl import (value, value_e, value_t, lvalue,
                                         lvalue_e, lvalue_t, scope_e, scope_t,
                                         HayNode, Cell)
-from _devbuild.gen.syntax_asdl import loc, Token
+from _devbuild.gen.syntax_asdl import loc, loc_t, Token
 from _devbuild.gen.types_asdl import opt_group_i
 from asdl import runtime
 from core import error
@@ -1417,8 +1417,11 @@ class Mem(object):
         self.current_tok = tok
 
     def CurrentLocation(self):
-        # type: () -> Token
-        return self.current_tok
+        # type: () -> loc_t
+        if self.current_tok:
+            return self.current_tok
+
+        return loc.Missing
 
     #
     # Status Variable Stack (for isolating $PS1 and $PS4)

--- a/library/func_cpython.py
+++ b/library/func_cpython.py
@@ -174,7 +174,7 @@ def Init(mem):
     # For compositionality and testing
     SetGlobalFunc(mem, 'identity', lambda x: x)  # IN-YSH
 
-    SetGlobalFunc(mem, 'len', len)
+    SetGlobalFunc(mem, 'len', func_misc.Len())
     SetGlobalFunc(mem, 'max', max)  # IN-YSH with <
     SetGlobalFunc(mem, 'min', min)  # IN-YSH
     # NOTE: cmp() deprecated in Python 3

--- a/library/func_cpython.py
+++ b/library/func_cpython.py
@@ -174,7 +174,6 @@ def Init(mem):
     # For compositionality and testing
     SetGlobalFunc(mem, 'identity', lambda x: x)  # IN-YSH
 
-    SetGlobalFunc(mem, 'len', func_misc.Len())
     SetGlobalFunc(mem, 'max', max)  # IN-YSH with <
     SetGlobalFunc(mem, 'min', min)  # IN-YSH
     # NOTE: cmp() deprecated in Python 3

--- a/library/func_misc.py
+++ b/library/func_misc.py
@@ -167,15 +167,7 @@ class Len(vm._Callable):
         UP_x = x
 
         with tagswitch(x) as case:
-            if case(value_e.BashArray):
-                x = cast(value.BashArray, UP_x)
-                return value.Int(len(x.strs))
-
-            elif case(value_e.BashAssoc):
-                x = cast(value.BashAssoc, UP_x)
-                return value.Int(len(x.d))
-
-            elif case(value_e.List):
+            if case(value_e.List):
                 x = cast(value.List, UP_x)
                 return value.Int(len(x.items))
 

--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -1168,6 +1168,7 @@ class CommandEvaluator(object):
 
             elif case(command_e.Retval):
                 node = cast(command.Retval, UP_node)
+                self.mem.SetLocationToken(node.keyword)
 
                 val = self.expr_ev.EvalExpr(node.val, node.keyword)
                 raise vm.ValueControlFlow(node.keyword, val)
@@ -1175,6 +1176,7 @@ class CommandEvaluator(object):
             elif case(command_e.ControlFlow):
                 node = cast(command.ControlFlow, UP_node)
                 keyword = node.keyword
+                self.mem.SetLocationToken(node.keyword)
 
                 if node.arg_word:  # Evaluate the argument
                     str_val = self.word_ev.EvalWordToString(node.arg_word)
@@ -1289,6 +1291,7 @@ class CommandEvaluator(object):
 
             elif case(command_e.WhileUntil):
                 node = cast(command.WhileUntil, UP_node)
+                self.mem.SetLocationToken(node.keyword)
                 status = 0
 
                 with ctx_LoopLevel(self):
@@ -1483,6 +1486,7 @@ class CommandEvaluator(object):
 
             elif case(command_e.ShFunction):
                 node = cast(command.ShFunction, UP_node)
+                self.mem.SetLocationToken(node.name_tok)
                 if node.name in self.procs and not self.exec_opts.redefine_proc_func(
                 ):
                     e_die(
@@ -1496,6 +1500,7 @@ class CommandEvaluator(object):
             elif case(command_e.Proc):
                 node = cast(command.Proc, UP_node)
 
+                self.mem.SetLocationToken(node.name)
                 proc_name = lexer.TokenVal(node.name)
                 if proc_name in self.procs and not self.exec_opts.redefine_proc_func(
                 ):
@@ -1552,6 +1557,7 @@ class CommandEvaluator(object):
                 node = cast(command.If, UP_node)
                 done = False
                 for if_arm in node.arms:
+                    self.mem.SetLocationToken(if_arm.keyword)
                     b = self._EvalCondition(if_arm.cond, if_arm.keyword)
                     if b:
                         status = self._ExecuteList(if_arm.action)

--- a/spec/ysh-expr.test.sh
+++ b/spec/ysh-expr.test.sh
@@ -68,7 +68,7 @@ echo $length
 3
 ## END
 
-#### Length in two different contexts
+#### Length doesn't apply to BashArray
 x=(a b c)
 x[10]=A
 x[20]=B
@@ -76,13 +76,12 @@ x[20]=B
 # shell style: length is 5
 echo shell=${#x[@]}
 
-# Oil function call: length is 20.  I think that makes sense?  It's just a
-# different notion of length.
-echo oil=$[len(x)]
+# Length could be 20, but we may change the representation to Dict[int, str]
+echo ysh=$[len(x)]
 
+## status: 3
 ## STDOUT:
 shell=5
-oil=21
 ## END
 
 #### $[len(x)] inside strings

--- a/spec/ysh-funcs-builtin.test.sh
+++ b/spec/ysh-funcs-builtin.test.sh
@@ -2,7 +2,7 @@
 
 # TODO: Test that there are exceptions when there are too many args, etc.
 
-#### Bool()
+#### Bool() - should this be Bool.fromObj()?
 var a = Bool( :|| )
 var b = Bool( :|foo| )
 write $a $b
@@ -11,7 +11,7 @@ false
 true
 ## END
 
-#### Int()
+#### Int() - should this be Int.fromStr() ?
 var a = Int("3")
 var b = Int("-35")
 write $a $b
@@ -25,7 +25,7 @@ echo 'should not get here'
 -35
 ## END
 
-#### Float()
+#### Float() - should this be Float.fromStr() ?
 # TODO: This needs a lot more testing, for precision, etc.
 var a = Float("1.2")
 var b = Float("3.4")
@@ -33,24 +33,6 @@ write $a $b
 ## STDOUT:
 1.2
 3.4
-## END
-
-#### Str()
-# TODO: more testing
-var a = Str(5)
-var b = Str(42)
-write $a $b
-## STDOUT:
-5
-42
-## END
-
-#### Dict()
-# TODO: more testing
-var a = Dict()
-write $[len(a)]
-## STDOUT:
-0
 ## END
 
 #### join()

--- a/spec/ysh-user-feedback.test.sh
+++ b/spec/ysh-user-feedback.test.sh
@@ -105,14 +105,18 @@ git-branch-merged | while read --line {
   }
 } | readarray -t :branches
 
-if (len(branches) === 0) {
+# TODO: I think we want read --lines :branches ?  Then we don't need this
+# conversion.
+var branchList = :| "${branches[@]}" |
+
+if (len(branchList) === 0) {
   echo "No merged branches"
 } else {
-  write git branch -D @branches
+  write git branch -D @branchList
 }
 
 # With "append".  Hm read --lines isn't bad.
-var branches2 = %()
+var branches2 = :| |
 git-branch-merged | while read --line {
   var line2 = _line->strip()  # removing leading space
   if (line2 !== 'master' and not line2->startswith('*')) {


### PR DESCRIPTION
This patch implements `len()` over `value_t`. It also fixes some error presentation code in the command evaluator