### PR TITLE
Better stringify list error

### DIFF
--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -232,6 +232,11 @@ def _ValueToPartValue(val, quoted, part_loc):
             s = val_ops.Stringify(val, loc.Missing)
             return part_value.String(s, quoted, not quoted)
 
+        elif case(value_e.List):
+            raise error.TypeErrVerbose(
+                "Can't substitute into word, got List. Use '@' instead of '$' to splice the List into Strings",
+                loc.WordPart(part_loc))
+
         else:
             raise error.TypeErr(val, "Can't substitute into word",
                                 loc.WordPart(part_loc))

--- a/ysh/val_ops.py
+++ b/ysh/val_ops.py
@@ -120,6 +120,11 @@ def Stringify(val, blame_loc, prefix=''):
             val = cast(value.Eggex, UP_val)
             s = regex_translate.AsPosixEre(val)  # lazily converts to ERE
 
+        elif case(value_e.List):
+            raise error.TypeErrVerbose(
+                "%sexpected Null, Bool, Int, Float, Eggex, got List. Use '@' instead of '$' to splice the returned List into Strings" % prefix,
+                blame_loc)
+
         else:
             raise error.TypeErr(
                 val, "%sexpected Null, Bool, Int, Float, Eggex" % prefix,


### PR DESCRIPTION
Describe a way to fix the error when accidentally using `$` instead of `@`.

Since this is something that will probably happen to a lot of `bash` users, it probably makes sense to be a bit helpful here :)
```
ysh ysh-0.19.0$ var x = :|a b c d e|
ysh ysh-0.19.0$ write $x
write $x
      ^~
[ interactive ]:2: fatal: Can't substitute into word, got List. Use '@' instead of '$' to splice the List into Strings

vs
[ interactive ]:6: fatal: Can't substitute into word, got List
```
and
```
ysh ysh-0.19.0$ write $[:|a b c|]
write $[:|a b c|]
      ^~
[ interactive ]:4: fatal: expected Null, Bool, Int, Float, Eggex, got List. Use '@' instead of '$' to splice the returned List into Strings

vs
[ interactive ]:4: fatal: expected Null, Bool, Int, Float, Eggex, got List
```