### PR TITLE
[fanos] implement basic completion for PARSE keyword

### DIFF
--- a/core/main_loop.py
+++ b/core/main_loop.py
@@ -14,6 +14,7 @@ from _devbuild.gen import arg_types
 from _devbuild.gen.syntax_asdl import (command, command_t, parse_result,
                                        parse_result_e)
 from core import error
+from core import completion
 from core import process
 from core import ui
 from core import util
@@ -100,11 +101,12 @@ def ShowDescriptorState(label):
 class Headless(object):
     """Main loop for headless mode."""
 
-    def __init__(self, cmd_ev, parse_ctx, errfmt):
+    def __init__(self, cmd_ev, parse_ctx, root_comp, errfmt):
         # type: (CommandEvaluator, parse_lib.ParseContext, ErrorFormatter) -> None
         self.cmd_ev = cmd_ev
         self.parse_ctx = parse_ctx
         self.errfmt = errfmt
+        self.root_comp = root_comp
 
     def Loop(self):
         # type: () -> int
@@ -178,7 +180,12 @@ class Headless(object):
             # Do we also need 'complete --osh' and 'complete --ysh' ?
             elif command == 'PARSE':
                 # Just parse
-                reply = 'TODO:PARSE'
+                comp = completion.Api(line=arg, begin=0, end=len(arg))
+                it = self.root_comp.Matches(comp)
+                matches = list(it)
+                reply = ""
+                for match in matches:
+                    reply += match + "\n"
 
             else:
                 fanos_log('Invalid command %r' % command)

--- a/core/shell.py
+++ b/core/shell.py
@@ -861,7 +861,7 @@ def Main(lang, arg_r, environ, login_shell, loader, readline):
                 except util.UserExit as e:
                     return e.status
 
-        loop = main_loop.Headless(cmd_ev, parse_ctx, errfmt)
+        loop = main_loop.Headless(cmd_ev, parse_ctx, root_comp, errfmt)
         try:
             # TODO: What other exceptions happen here?
             status = loop.Loop()


### PR DESCRIPTION
implement PARSE, return completions with newline separation. This PR is very minimal and I'd like to have a discussion on how to properly return the completions (since newline-separated is IMO bad).
It would also be great if we can add additional information like the symbol type (function, file, builtin, etc.).