### PR TITLE
[frontend] Fill Out typed_args::Reader

### DIFF
--- a/frontend/typed_args.py
+++ b/frontend/typed_args.py
@@ -8,6 +8,7 @@ from _devbuild.gen.syntax_asdl import (loc, ArgList, BlockArg, command_t,
 from core import error
 from core.error import e_usage
 from mycpp.mylib import tagswitch
+from ysh import val_ops
 
 from typing import Optional, Dict, List, cast
 
@@ -113,18 +114,71 @@ class Reader(object):
 
     ### Typed positional args
 
-    # TODO: may need location info
     def PosStr(self):
         # type: () -> str
-        return None  # TODO
+        try:
+            arg = self.pos_args.pop(0)
+        except IndexError:
+            # TODO: may need location info
+            raise error.InvalidType('No arguments left', loc.Missing)
+
+        return val_ops.MustBeStr(arg).s
 
     def PosInt(self):
         # type: () -> int
-        return -1  # TODO
+        try:
+            arg = self.pos_args.pop(0)
+        except IndexError:
+            # TODO: may need location info
+            raise error.InvalidType('No arguments left', loc.Missing)
+
+        return val_ops.MustBeInt(arg).i
+
+    def PosFloat(self):
+        # type: () -> float
+        try:
+            arg = self.pos_args.pop(0)
+        except IndexError:
+            # TODO: may need location info
+            raise error.InvalidType('No arguments left', loc.Missing)
+
+        return val_ops.MustBeFloat(arg).f
+
+    def PosList(self):
+        # type: () -> List[value_t]
+        try:
+            arg = self.pos_args.pop(0)
+        except IndexError:
+            # TODO: may need location info
+            raise error.InvalidType('No arguments left', loc.Missing)
+
+        return val_ops.MustBeList(arg).items
+
+    def PosDict(self):
+        # type: () -> Dict[str, value_t]
+        try:
+            arg = self.pos_args.pop(0)
+        except IndexError:
+            # TODO: may need location info
+            raise error.InvalidType('No arguments left', loc.Missing)
+
+        return val_ops.MustBeDict(arg).d
+
+    def PosValue(self):
+        # type: () -> value_t
+        try:
+            arg = self.pos_args.pop(0)
+        except IndexError:
+            # TODO: may need location info
+            raise error.InvalidType('No arguments left', loc.Missing)
+
+        return arg
 
     def RestPos(self):
         # type: () -> List[value_t]
-        return None  # TODO
+        ret = self.pos_args
+        self.pos_args = []
+        return ret
 
     ### Typed named args
 
@@ -159,7 +213,11 @@ class Reader(object):
         problem
         """
         # Note: Python throws TypeError on mismatch
-        pass
+        if len(self.pos_args):
+            raise error.InvalidType('Still have %d args left' % len(self.pos_args), loc.Missing)
+
+        if len(self.named_args):
+            raise error.InvalidType('Still have %d named args left' % len(self.pos_args), loc.Missing)
 
 
 def DoesNotAccept(arg_list):

--- a/frontend/typed_args.py
+++ b/frontend/typed_args.py
@@ -2,7 +2,7 @@
 """Typed_args.py."""
 from __future__ import print_function
 
-from _devbuild.gen.runtime_asdl import value_t, value_str
+from _devbuild.gen.runtime_asdl import value_t
 from _devbuild.gen.syntax_asdl import (loc, ArgList, BlockArg, command_t,
                                        expr_e, expr_t, CommandSub)
 from core import error

--- a/frontend/typed_args.py
+++ b/frontend/typed_args.py
@@ -13,47 +13,6 @@ from ysh import val_ops
 from typing import Optional, Dict, List, cast
 
 
-class Spec(object):
-    """Utility to express argument specifications (runtime typechecking)."""
-
-    def __init__(self, pos_args, named_args):
-        # type: (List[int], Dict[str, int]) -> None
-        """Empty constructor for mycpp."""
-        self.pos_args = pos_args
-        self.named_args = named_args
-
-    def AssertArgs(self, func_name, pos_args, named_args):
-        # type: (str, List[value_t], Dict[str, value_t]) -> None
-        """Assert any type differences between the spec and the given args."""
-        nargs = len(pos_args)
-        expected = len(self.pos_args)
-        if nargs != expected:
-            raise error.InvalidType(
-                "%s() expects %d arguments but %d were given" %
-                (func_name, expected, nargs), loc.Missing)
-
-        nargs = len(named_args)
-        expected = len(self.named_args)
-        if len(named_args) != 0:
-            raise error.InvalidType(
-                "%s() expects %d named arguments but %d were given" %
-                (func_name, expected, nargs), loc.Missing)
-
-        for i in xrange(len(pos_args)):
-            expected = self.pos_args[i]
-            got = pos_args[i]
-            if got.tag() != expected:
-                msg = "%s() expected %s" % (func_name, value_str(expected))
-                raise error.InvalidType2(got, msg, loc.Missing)
-
-        for name in named_args:
-            expected = self.named_args[name]
-            got = named_args[name]
-            if got.tag() != expected:
-                msg = "%s() expected %s" % (func_name, value_str(expected))
-                raise error.InvalidType2(got, msg, loc.Missing)
-
-
 class Reader(object):
     """
     func f(a Str) {

--- a/frontend/typed_args.py
+++ b/frontend/typed_args.py
@@ -7,7 +7,7 @@ from _devbuild.gen.syntax_asdl import (loc, ArgList, BlockArg, command_t,
                                        expr_e, expr_t, CommandSub)
 from core import error
 from core.error import e_usage
-from mycpp.mylib import tagswitch
+from mycpp.mylib import dict_erase, tagswitch
 from ysh import val_ops
 
 from typing import Optional, Dict, List, cast
@@ -184,15 +184,54 @@ class Reader(object):
 
     def NamedStr(self, param_name, default_):
         # type: (str, str) -> str
-        return None  # TODO
+        if param_name not in self.named_args:
+            return default_
+
+        ret = val_ops.MustBeStr(self.named_args[param_name]).s
+        dict_erase(self.named_args, param_name)
+        return ret
 
     def NamedInt(self, param_name, default_):
         # type: (str, int) -> int
-        return -1  # TODO
+        if param_name not in self.named_args:
+            return default_
+
+        ret = val_ops.MustBeInt(self.named_args[param_name]).i
+        dict_erase(self.named_args, param_name)
+        return ret
+
+    def NamedFloat(self, param_name, default_):
+        # type: (str, float) -> float
+        if param_name not in self.named_args:
+            return default_
+
+        ret = val_ops.MustBeFloat(self.named_args[param_name]).f
+        dict_erase(self.named_args, param_name)
+        return ret
+
+    def NamedList(self, param_name, default_):
+        # type: (str, List[value_t]) -> List[value_t]
+        if param_name not in self.named_args:
+            return default_
+
+        ret = val_ops.MustBeList(self.named_args[param_name]).items
+        dict_erase(self.named_args, param_name)
+        return ret
+
+    def NamedDict(self, param_name, default_):
+        # type: (str, Dict[str, value_t]) -> Dict[str, value_t]
+        if param_name not in self.named_args:
+            return default_
+
+        ret = val_ops.MustBeDict(self.named_args[param_name]).d
+        dict_erase(self.named_args, param_name)
+        return ret
 
     def RestNamed(self):
         # type: () -> Dict[str, value_t]
-        return None  # TODO
+        ret = self.named_args
+        self.named_args = {}
+        return ret
 
     def Block(self):
         # type: () -> command_t

--- a/frontend/typed_args.py
+++ b/frontend/typed_args.py
@@ -111,6 +111,7 @@ class Reader(object):
         return val_ops.MustBeDict(arg).d
 
     def PosValue(self):
+        # type: () -> value_t
         return self._GetNextPos()
 
     def RestPos(self):

--- a/frontend/typed_args_test.py
+++ b/frontend/typed_args_test.py
@@ -57,6 +57,51 @@ class TypedArgsTest(unittest.TestCase):
 
         reader.Done()
 
+    def testReaderKwargs(self):
+        kwargs = {
+            'hot': value.Int(0xc0ffee),
+            'name': value.Str('foo'),
+            'numbers': value.List([value.Int(1), value.Int(2), value.Int(3)]),
+            'blah': value.Dict({'a': value.Int(0xaa), 'b': value.Int(0xbb)}),
+            'pi': value.Float(3.14),
+            'a': value.Int(0xdead),
+            'b': value.Int(0xbeef),
+            'c': value.Str('bar'),
+        }
+        reader = typed_args.Reader([], kwargs)
+
+        # Haven't processed any args yet...
+        self.assertRaises(error.InvalidType, reader.Done)
+
+        arg = reader.NamedInt('hot', -1)
+        self.assertEqual(0xc0ffee, arg)
+
+        arg = reader.NamedStr('name', '')
+        self.assertEqual('foo', arg)
+
+        arg = reader.NamedList('numbers', [])
+        self.assertEqual(1, cast(value.Int, arg[0]).i)
+        self.assertEqual(2, cast(value.Int, arg[1]).i)
+        self.assertEqual(3, cast(value.Int, arg[2]).i)
+
+        arg = reader.NamedDict('blah', {})
+        self.assertIn('a', arg)
+        self.assertEqual(0xaa, arg['a'].i)
+        self.assertIn('b', arg)
+        self.assertEqual(0xbb, arg['b'].i)
+
+        arg = reader.NamedFloat('pi', -1.0)
+        self.assertEqual(3.14, arg)
+
+        rest = reader.RestNamed()
+        self.assertEqual(3, len(rest))
+        self.assertIn('a', rest)
+        self.assertEqual(0xdead, rest['a'].i)
+        self.assertIn('b', rest)
+        self.assertEqual(0xbeef, rest['b'].i)
+        self.assertIn('c', rest)
+        self.assertEqual('bar', rest['c'].s)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/frontend/typed_args_test.py
+++ b/frontend/typed_args_test.py
@@ -14,6 +14,10 @@ from typing import cast
 
 class TypedArgsTest(unittest.TestCase):
     def testReaderPosArgs(self):
+        # Not enough args...
+        reader = typed_args.Reader([], {})
+        self.assertRaises(error.InvalidType, reader.PosStr)
+
         pos_args = [
             value.Int(0xc0ffee),
             value.Str('foo'),
@@ -24,11 +28,16 @@ class TypedArgsTest(unittest.TestCase):
             value.Int(0xbeef),
             value.Str('bar'),
         ]
-        reader = typed_args.Reader(pos_args, {})
+        reader = typed_args.Reader(list(pos_args), {})
 
         # Haven't processed any args yet...
         self.assertRaises(error.InvalidType, reader.Done)
 
+        # Arg is wrong type...
+        self.assertRaises(error.InvalidType, reader.PosStr)
+
+        # Normal operation from here on
+        reader = typed_args.Reader(pos_args, {})
         arg = reader.PosInt()
         self.assertEqual(0xc0ffee, arg)
 

--- a/frontend/typed_args_test.py
+++ b/frontend/typed_args_test.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python2
+"""
+typed_args_test.py: Tests for typed_args.py
+"""
+
+import unittest
+
+from _devbuild.gen.runtime_asdl import value
+from core import error
+from frontend import typed_args  # module under test
+
+from typing import cast
+
+
+class TypedArgsTest(unittest.TestCase):
+    def testReaderPosArgs(self):
+        pos_args = [
+            value.Int(0xc0ffee),
+            value.Str('foo'),
+            value.List([value.Int(1), value.Int(2), value.Int(3)]),
+            value.Dict({'a': value.Int(0xaa), 'b': value.Int(0xbb)}),
+            value.Float(3.14),
+            value.Int(0xdead),
+            value.Int(0xbeef),
+            value.Str('bar'),
+        ]
+        reader = typed_args.Reader(pos_args, {})
+
+        # Haven't processed any args yet...
+        self.assertRaises(error.InvalidType, reader.Done)
+
+        arg = reader.PosInt()
+        self.assertEqual(0xc0ffee, arg)
+
+        arg = reader.PosStr()
+        self.assertEqual('foo', arg)
+
+        arg = reader.PosList()
+        self.assertEqual(1, cast(value.Int, arg[0]).i)
+        self.assertEqual(2, cast(value.Int, arg[1]).i)
+        self.assertEqual(3, cast(value.Int, arg[2]).i)
+
+        arg = reader.PosDict()
+        self.assertIn('a', arg)
+        self.assertEqual(0xaa, arg['a'].i)
+        self.assertIn('b', arg)
+        self.assertEqual(0xbb, arg['b'].i)
+
+        arg = reader.PosFloat()
+        self.assertEqual(3.14, arg)
+
+        rest = reader.RestPos()
+        self.assertEqual(3, len(rest))
+        self.assertEqual(0xdead, rest[0].i)
+        self.assertEqual(0xbeef, rest[1].i)
+        self.assertEqual('bar', rest[2].s)
+
+        reader.Done()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/library/func_hay.py
+++ b/library/func_hay.py
@@ -70,9 +70,9 @@ class ParseHay(vm._Callable):
     def Call(self, pos_args, named_args):
         # type: (List[value_t], Dict[str, value_t]) -> value_t
 
-        reader = typed_args.Reader(pos_args, named_args)
-        string = reader.PosStr()
-        reader.Done()
+        arg_reader = typed_args.Reader(pos_args, named_args)
+        string = arg_reader.PosStr()
+        arg_reader.Done()
         return self._Call(string)
 
 

--- a/library/func_hay.py
+++ b/library/func_hay.py
@@ -70,10 +70,9 @@ class ParseHay(vm._Callable):
     def Call(self, pos_args, named_args):
         # type: (List[value_t], Dict[str, value_t]) -> value_t
 
-        spec = typed_args.Spec([value_e.Str], {})
-        spec.AssertArgs("parseHay", pos_args, named_args)
-
-        string = cast(value.Str, pos_args[0]).s
+        reader = typed_args.Reader(pos_args, named_args)
+        string = reader.PosStr()
+        reader.Done()
         return self._Call(string)
 
 

--- a/library/func_misc.py
+++ b/library/func_misc.py
@@ -85,10 +85,10 @@ class StartsWith(vm._Callable):
     def Call(self, pos_args, named_args):
         # type: (List[value_t], Dict[str, value_t]) -> value_t
 
-        reader = typed_args.Reader(pos_args, named_args)
-        string = reader.PosStr()
-        match = reader.PosStr()
-        reader.Done()
+        arg_reader = typed_args.Reader(pos_args, named_args)
+        string = arg_reader.PosStr()
+        match = arg_reader.PosStr()
+        arg_reader.Done()
 
         res = string.startswith(match)
         return value.Bool(res)
@@ -103,9 +103,9 @@ class Strip(vm._Callable):
     def Call(self, pos_args, named_args):
         # type: (List[value_t], Dict[str, value_t]) -> value_t
 
-        reader = typed_args.Reader(pos_args, named_args)
-        string = reader.PosStr()
-        reader.Done()
+        arg_reader = typed_args.Reader(pos_args, named_args)
+        string = arg_reader.PosStr()
+        arg_reader.Done()
 
         res = string.strip()
         return value.Str(res)
@@ -120,9 +120,9 @@ class Upper(vm._Callable):
     def Call(self, pos_args, named_args):
         # type: (List[value_t], Dict[str, value_t]) -> value_t
 
-        reader = typed_args.Reader(pos_args, named_args)
-        string = reader.PosStr()
-        reader.Done()
+        arg_reader = typed_args.Reader(pos_args, named_args)
+        string = arg_reader.PosStr()
+        arg_reader.Done()
 
         res = string.upper()
         return value.Str(res)
@@ -137,9 +137,9 @@ class Keys(vm._Callable):
     def Call(self, pos_args, named_args):
         # type: (List[value_t], Dict[str, value_t]) -> value_t
 
-        reader = typed_args.Reader(pos_args, named_args)
-        dictionary = reader.PosDict()
-        reader.Done()
+        arg_reader = typed_args.Reader(pos_args, named_args)
+        dictionary = arg_reader.PosDict()
+        arg_reader.Done()
 
         keys = [value.Str(k) for k in dictionary.keys()]  # type: List[value_t]
         return value.List(keys)
@@ -154,9 +154,9 @@ class Len(vm._Callable):
     def Call(self, pos_args, named_args):
         # type: (List[value_t], Dict[str, value_t]) -> value_t
 
-        reader = typed_args.Reader(pos_args, named_args)
-        x = reader.PosValue()
-        reader.Done()
+        arg_reader = typed_args.Reader(pos_args, named_args)
+        x = arg_reader.PosValue()
+        arg_reader.Done()
 
         UP_x = x
         with tagswitch(x) as case:

--- a/library/func_misc.py
+++ b/library/func_misc.py
@@ -85,11 +85,10 @@ class StartsWith(vm._Callable):
     def Call(self, pos_args, named_args):
         # type: (List[value_t], Dict[str, value_t]) -> value_t
 
-        spec = typed_args.Spec([value_e.Str, value_e.Str], {})
-        spec.AssertArgs("startswith", pos_args, named_args)
-
-        string = cast(value.Str, pos_args[0]).s
-        match = cast(value.Str, pos_args[1]).s
+        reader = typed_args.Reader(pos_args, named_args)
+        string = reader.PosStr()
+        match = reader.PosStr()
+        reader.Done()
 
         res = string.startswith(match)
         return value.Bool(res)
@@ -104,10 +103,9 @@ class Strip(vm._Callable):
     def Call(self, pos_args, named_args):
         # type: (List[value_t], Dict[str, value_t]) -> value_t
 
-        spec = typed_args.Spec([value_e.Str], {})
-        spec.AssertArgs("strip", pos_args, named_args)
-
-        string = cast(value.Str, pos_args[0]).s
+        reader = typed_args.Reader(pos_args, named_args)
+        string = reader.PosStr()
+        reader.Done()
 
         res = string.strip()
         return value.Str(res)
@@ -122,10 +120,9 @@ class Upper(vm._Callable):
     def Call(self, pos_args, named_args):
         # type: (List[value_t], Dict[str, value_t]) -> value_t
 
-        spec = typed_args.Spec([value_e.Str], {})
-        spec.AssertArgs("upper", pos_args, named_args)
-
-        string = cast(value.Str, pos_args[0]).s
+        reader = typed_args.Reader(pos_args, named_args)
+        string = reader.PosStr()
+        reader.Done()
 
         res = string.upper()
         return value.Str(res)
@@ -140,10 +137,9 @@ class Keys(vm._Callable):
     def Call(self, pos_args, named_args):
         # type: (List[value_t], Dict[str, value_t]) -> value_t
 
-        spec = typed_args.Spec([value_e.Dict], {})
-        spec.AssertArgs("keys", pos_args, named_args)
-
-        dictionary = cast(value.Dict, pos_args[0]).d
+        reader = typed_args.Reader(pos_args, named_args)
+        dictionary = reader.PosDict()
+        reader.Done()
 
         keys = [value.Str(k) for k in dictionary.keys()]  # type: List[value_t]
         return value.List(keys)
@@ -158,14 +154,11 @@ class Len(vm._Callable):
     def Call(self, pos_args, named_args):
         # type: (List[value_t], Dict[str, value_t]) -> value_t
 
-        n_args = len(pos_args)
-        if n_args != 1:
-            raise error.InvalidType("len() expects exactly one argument but %d were given" %
-                          n_args, loc.Missing)
+        reader = typed_args.Reader(pos_args, named_args)
+        x = reader.PosValue()
+        reader.Done()
 
-        x = pos_args[0]
         UP_x = x
-
         with tagswitch(x) as case:
             if case(value_e.List):
                 x = cast(value.List, UP_x)

--- a/ysh/val_ops.py
+++ b/ysh/val_ops.py
@@ -51,7 +51,7 @@ def MustBeInt(val):
         return val
 
     raise error.InvalidType(
-        'expected value.Int, but got %s' % value_str(val.tag()), loc.Missing)
+        'Expected value.Int, but got %s' % value_str(val.tag()), loc.Missing)
 
 
 def MustBeFloat(val):
@@ -62,7 +62,7 @@ def MustBeFloat(val):
         return val
 
     raise error.InvalidType(
-        'expected value.Float, but got %s' % value_str(val.tag()), loc.Missing)
+        'Expected value.Float, but got %s' % value_str(val.tag()), loc.Missing)
 
 
 def MustBeStr(val):
@@ -73,7 +73,7 @@ def MustBeStr(val):
         return val
 
     raise error.InvalidType(
-        'expected value.Str, but got %s' % value_str(val.tag()), loc.Missing)
+        'Expected value.Str, but got %s' % value_str(val.tag()), loc.Missing)
 
 
 def MustBeList(val):
@@ -84,7 +84,7 @@ def MustBeList(val):
         return val
 
     raise error.InvalidType(
-        'expected value.List, but got %s' % value_str(val.tag()), loc.Missing)
+        'Expected value.List, but got %s' % value_str(val.tag()), loc.Missing)
 
 
 def MustBeDict(val):
@@ -95,7 +95,7 @@ def MustBeDict(val):
         return val
 
     raise error.InvalidType(
-        'expected value.Dict, but got %s' % value_str(val.tag()), loc.Missing)
+        'Expected value.Dict, but got %s' % value_str(val.tag()), loc.Missing)
 
 
 def MustBeFunc(val):
@@ -106,7 +106,7 @@ def MustBeFunc(val):
         return val
 
     raise error.InvalidType(
-        'expected value.Func, but got %s' % value_str(val.tag()), loc.Missing)
+        'Expected value.Func, but got %s' % value_str(val.tag()), loc.Missing)
 
 
 def Stringify(val, blame_loc, prefix=''):

--- a/ysh/val_ops.py
+++ b/ysh/val_ops.py
@@ -54,6 +54,17 @@ def MustBeInt(val):
         'expected value.Int, but got %s' % value_str(val.tag()), loc.Missing)
 
 
+def MustBeFloat(val):
+    # type: (value_t) -> value.Float
+    UP_val = val
+    if val.tag() == value_e.Float:
+        val = cast(value.Float, UP_val)
+        return val
+
+    raise error.InvalidType(
+        'expected value.Float, but got %s' % value_str(val.tag()), loc.Missing)
+
+
 def MustBeStr(val):
     # type: (value_t) -> value.Str
     UP_val = val
@@ -74,6 +85,17 @@ def MustBeList(val):
 
     raise error.InvalidType(
         'expected value.List, but got %s' % value_str(val.tag()), loc.Missing)
+
+
+def MustBeDict(val):
+    # type: (value_t) -> value.Dict
+    UP_val = val
+    if val.tag() == value_e.Dict:
+        val = cast(value.Dict, UP_val)
+        return val
+
+    raise error.InvalidType(
+        'expected value.Dict, but got %s' % value_str(val.tag()), loc.Missing)
 
 
 def MustBeFunc(val):


### PR DESCRIPTION
This patch implements the positional and named arg parts. I left out the stuff for procs for now, since I haven't been following the discussions around what we need there.

I added some unit tests to serve as documentation of sorts. Let me know if you think we should add more comprehensive ones though.