### PR TITLE
Replaced `mktemp` with `mkstemp`

### DIFF
--- a/opy/_regtest/src/platform.py
+++ b/opy/_regtest/src/platform.py
@@ -385,9 +385,9 @@ class _popen:
         if mode != 'r':
             raise ValueError,'popen()-emulation only supports read mode'
         import tempfile
-        self.tmpfile = tmpfile = tempfile.mktemp()
+        self.tmpfd, self.tmpfile = fd, tmpfile = tempfile.mkstemp()
         os.system(cmd + ' > %s' % tmpfile)
-        self.pipe = open(tmpfile,'rb')
+        self.pipe = open(fd,'rb')
         self.bufsize = bufsize
         self.mode = mode
 
@@ -400,9 +400,7 @@ class _popen:
         if self.bufsize is not None:
             return self.pipe.readlines()
 
-    def close(self,
-
-              remove=os.unlink,error=os.error):
+    def close(self,remove=os.close,error=os.error):
 
         if self.pipe:
             rc = self.pipe.close()
@@ -410,7 +408,7 @@ class _popen:
             rc = 255
         if self.tmpfile:
             try:
-                remove(self.tmpfile)
+                remove(self.tmpfd)
             except error:
                 pass
         return rc


### PR DESCRIPTION
## Details
While triaging your project, our bug fixing tool generated the following message(s)-

> In file: [platform.py](https://github.com/oilshell/oil/blob/master/opy/_regtest/src/platform.py#L388), there is a method that creates a temporary file using an unsafe API mktemp. The use of this method is discouraged in the Python [documentation](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp). iCR suggested that a temporary file should be created using `mkstemp` which is a [safe API](https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp). iCR replaced the usage of `mktemp` with `mkstemp`.


#### Here are a few reasons why you shouldn't use `mktemp`
- [POC - Improper Method Call - python - mktemp.mp4](https://drive.google.com/file/d/16YKuKgv7iItWcac2biRyi2Cm8upJ3HP_/view?usp=share_link)
- [MISC - Python - Taking a peek under the tempfile library.mp4](https://drive.google.com/file/d/1ns2_x_ZDvzFwj0eNNxyay-HUMclLasNT/view?usp=share_link)

## Changes
- Replaced `mktemp` method with `mkstemp`
- Closed the file descriptor `self.tmpfd` that was given by `mkstemp` method in a safe manner


## Previously Found & Fixed
- https://github.com/Azure/azure-linux-extensions/pull/1816


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
