### PR TITLE
[docs] Document all stdlib/{math,list}.ysh functions

### DIFF
--- a/devtools/release.sh
+++ b/devtools/release.sh
@@ -458,7 +458,7 @@ compress() {
   popd
 
   log "--- src-tree"
-  local out="$root/srec-tree.wwz"
+  local out="$root/src-tree.wwz"
   pushd _tmp/src-tree
   time zip -r -q $out .  # recursive, quiet
   popd

--- a/doc/ref/chap-builtin-func.md
+++ b/doc/ref/chap-builtin-func.md
@@ -24,16 +24,92 @@ This chapter in the [Oils Reference](index.html) describes builtin functions.
 
 ### abs()
 
+Compute the absolute (positive) value of a number (float or int).
+
+    = abs(-1)  # => 1
+    = abs(0)   # => 0
+    = abs(1)   # => 1
+
+Note, you will need to `source --builtin math.ysh` to use this function.
+
 ### max()
 
+Compute the maximum of 2 or more values.
+
+`max` takes two different signatures:
+
+  1. `max(a, b)` to return the maximum of `a`, `b`
+  2. `max(list)` to return the greatest item in the `list`
+
+For example:
+
+      = max(1, 2)  # => 2
+      = max([1, 2, 3])  # => 3
+
+Note, you will need to `source --builtin math.ysh` to use this function.
+
 ### min()
+
+Compute the minimum of 2 or more values.
+
+`min` takes two different signatures:
+
+  1. `min(a, b)` to return the minimum of `a`, `b`
+  2. `min(list)` to return the least item in the `list`
+
+For example:
+
+    = min(2, 3)  # => 2
+    = max([1, 2, 3])  # => 1
+
+Note, you will need to `source --builtin math.ysh` to use this function.
 
 ### round()
 
 ### sum()
 
+Computes the sum of all elements in the list.
+
+Returns 0 for an empty list.
+
+    = sum([])  # => 0
+    = sum([0])  # => 0
+    = sum([1, 2, 3])  # => 6
+
+Note, you will need to `source --builtin list.ysh` to use this function.
+
 ## Int
 
+
+## List
+
+### any()
+
+Returns true if any value in the list is truthy (`x` is truthy if `Bool(x)`
+returns true).
+
+If the list is empty, return false.
+
+    = any([])  # => false
+    = any([true, false])  # => true
+    = any([false, false])  # => false
+    = any([false, "foo", false])  # => true
+
+Note, you will need to `source --builtin list.ysh` to use this function.
+
+### all()
+
+Returns true if all values in the list are truthy (`x` is truthy if `Bool(x)`
+returns true).
+
+If the list is empty, return true.
+
+    = any([])  # => true
+    = any([true, true])  # => true
+    = any([false, true])  # => false
+    = any(["foo", true, true])  # => true
+
+Note, you will need to `source --builtin list.ysh` to use this function.
 
 ## Pattern
 

--- a/doc/ref/toc-ysh.md
+++ b/doc/ref/toc-ysh.md
@@ -251,6 +251,7 @@ X [Builtin Sub]   _buffer
 
 ```chapter-links-builtin-func
   [Values]        len()   type() 
+  [List]          any()   all()
   [Math]          abs()   max()   min()   round()   sum()
 X [Int]           ord()   chr()
 X [Str]           find(eggex)   replace(eggex, template)


### PR DESCRIPTION
I don't like that I have to write "Note, you will need to `source --builtin <some-file>.ysh` to use this function" everywhere. Maybe we can add a link to the right of the function name? We might be able to fit a link to the source location there too.

But, this should be fine on it's own. I can always do the above changes in another PR.

EDIT: Here's the rendered docs for reference http://travis-ci.oilshell.org/github-jobs/4914/ovm-tarball.wwz/_release/VERSION/doc/ref/chap-builtin-func.html#abs.