### PR TITLE
[ysh] Expression Literals

### DIFF
--- a/core/shell.py
+++ b/core/shell.py
@@ -680,6 +680,7 @@ def Main(lang, arg_r, environ, login_shell, loader, readline):
     func_init.SetGlobalFunc(mem, 'join', func_misc.Join())
     func_init.SetGlobalFunc(mem, 'maybe', func_misc.Maybe())
     func_init.SetGlobalFunc(mem, 'type', func_misc.Type())
+    func_init.SetGlobalFunc(mem, 'evalExpr', func_misc.EvalExpr(expr_ev))
 
     # type conversions
     func_init.SetGlobalFunc(mem, 'bool', func_misc.Bool())

--- a/frontend/lexer_def.py
+++ b/frontend/lexer_def.py
@@ -766,7 +766,7 @@ YSH_LEFT_UNQUOTED = [
     C("$'''", Id.Left_DollarTSingleQuote),
     C('@(', Id.Left_AtParen),  # Split Command Sub
     C('^(', Id.Left_CaretParen),  # Block literals in expression mode
-    C('^[', Id.Left_CaretBracket),  # Expr literals, unimplemented
+    C('^[', Id.Left_CaretBracket),  # Expr literals
     C('^{', Id.Left_CaretBrace),  # Unused
     C(':|', Id.Left_ColonPipe),  # shell-like word arrays.
     C('%(', Id.Left_PercentParen),  # old syntax for shell-like word arrays.

--- a/frontend/syntax.asdl
+++ b/frontend/syntax.asdl
@@ -501,6 +501,7 @@ module syntax
 
   | BlockArg %BlockArg
 
+  | Literal(expr inner)
   | Lambda(List[NameType] params, expr body)
 
   | Unary(Token op, expr child)

--- a/frontend/typed_args.py
+++ b/frontend/typed_args.py
@@ -190,6 +190,17 @@ class Reader(object):
         raise error.TypeErr(arg, 'Arg %d should be a Dict' % self.pos_consumed,
                             self.BlamePos())
 
+    def PosExpr(self):
+        # type: () -> expr_t
+        arg = self._GetNextPos()
+        UP_arg = arg
+        if arg.tag() == value_e.Expr:
+            arg = cast(value.Expr, UP_arg)
+            return arg.e
+
+        raise error.TypeErr(arg, 'Arg %d should be a lazy Expr' % self.pos_consumed,
+                            self.BlamePos())
+
     def PosCommand(self):
         # type: () -> command_t
         arg = self._GetNextPos()

--- a/frontend/typed_args.py
+++ b/frontend/typed_args.py
@@ -198,7 +198,7 @@ class Reader(object):
             arg = cast(value.Expr, UP_arg)
             return arg.e
 
-        raise error.TypeErr(arg, 'Arg %d should be a lazy Expr' % self.pos_consumed,
+        raise error.TypeErr(arg, 'Arg %d should be a Expr' % self.pos_consumed,
                             self.BlamePos())
 
     def PosCommand(self):

--- a/library/func_misc.py
+++ b/library/func_misc.py
@@ -513,3 +513,19 @@ class Assert(vm._Callable):
             raise error.AssertionErr(msg, args.LeftParenToken())
 
         return value.Null
+
+
+class EvalExpr(vm._Callable):
+
+    def __init__(self, expr_ev):
+        # type: (expr_eval.ExprEvaluator) -> None
+        self.expr_ev = expr_ev
+
+    def Call(self, args):
+        # type: (typed_args.Reader) -> value_t
+        lazy = args.PosExpr()
+        args.Done()
+
+        result = self.expr_ev.EvalExpr(lazy, loc.Missing)
+
+        return result

--- a/library/func_misc.py
+++ b/library/func_misc.py
@@ -526,6 +526,6 @@ class EvalExpr(vm._Callable):
         lazy = args.PosExpr()
         args.Done()
 
-        result = self.expr_ev.EvalExpr(lazy, loc.Missing)
+        result = self.expr_ev.EvalExpr(lazy, args.LeftParenToken())
 
         return result

--- a/spec/ysh-expr.test.sh
+++ b/spec/ysh-expr.test.sh
@@ -724,4 +724,29 @@ echo $x
 ## END
 
 
+#### expression literals
+var e = ^[1 + 2]
 
+echo type=$[type(e)]
+echo eval=$[evalExpr(e)]
+## STDOUT:
+type=Expr
+eval=3
+## END
+
+#### expression literals, evaluation failure
+var e = ^[1 / 0]
+_ evalExpr(e)
+## status: 3
+## STDOUT:
+## END
+
+#### expression literals, no scope capture
+var x = 0
+var e = ^[x]
+
+setvar x = 1
+echo result=$[evalExpr(e)]
+## STDOUT:
+result=1
+## END

--- a/spec/ysh-expr.test.sh
+++ b/spec/ysh-expr.test.sh
@@ -741,7 +741,7 @@ _ evalExpr(e)
 ## STDOUT:
 ## END
 
-#### expression literals, no scope capture
+#### expression literals, lazy evaluation
 var x = 0
 var e = ^[x]
 

--- a/ysh/expr_eval.py
+++ b/ysh/expr_eval.py
@@ -1075,6 +1075,10 @@ class ExprEvaluator(object):
                 e_die_status(
                     2, 'Generator expression reserved but not implemented')
 
+            elif case(expr_e.Literal):  # ^[1 + 2]
+                node = cast(expr.Literal, UP_node)
+                return value.Expr(node.inner)
+
             elif case(expr_e.Lambda):  # |x| x+1 syntax is reserved
                 # TODO: Location information for |, or func
                 # Note: anonymous functions also evaluate to a Lambda, but they shouldn't

--- a/ysh/expr_to_ast.py
+++ b/ysh/expr_to_ast.py
@@ -640,6 +640,10 @@ class Transformer(object):
 
                 return node
 
+            elif typ == grammar_nt.literal_expr:
+                inner = self.Expr(pnode.GetChild(1))
+                return expr.Literal(inner)
+
             elif typ == grammar_nt.oil_expr_sub:
                 return self.Expr(pnode.GetChild(0))
 

--- a/ysh/grammar.pgen2
+++ b/ysh/grammar.pgen2
@@ -102,7 +102,9 @@ atom: (
 
   | dq_string | sq_string
     # Expr_Symbol could be %mykey
-    
+
+  | literal_expr
+
   # $foo is disallowed, but $? is allowed.  Should be "$foo" to indicate a
   # string, or ${foo:-}
   | simple_var_sub
@@ -112,6 +114,8 @@ atom: (
     # Anonymous function.  Is this only in Tea mode?
   | 'func' tea_func
 )
+
+literal_expr: '^[' expr ']'
 
 # Tea can run a limited form of procs.  The first word must be a name, and NO
 # BARE WORDS.


### PR DESCRIPTION
Adds support for expression literals:

```
ysh$ var l = ^[1 + 2]
ysh$ = type(l)
(Str)   'Expr'
ysh$ = evalExpr(l)
(Int)   3
```