### PR TITLE
[ysh] Improve error message when using setvar without var

### DIFF
--- a/osh/cmd_parse.py
+++ b/osh/cmd_parse.py
@@ -445,7 +445,7 @@ class VarChecker(object):
 
         if keyword_id == Id.KW_SetVar:
             if name not in top:
-                p_die("%r hasn't been declared" % name, name_tok)
+                p_die("Declare 'var %s' before using 'setvar'" % name, name_tok)
 
 
 class ctx_VarChecker(object):


### PR DESCRIPTION
Previously:

```
$ cat example.ysh
proc foo() {
  read --line (&x)
  setvar x = x + "xyz"
  echo $x
}

foo
$ bin/ysh example.ysh
    setvar x = x + "xyz"
           ^
example.ysh:3: 'x' hasn't been declared
```

Now
```
$ cat example.ysh
proc foo() {
  read --line (&x)
  setvar x = x + "xyz"
  echo $x
}

foo
$ bin/ysh example.ysh
    setvar x = x + "xyz"
           ^
example.ysh:3: Declare 'var x' before using 'setvar'
```