### PR TITLE
[builtin/error] Update the error builtin to use typed_args.Reader

### DIFF
--- a/frontend/typed_args.py
+++ b/frontend/typed_args.py
@@ -69,12 +69,11 @@ class Reader(object):
 
     def Word(self):
         # type: () -> str
-
-        return None
+        return None  # TODO
 
     def RestWords(self):
         # type: () -> List[str]
-        return None
+        return None  # TODO
 
     ### Typed positional args
 

--- a/frontend/typed_args.py
+++ b/frontend/typed_args.py
@@ -217,13 +217,15 @@ class Reader(object):
         """
         # Note: Python throws TypeError on mismatch
         if len(self.pos_args):
-            raise error.TypeErrVerbose('Expected %d arguments, but got %d' %
-                                    (self.pos_consumed, self.pos_consumed +
-                                     len(self.pos_args)), loc.Missing)
+            raise error.TypeErrVerbose(
+                'Expected %d arguments, but got %d' %
+                (self.pos_consumed, self.pos_consumed + len(self.pos_args)),
+                loc.Missing)
 
         if len(self.named_args):
             bad_args = ','.join(self.named_args.keys())
-            raise error.TypeErrVerbose('Got unexpected named args: %s' % bad_args, loc.Missing)
+            raise error.TypeErrVerbose(
+                'Got unexpected named args: %s' % bad_args, loc.Missing)
 
 
 def ReaderFromArgv(typed_args, expr_ev):

--- a/frontend/typed_args.py
+++ b/frontend/typed_args.py
@@ -9,10 +9,11 @@ from core import error
 from core.error import e_usage
 from frontend import lexer
 from mycpp.mylib import dict_erase, tagswitch
-from ysh import expr_eval
 from ysh import val_ops
 
-from typing import Optional, Dict, List, cast
+from typing import Optional, Dict, List, TYPE_CHECKING, cast
+if TYPE_CHECKING:
+    from ysh.expr_eval import ExprEvaluator
 
 
 class Reader(object):
@@ -236,7 +237,7 @@ class Reader(object):
 
 
 def ReaderFromArgv(cmd_val, expr_ev):
-    # type: (cmd_value.Argv, expr_eval.ExprEvaluator) -> Reader
+    # type: (cmd_value.Argv, ExprEvaluator) -> Reader
     """
     Build a typed_args.Reader given a builtin command's Argv.
 

--- a/frontend/typed_args.py
+++ b/frontend/typed_args.py
@@ -7,7 +7,9 @@ from _devbuild.gen.syntax_asdl import (loc, ArgList, BlockArg, command_t,
                                        expr_e, expr_t, CommandSub)
 from core import error
 from core.error import e_usage
+from frontend import lexer
 from mycpp.mylib import dict_erase, tagswitch
+from ysh import expr_eval
 from ysh import val_ops
 
 from typing import Optional, Dict, List, cast
@@ -234,7 +236,7 @@ class Reader(object):
 
 
 def ReaderFromArgv(cmd_val, expr_ev):
-    # type: (cmd_value.Argv, expr_eval.ExprEvaluator) -> typed_args.Reader
+    # type: (cmd_value.Argv, expr_eval.ExprEvaluator) -> Reader
     """
     Build a typed_args.Reader given a builtin command's Argv.
 
@@ -254,7 +256,7 @@ def ReaderFromArgv(cmd_val, expr_ev):
             name = lexer.TokenVal(named_arg.name)
             named_args[name] = result
 
-    return typed_args.Reader(cmd_val.argv, pos_args, named_args)
+    return Reader(cmd_val.argv, pos_args, named_args)
 
 
 def DoesNotAccept(arg_list):

--- a/osh/builtin_meta.py
+++ b/osh/builtin_meta.py
@@ -39,30 +39,6 @@ if TYPE_CHECKING:
     from osh.cmd_parse import CommandParser
 
 
-def BuildArgReader(cmd_val, expr_ev):
-    # type: (cmd_value.Argv, expr_eval.Evaluator) -> typed_args.Reader
-    """
-    Build a typed_args.Reader given a builtin command's Argv.
-
-    As part of constructing the Reader, we must evaluate all arguments. This
-    function may fail if there are any runtime errors whilst evaluating those
-    arguments.
-    """
-    pos_args = cmd_val.typed_args and []
-    named_args = cmd_val.typed_args and {}
-    if cmd_val.typed_args:
-        for i, arg in enumerate(cmd_val.typed_args.pos_args):
-            result = self.expr_ev.EvalExpr(arg, cmd_val.arg_locs[i])
-            pos_args.append(result)
-
-        for arg in cmd_val.typed_args.named_args:
-            result = self.expr_ev.EvalExpr(arg.value, arg.name)
-            name = lexer.TokenVal(arg.name)
-            named_args[name] = result
-
-    return typed_args.Reader(cmd_val.argv, pos_args, named_args)
-
-
 class Eval(vm._Builtin):
     def __init__(self, parse_ctx, exec_opts, cmd_ev, tracer, errfmt):
         # type: (ParseContext, optview.Exec, CommandEvaluator, dev.Tracer, ui.ErrorFormatter) -> None
@@ -390,7 +366,7 @@ class Error(vm._Builtin):
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        t = BuildArgReader(cmd_val)
+        t = typed_args.ReaderFromArgv(cmd_val, self.expr_ev)
 
         message = t.PosStr()
         status = t.NamedInt("error", 1)

--- a/osh/builtin_meta.py
+++ b/osh/builtin_meta.py
@@ -5,7 +5,7 @@ builtin_meta.py - Builtins that call back into the interpreter.
 from __future__ import print_function
 
 from _devbuild.gen import arg_types
-from _devbuild.gen.runtime_asdl import cmd_value, CommandStatus, value_e, value
+from _devbuild.gen.runtime_asdl import cmd_value, CommandStatus
 from _devbuild.gen.syntax_asdl import source, loc
 from core import alloc
 from core import dev
@@ -18,7 +18,6 @@ from core import state
 from core import vm
 from frontend import flag_spec
 from frontend import consts
-from frontend import lexer
 from frontend import reader
 from frontend import typed_args
 from mycpp.mylib import log
@@ -28,7 +27,7 @@ from ysh import expr_eval
 
 _ = log
 
-from typing import Dict, List, Tuple, Optional, TYPE_CHECKING, cast
+from typing import Dict, List, Tuple, Optional, TYPE_CHECKING
 if TYPE_CHECKING:
     from _devbuild.gen.runtime_asdl import Proc
     from frontend import args

--- a/osh/builtin_meta.py
+++ b/osh/builtin_meta.py
@@ -365,12 +365,19 @@ class Error(vm._Builtin):
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        t = typed_args.ReaderFromArgv(cmd_val, self.expr_ev)
+        t = typed_args.ReaderFromArgv(cmd_val.typed_args, self.expr_ev)
 
         message = t.PosStr()
-        status = t.NamedInt("error", 1)
+        status = t.NamedInt("status", 1)
+        t.Done()
+
         if status == 0:
             e_die("Status must be a non-zero integer", cmd_val.arg_locs[0])
+
+        if len(cmd_val.argv) > 1:
+            raise error.TypeErrVerbose(
+                'Expected 0 untyped arguments, but got %d' %
+                    (len(cmd_val.argv) - 1), loc.Missing)
 
         raise error.UserError(status, message, cmd_val.arg_locs[0])
 

--- a/osh/builtin_meta.py
+++ b/osh/builtin_meta.py
@@ -377,7 +377,7 @@ class Error(vm._Builtin):
         if len(cmd_val.argv) > 1:
             raise error.TypeErrVerbose(
                 'Expected 0 untyped arguments, but got %d' %
-                    (len(cmd_val.argv) - 1), loc.Missing)
+                (len(cmd_val.argv) - 1), loc.Missing)
 
         raise error.UserError(status, message, cmd_val.arg_locs[0])
 

--- a/spec/ysh-builtin-error.test.sh
+++ b/spec/ysh-builtin-error.test.sh
@@ -84,19 +84,19 @@ error ('some error')
 
 #### Error expects a positional argument
 error (status=42)
-## status: 2
+## status: 3
 ## STDOUT:
 ## END
 
 #### Error will object to an incorrect named arg
 error ('error', status_typo=42)
-## status: 2
+## status: 3
 ## STDOUT:
 ## END
 
 #### Error will object to an extraneous named arg
 error ('error', status=42, other=100)
-## status: 2
+## status: 3
 ## STDOUT:
 ## END
 
@@ -114,13 +114,13 @@ error (100, status=42)
 
 #### Errors cannot take command args
 error uh-oh ('error', status=1)
-## status: 2
+## status: 3
 ## STDOUT:
 ## END
 
 #### Error must take arguments
 error
-## status: 2
+## status: 3
 ## STDOUT:
 ## END
 

--- a/ysh/expr_eval.py
+++ b/ysh/expr_eval.py
@@ -756,7 +756,7 @@ class ExprEvaluator(object):
                 pos_args, named_args = self._EvalArgList(node.args)
                 #log('pos_args %s', pos_args)
 
-                ret = f.Call(typed_args.Reader(pos_args, named_args))
+                ret = f.Call(typed_args.Reader(None, pos_args, named_args))
 
                 #log('ret %s', ret)
                 return ret
@@ -770,7 +770,7 @@ class ExprEvaluator(object):
 
                 pos_args, named_args = self._EvalArgList(node.args, me=func.me)
 
-                ret = f.Call(typed_args.Reader(pos_args, named_args))
+                ret = f.Call(typed_args.Reader(None, pos_args, named_args))
 
                 return ret
 

--- a/ysh/expr_eval.py
+++ b/ysh/expr_eval.py
@@ -756,7 +756,7 @@ class ExprEvaluator(object):
                 pos_args, named_args = self._EvalArgList(node.args)
                 #log('pos_args %s', pos_args)
 
-                ret = f.Call(typed_args.Reader(None, pos_args, named_args))
+                ret = f.Call(typed_args.Reader(pos_args, named_args))
 
                 #log('ret %s', ret)
                 return ret
@@ -770,7 +770,7 @@ class ExprEvaluator(object):
 
                 pos_args, named_args = self._EvalArgList(node.args, me=func.me)
 
-                ret = f.Call(typed_args.Reader(None, pos_args, named_args))
+                ret = f.Call(typed_args.Reader(pos_args, named_args))
 
                 return ret
 


### PR DESCRIPTION
This will cause error messages+codes to change for the error builtin, but now they are closer to what we have for the other builtin functions.

In order to make this work, we have to evaluate all arguments before constructing the `typed_args.Reader`. So previously something like `error (not_an_arg=42/0)` would fail on the `not_an_arg`, but now it fails on `42/0`. I think this may actually be a good thing as it better matches other languages such as python:

```py
>>> def myfunc(named_arg=2):
...   return named_arg
... 
>>> myfunc(different_arg=42/0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ZeroDivisionError: division by zero
>>> myfunc(different_arg=42)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: myfunc() got an unexpected keyword argument 'different_arg'
```