### PR TITLE
Document Eggex Flags

### DIFF
--- a/doc/eggex.md
+++ b/doc/eggex.md
@@ -311,6 +311,21 @@ Flags and translation preferences together:
 
     / digit+ ; ignorecase ; python /  # could translate to (?i)\d+
 
+The following flags are currently supported:
+
+#### `i` / `reg_icase` (Ignore Case)
+
+**With** this flag, the match _is not_ case sensitive.
+
+**Without** this flag, the match _is_ case sensitive.
+
+#### `reg_newline` (Multiline)
+
+**With** this flag, `$` will match before a newline and `^` will match after a
+newline. Newlines are also ignored in `dot` and `!...` patterns.
+
+**Without** this flag, the newline `\n` is treated as an ordinary character.
+
 ### Multiline Syntax
 
 You can spread regexes over multiple lines and add comments:

--- a/doc/eggex.md
+++ b/doc/eggex.md
@@ -320,17 +320,17 @@ Use this flag to ignore case when matching. For example, `/'foo'; i/` matches
 
 #### `reg_newline` (Multiline)
 
-With this flag, `%end`/`$` will match before a newline and `%start`/`^` will
-match after a newline.
+With this flag, `%end` will match before a newline and `%start` will match
+after a newline.
 
     u'abc123\n' ~ / digit %end ; reg_newline /    # true
     u'abc\n123' ~ / %start digit ; reg_newline /  # true
 
-Without the flag, `%start`/`^` and `%end`/`$` only match from the start or end
-of the string, respectively.
+Without the flag, `%start` and `%end` only match from the start or end of the
+string, respectively.
 
-    u'abc123\n' ~ / digit $ /                     # false
-    u'abc\n123' ~ / ^ digit /                     # false
+    u'abc123\n' ~ / digit %end /                  # false
+    u'abc\n123' ~ / %start digit /                # false
 
 Newlines are also ignored in `dot` and `![abc]` patterns.
 

--- a/doc/eggex.md
+++ b/doc/eggex.md
@@ -311,20 +311,36 @@ Flags and translation preferences together:
 
     / digit+ ; ignorecase ; python /  # could translate to (?i)\d+
 
-The following flags are currently supported:
+In Oils, the following flags are currently supported:
 
-#### `i` / `reg_icase` (Ignore Case)
+#### `reg_icase` / `i` (Ignore Case)
 
-**With** this flag, the match _is not_ case sensitive.
-
-**Without** this flag, the match _is_ case sensitive.
+Use this flag to ignore case when matching. For example, `/'foo'; i/` matches
+'FOO', but `/'foo'/` doesn't.
 
 #### `reg_newline` (Multiline)
 
-**With** this flag, `$` will match before a newline and `^` will match after a
-newline. Newlines are also ignored in `dot` and `!...` patterns.
+With this flag, `%end`/`$` will match before a newline and `%start`/`^` will
+match after a newline.
 
-**Without** this flag, the newline `\n` is treated as an ordinary character.
+    u'abc123\n' ~ / digit %end ; reg_newline /    # true
+    u'abc\n123' ~ / %start digit ; reg_newline /  # true
+
+Without the flag, `%start`/`^` and `%end`/`$` only match from the start or end
+of the string, respectively.
+
+    u'abc123\n' ~ / digit $ /                     # false
+    u'abc\n123' ~ / ^ digit /                     # false
+
+Newlines are also ignored in `dot` and `![abc]` patterns.
+
+    u'\n' ~ / . /                                 # true
+    u'\n' ~ / !digit /                            # true
+
+Without this flag, the newline `\n` is treated as an ordinary character.
+
+    u'\n' ~ / . ; reg_newline /                   # false
+    u'\n' ~ / !digit ; reg_newline /              # false
 
 ### Multiline Syntax
 

--- a/doc/eggex.md
+++ b/doc/eggex.md
@@ -323,24 +323,24 @@ Use this flag to ignore case when matching. For example, `/'foo'; i/` matches
 With this flag, `%end` will match before a newline and `%start` will match
 after a newline.
 
-    u'abc123\n' ~ / digit %end ; reg_newline /    # true
-    u'abc\n123' ~ / %start digit ; reg_newline /  # true
+    = u'abc123\n' ~ / digit %end ; reg_newline /    # true
+    = u'abc\n123' ~ / %start digit ; reg_newline /  # true
 
 Without the flag, `%start` and `%end` only match from the start or end of the
 string, respectively.
 
-    u'abc123\n' ~ / digit %end /                  # false
-    u'abc\n123' ~ / %start digit /                # false
+    = u'abc123\n' ~ / digit %end /                  # false
+    = u'abc\n123' ~ / %start digit /                # false
 
 Newlines are also ignored in `dot` and `![abc]` patterns.
 
-    u'\n' ~ / . /                                 # true
-    u'\n' ~ / !digit /                            # true
+    = u'\n' ~ / . /                                 # true
+    = u'\n' ~ / !digit /                            # true
 
 Without this flag, the newline `\n` is treated as an ordinary character.
 
-    u'\n' ~ / . ; reg_newline /                   # false
-    u'\n' ~ / !digit ; reg_newline /              # false
+    = u'\n' ~ / . ; reg_newline /                   # false
+    = u'\n' ~ / !digit ; reg_newline /              # false
 
 ### Multiline Syntax
 

--- a/spec/ysh-regex-api.test.sh
+++ b/spec/ysh-regex-api.test.sh
@@ -87,31 +87,31 @@ yes
 #### Eggex flags to treat newlines as special are respected
 shopt -s ysh:upgrade
 
-if ($'abc123\n' ~ / digit $ /) {
+if (u'abc123\n' ~ / digit $ /) {
   echo 'BUG'
 }
-if ($'abc\n123' ~ / ^ digit /) {
+if (u'abc\n123' ~ / ^ digit /) {
   echo 'BUG'
 }
 
-if ($'abc123\n' ~ / digit $ ; reg_newline /) {
+if (u'abc123\n' ~ / digit $ ; reg_newline /) {
   echo 'yes'
 }
-if ($'abc\n123' ~ / ^ digit ; reg_newline /) {
-  echo 'yes'
-}
-
-if ($'\n' ~ / . /) {
-  echo 'yes'
-}
-if ($'\n' ~ / !digit /) {
+if (u'abc\n123' ~ / ^ digit ; reg_newline /) {
   echo 'yes'
 }
 
-if ($'\n' ~ / . ; reg_newline /) {
+if (u'\n' ~ / . /) {
+  echo 'yes'
+}
+if (u'\n' ~ / !digit /) {
+  echo 'yes'
+}
+
+if (u'\n' ~ / . ; reg_newline /) {
   echo 'BUG'
 }
-if ($'\n' ~ / !digit ; reg_newline /) {
+if (u'\n' ~ / !digit ; reg_newline /) {
   echo 'BUG'
 }
 

--- a/spec/ysh-regex-api.test.sh
+++ b/spec/ysh-regex-api.test.sh
@@ -87,17 +87,17 @@ yes
 #### Eggex flags to treat newlines as special are respected
 shopt -s ysh:upgrade
 
-if (u'abc123\n' ~ / digit $ /) {
+if (u'abc123\n' ~ / digit %end /) {
   echo 'BUG'
 }
-if (u'abc\n123' ~ / ^ digit /) {
+if (u'abc\n123' ~ / %start digit /) {
   echo 'BUG'
 }
 
-if (u'abc123\n' ~ / digit $ ; reg_newline /) {
+if (u'abc123\n' ~ / digit %end ; reg_newline /) {
   echo 'yes'
 }
-if (u'abc\n123' ~ / ^ digit ; reg_newline /) {
+if (u'abc\n123' ~ / %start digit ; reg_newline /) {
   echo 'yes'
 }
 

--- a/spec/ysh-regex-api.test.sh
+++ b/spec/ysh-regex-api.test.sh
@@ -84,6 +84,44 @@ yes
 yes
 ## END
 
+#### Eggex flags to treat newlines as special are respected
+shopt -s ysh:upgrade
+
+if ($'abc123\n' ~ / digit $ /) {
+  echo 'BUG'
+}
+if ($'abc\n123' ~ / ^ digit /) {
+  echo 'BUG'
+}
+
+if ($'abc123\n' ~ / digit $ ; reg_newline /) {
+  echo 'yes'
+}
+if ($'abc\n123' ~ / ^ digit ; reg_newline /) {
+  echo 'yes'
+}
+
+if ($'\n' ~ / . /) {
+  echo 'yes'
+}
+if ($'\n' ~ / !digit /) {
+  echo 'yes'
+}
+
+if ($'\n' ~ / . ; reg_newline /) {
+  echo 'BUG'
+}
+if ($'\n' ~ / !digit ; reg_newline /) {
+  echo 'BUG'
+}
+
+## STDOUT:
+yes
+yes
+yes
+yes
+## END
+
 #### Positional captures with _group
 shopt -s ysh:all
 


### PR DESCRIPTION
The [current docs](https://www.oilshell.org/release/0.19.0/doc/eggex.html#flags-and-translation-preferences) do not cover any of the [currently implemented eggex flags](https://github.com/oilshell/oil/blob/139146035a4f76a9fbaf88eb9ee61e3759c84be5/ysh/regex_translate.py#L371). I have added documentation for those flags:

- `i`/`reg_icase` [REG_ICASE](https://www.gnu.org/software/libc/manual/html_node/Flags-for-POSIX-Regexps.html)
- `reg_newline` [REG_NEWLINE](https://www.gnu.org/software/libc/manual/html_node/Flags-for-POSIX-Regexps.html)

There were no tests for `reg_newline`, so I added some in `spec/ysh-reggex-api`.