### PR TITLE
[ysh] Fix Crash When Comparing Non-Comparable Types

### DIFF
--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -1470,7 +1470,7 @@ class CommandEvaluator(object):
                         expr_val = self.expr_ev.EvalExpr(
                             pat_expr, case_arm.left)
 
-                        if val_ops.ExactlyEqual(expr_val, to_match):
+                        if val_ops.ExactlyEqual(expr_val, to_match, case_arm.left):
                             status = self._ExecuteList(case_arm.action)
                             matched = True
                             break

--- a/spec/ysh-expr-compare.test.sh
+++ b/spec/ysh-expr-compare.test.sh
@@ -370,3 +370,13 @@ for val in (unimpl) {
 }
 ## STDOUT:
 ## END
+
+#### Non-comparable types in case arms
+var myexpr = ^[123]
+
+case (myexpr) {
+  (myexpr) { echo 123; }
+}
+## status: 3
+## STDOUT:
+## END

--- a/spec/ysh-expr-compare.test.sh
+++ b/spec/ysh-expr-compare.test.sh
@@ -343,3 +343,30 @@ y=42
 x=42
 ## END
 
+#### Undefined comparisons
+shopt -s ysh:all
+
+func f() { true }
+var mydict = {}
+var myexpr = ^[123]
+
+var unimpl = [
+    / [a-z]+ /,  # Eggex
+    myexpr,  # Expr
+    ^(echo hello),  # Block
+    f,  # Func
+    mydict->keys,  # BoundFunc
+    # These cannot be constructed
+    # - Proc
+    # - Slice
+    # - Range
+]
+
+for val in (unimpl) {
+  try { _ val === val }
+  if (_status !== 3) {
+    exit 1
+  }
+}
+## STDOUT:
+## END

--- a/spec/ysh-expr-compare.test.sh
+++ b/spec/ysh-expr-compare.test.sh
@@ -363,7 +363,7 @@ var unimpl = [
 ]
 
 for val in (unimpl) {
-  try { _ val === val }
+  try { :: val === val }
   if (_status !== 3) {
     exit 1
   }

--- a/test/parse-errors.sh
+++ b/test/parse-errors.sh
@@ -1012,6 +1012,14 @@ ysh_case() {
   '
 
   _ysh-should-parse '
+  var myexpr = ^[123]
+
+  case (123) {
+    (myexpr) { echo 1 }
+  }
+  '
+
+  _ysh-should-parse '
   case (x) {
     (else) { echo 1 }
   }

--- a/test/ysh-runtime-errors.sh
+++ b/test/ysh-runtime-errors.sh
@@ -743,6 +743,23 @@ test-read-builtin() {
   _error-case-X 2 'echo hi | read --line x y'
 }
 
+test-equality() {
+  _expr-error-case '
+  = ^[42] === ^[43]
+  '
+
+  _expr-error-case '
+  = ^(echo hi) === ^(echo yo)
+  '
+
+  return
+
+  # Hm it's kind of weird you can do this -- it's False
+  _expr-error-case '
+  = ^[42] === "hi"
+  '
+}
+
 soil-run() {
   # This is like run-test-funcs, except errexit is off here
   run-test-funcs

--- a/ysh/expr_eval.py
+++ b/ysh/expr_eval.py
@@ -622,12 +622,12 @@ class ExprEvaluator(object):
                 if left.tag() != right.tag():
                     result = False
                 else:
-                    result = val_ops.ExactlyEqual(left, right)
+                    result = val_ops.ExactlyEqual(left, right, op)
             elif op.id == Id.Expr_NotDEqual:
                 if left.tag() != right.tag():
                     result = True
                 else:
-                    result = not val_ops.ExactlyEqual(left, right)
+                    result = not val_ops.ExactlyEqual(left, right, op)
 
             elif op.id == Id.Expr_In:
                 result = val_ops.Contains(left, right)

--- a/ysh/val_ops.py
+++ b/ysh/val_ops.py
@@ -408,8 +408,7 @@ def ExactlyEqual(left, right, blame_loc):
             return True
 
     raise error.TypeErrVerbose(
-        "Can't compare %s and %s" % (ui.ValType(left), ui.ValType(right)),
-        blame_loc)
+        "Can't compare two values of type %s" % ui.ValType(left), blame_loc)
 
 
 def Contains(needle, haystack):

--- a/ysh/val_ops.py
+++ b/ysh/val_ops.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 from _devbuild.gen.syntax_asdl import loc, loc_t, command_t
 from _devbuild.gen.value_asdl import (value, value_e, value_t)
 from core import error
+from core import ui
 from mycpp.mylib import tagswitch
 from ysh import regex_translate
 
@@ -406,7 +407,9 @@ def ExactlyEqual(left, right, blame_loc):
 
             return True
 
-    raise error.TypeErr(left, "Cannot compare this type", blame_loc)
+    raise error.TypeErrVerbose(
+        "Can't compare %s and %s" % (ui.ValType(left), ui.ValType(right)),
+        blame_loc)
 
 
 def Contains(needle, haystack):

--- a/ysh/val_ops.py
+++ b/ysh/val_ops.py
@@ -323,8 +323,8 @@ def ToBool(val):
             return True  # all other types are Truthy
 
 
-def ExactlyEqual(left, right):
-    # type: (value_t, value_t) -> bool
+def ExactlyEqual(left, right, blame_loc):
+    # type: (value_t, value_t, loc_t) -> bool
     if left.tag() != right.tag():
         return False
 
@@ -351,7 +351,7 @@ def ExactlyEqual(left, right):
             # Note: could provide floatEquals(), and suggest it
             # Suggested idiom is abs(f1 - f2) < 0.1
             raise error.TypeErrVerbose("Equality isn't defined on Float",
-                                       loc.Missing)
+                                       blame_loc)
 
         elif case(value_e.Str):
             left = cast(value.Str, UP_left)
@@ -377,7 +377,7 @@ def ExactlyEqual(left, right):
                 return False
 
             for i in xrange(0, len(left.items)):
-                if not ExactlyEqual(left.items[i], right.items[i]):
+                if not ExactlyEqual(left.items[i], right.items[i], blame_loc):
                     return False
 
             return True
@@ -401,12 +401,12 @@ def ExactlyEqual(left, right):
                 return False
 
             for k in left.d.keys():
-                if k not in right.d or not ExactlyEqual(right.d[k], left.d[k]):
+                if k not in right.d or not ExactlyEqual(right.d[k], left.d[k], blame_loc):
                     return False
 
             return True
 
-    raise error.TypeErr(left, "Cannot compare this type", loc.Missing)
+    raise error.TypeErr(left, "Cannot compare this type", blame_loc)
 
 
 def Contains(needle, haystack):

--- a/ysh/val_ops.py
+++ b/ysh/val_ops.py
@@ -406,7 +406,7 @@ def ExactlyEqual(left, right):
 
             return True
 
-    raise NotImplementedError(left)
+    raise error.TypeErr(left, "Cannot compare this type", loc.Missing)
 
 
 def Contains(needle, haystack):


### PR DESCRIPTION
Issue: #1732

Now we raise a `error.TypeErr` when comparing non-comparable types.

```sh
ysh$ = {}->keys === {}->keys
  = {}->keys === {}->keys
  ^
[ interactive ]:1: fatal: Cannot compare this type, got BuiltinMethod
```