### PR TITLE
[mycpp] warn about excessive stack roots

### DIFF
--- a/build/ninja-rules-py.sh
+++ b/build/ninja-rules-py.sh
@@ -10,6 +10,7 @@ set -o pipefail
 set -o errexit
 
 REPO_ROOT=$(cd "$(dirname $0)/.."; pwd)
+: ${EXTRA_MYCPP_FLAGS:=""}
 
 source build/dev-shell.sh  # python2 in $PATH
 source mycpp/common-vars.sh  # MYPY_REPO
@@ -75,6 +76,7 @@ gen-oils-for-unix() {
 
   _bin/shwrap/mycpp_main $mypypath $raw_cc \
     --header-out $raw_header \
+    "$EXTRA_MYCPP_FLAGS" \
     "$@"
     #--to-header osh.cmd_eval \
 

--- a/build/ninja-rules-py.sh
+++ b/build/ninja-rules-py.sh
@@ -10,7 +10,7 @@ set -o pipefail
 set -o errexit
 
 REPO_ROOT=$(cd "$(dirname $0)/.."; pwd)
-: ${EXTRA_MYCPP_FLAGS:=""}
+: ${EXTRA_MYCPP_ARGS:=""}
 
 source build/dev-shell.sh  # python2 in $PATH
 source mycpp/common-vars.sh  # MYPY_REPO
@@ -76,7 +76,7 @@ gen-oils-for-unix() {
 
   _bin/shwrap/mycpp_main $mypypath $raw_cc \
     --header-out $raw_header \
-    "$EXTRA_MYCPP_FLAGS" \
+    $EXTRA_MYCPP_ARGS \
     "$@"
     #--to-header osh.cmd_eval \
 

--- a/mycpp/cppgen_pass.py
+++ b/mycpp/cppgen_pass.py
@@ -2575,6 +2575,12 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
             #self.log('roots %s', roots)
 
             if len(roots):
+                if len(roots) > 16:
+                    log(
+                        'WARNING: %s::%s() has %d stack roots. Consider refactoring this function.'
+                        % (self.current_class_name or '', self.current_func_node.name, len(roots))
+                    )
+
                 for i, r in enumerate(roots):
                     self.write_ind('StackRoot _root%d(&%s);\n' % (i, r))
 

--- a/mycpp/cppgen_pass.py
+++ b/mycpp/cppgen_pass.py
@@ -367,7 +367,8 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
                  fmt_ids=None,
                  field_gc=None,
                  decl=False,
-                 forward_decl=False):
+                 forward_decl=False,
+                 stack_roots_warn_threshold=None):
         self.types = types
         self.const_lookup = const_lookup
         self.f = f
@@ -383,6 +384,7 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
 
         self.decl = decl
         self.forward_decl = forward_decl
+        self.stack_roots_warn_threshold = stack_roots_warn_threshold
 
         self.unique_id = 0
 
@@ -2575,7 +2577,7 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
             #self.log('roots %s', roots)
 
             if len(roots):
-                if len(roots) > 16:
+                if self.stack_roots_warn_threshold and len(roots) > self.stack_roots_warn_threshold:
                     log(
                         'WARNING: %s::%s() has %d stack roots. Consider refactoring this function.'
                         % (self.current_class_name or '', self.current_func_node.name, len(roots))

--- a/mycpp/mycpp_main.py
+++ b/mycpp/mycpp_main.py
@@ -48,6 +48,11 @@ def Options():
                  default=None,
                  help='Write this header')
 
+    p.add_option('--stack-roots-warn',
+                 dest='stack_roots_warn',
+                 default=None,
+                 help='Emit warnings about functions with too many stack roots')
+
     return p
 
 

--- a/soil/worker.sh
+++ b/soil/worker.sh
@@ -10,6 +10,7 @@ set -o pipefail
 set -o errexit
 
 REPO_ROOT=$(cd "$(dirname $0)/.."; pwd)  # tsv-lib.sh uses this
+EXTRA_MYCPP_ARGS="--stack-roots-warn 16"
 readonly REPO_ROOT
 
 source soil/common.sh


### PR DESCRIPTION
Output on master.

```
WARNING: RootCompleter::Matches() has 29 stack roots. Consider refactoring this function.
WARNING: ::_PrintVariables() has 25 stack roots. Consider refactoring this function.
WARNING: SpecBuilder::Build() has 18 stack roots. Consider refactoring this function.
WARNING: Printf::_Format() has 23 stack roots. Consider refactoring this function.
WARNING: Printf::Run() has 17 stack roots. Consider refactoring this function.
WARNING: CommandEvaluator::_Dispatch() has 39 stack roots. Consider refactoring this function.
WARNING: ::_MakeAssignPair() has 19 stack roots. Consider refactoring this function.
WARNING: CommandParser::_MaybeExpandAliases() has 17 stack roots. Consider refactoring this function.
WARNING: CommandParser::ParseSimpleCommand() has 18 stack roots. Consider refactoring this function.
WARNING: Evaluator::Eval() has 19 stack roots. Consider refactoring this function.
WARNING: OilPrinter::DoCommand() has 18 stack roots. Consider refactoring this function.
WARNING: ::_PushOilTokens() has 25 stack roots. Consider refactoring this function.
WARNING: ::Main() has 100 stack roots. Consider refactoring this function.
```