### PR TITLE
Add spec test for command with -p flag

### DIFF
--- a/spec/builtins2.test.sh
+++ b/spec/builtins2.test.sh
@@ -1,4 +1,4 @@
-## oils_failures_allowed: 0
+## oils_failures_allowed: 3
 ## compare_shells: dash bash mksh zsh
 
 

--- a/spec/builtins2.test.sh
+++ b/spec/builtins2.test.sh
@@ -366,6 +366,35 @@ status=127
 status=127
 ## END
 
+#### command -p (override existing program)
+# Tests whether command -p overrides the path
+# tr chosen because we need a simple non-builtin
+mkdir -p $TMP/bin
+echo "echo wrong" > $TMP/bin/tr
+chmod +x $TMP/bin/tr
+PATH="$TMP/bin:$PATH"
+echo aaa | tr "a" "b"
+echo aaa | command -p tr "a" "b"
+rm $TMP/bin/tr
+## STDOUT:
+wrong
+bbb
+## END
+
+#### command -p (hide tool in custom path)
+mkdir -p $TMP/bin
+echo "echo hello" > $TMP/bin/hello
+chmod +x $TMP/bin/hello
+export PATH=$TMP/bin
+command -p hello
+## status: 127 
+
+#### command -p (find hidden tool in default path)
+export PATH=''
+command -p ls
+## status: 0
+
+
 #### $(command type ls)
 type() { echo FUNCTION; }
 type


### PR DESCRIPTION
Test of `command -p` that ignores existing PATH in favor of a default system PATH

Currently, dash/bash/mksh/zsh pass, osh fails.

Adds tests for, but does not fix, #1795 