### PR TITLE
Prototype the ctx builtin

### DIFF
--- a/builtin/pure_ysh.py
+++ b/builtin/pure_ysh.py
@@ -102,6 +102,23 @@ class Shvar(vm._Builtin):
         return 0
 
 
+class ctx_Context(object):
+    """For ctx push (context) { ... }"""
+
+    def __init__(self, mem, context):
+        # type: (state.Mem, Dict[str, value_t]) -> None
+        self.mem = mem
+        self.mem.PushContextStack(context)
+
+    def __enter__(self):
+        # type: () -> None
+        pass
+
+    def __exit__(self, type, value, traceback):
+        # type: (Any, Any, Any) -> None
+        self.mem.PopContextStack()
+
+
 class Ctx(vm._Builtin):
 
     def __init__(self, mem, cmd_ev):
@@ -111,13 +128,8 @@ class Ctx(vm._Builtin):
 
     def _Push(self, context, block):
         # type: (Dict[str, value_t], command_t) -> int
-
-        # TODO: ctx_Ctx
-        self.mem.PushContextStack(context)
-        self.cmd_ev.EvalCommand(block)
-        self.mem.PopContextStack()
-
-        return 0
+        with ctx_Context(self.mem, context):
+            return self.cmd_ev.EvalCommand(block)
 
     def _Set(self, updates):
         # type: (Dict[str, value_t]) -> int

--- a/builtin/pure_ysh.py
+++ b/builtin/pure_ysh.py
@@ -130,7 +130,9 @@ class Ctx(vm._Builtin):
         # type: () -> Dict[str, value_t]
         ctx = self.mem.GetContext()
         if ctx is None:
-            raise error.FatalRuntime("Could not find a context. Did you forget to 'ctx push'?")
+            raise error.FatalRuntime(
+                3, "Could not find a context. Did you forget to 'ctx push'?",
+                loc.Missing)
         return ctx
 
     def _Push(self, context, block):
@@ -154,8 +156,8 @@ class Ctx(vm._Builtin):
         UP_arr = ctx[field]
         if UP_arr.tag() != value_e.List:
             raise error.TypeErr(
-                UP_arr, "Expected the context item '%s' to be a List" % (field),
-                blame)
+                UP_arr,
+                "Expected the context item '%s' to be a List" % (field), blame)
 
         arr = cast(value.List, UP_arr)
         arr.items.append(item)
@@ -169,7 +171,8 @@ class Ctx(vm._Builtin):
                                          cmd_val,
                                          accept_typed_args=True)
 
-        verb, verb_loc = arg_r.ReadRequired2('Expected a verb (push, set, emit)')
+        verb, verb_loc = arg_r.ReadRequired2(
+            'Expected a verb (push, set, emit)')
 
         if verb == "push":
             context = rd.PosDict()
@@ -187,7 +190,8 @@ class Ctx(vm._Builtin):
             return self._Set(updates)
 
         elif verb == "emit":
-            field, field_loc = arg_r.ReadRequired2("A target field is required")
+            field, field_loc = arg_r.ReadRequired2(
+                "A target field is required")
             item = rd.PosValue()
             rd.Done()
             arg_r.AtEnd()

--- a/builtin/pure_ysh.py
+++ b/builtin/pure_ysh.py
@@ -4,7 +4,7 @@ builtin/pure_ysh.py - YSH builtins that don't do I/O.
 from __future__ import print_function
 
 from _devbuild.gen.runtime_asdl import (cmd_value, scope_e)
-from _devbuild.gen.syntax_asdl import loc, loc_t
+from _devbuild.gen.syntax_asdl import command_t, loc, loc_t
 from _devbuild.gen.value_asdl import (value, value_e, value_t, LeftName)
 from core import error
 from core import state
@@ -15,7 +15,7 @@ from frontend import typed_args
 from mycpp import mylib
 from mycpp.mylib import tagswitch
 
-from typing import TYPE_CHECKING, cast, List, Tuple, Any
+from typing import TYPE_CHECKING, cast, Any, Dict, List, Optional, Tuple
 
 if TYPE_CHECKING:
     from core import ui
@@ -142,14 +142,13 @@ class Ctx(vm._Builtin):
         if field not in ctx:
             ctx[field] = value.List([])
 
-        arr = ctx[field]
-
-        if arr.tag() != value_e.List:
+        UP_arr = ctx[field]
+        if UP_arr.tag() != value_e.List:
             raise error.TypeErr(
-                arr, "Expected the context item '%s' to be a List" % (field),
-                blame)
+                UP_arr,
+                "Expected the context item '%s' to be a List" % (field), blame)
 
-        arr = cast(value.List, arr)
+        arr = cast(value.List, UP_arr)
         arr.items.append(item)
 
         return 0
@@ -161,8 +160,8 @@ class Ctx(vm._Builtin):
                                          accept_typed_args=True)
 
         verb = arg_r.Peek()
-        field = None  # Optional[str]
-        field_loc = None  # Optional[loc_t]
+        field = None  # type: Optional[str]
+        field_loc = None  # type: Optional[loc_t]
         if verb is None:
             raise error.Usage('expected a verb (push, set, emit)',
                               arg_r.Location())

--- a/builtin/pure_ysh.py
+++ b/builtin/pure_ysh.py
@@ -15,7 +15,7 @@ from frontend import typed_args
 from mycpp import mylib
 from mycpp.mylib import tagswitch
 
-from typing import TYPE_CHECKING, cast, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, cast, Any, Dict, List, Tuple
 
 if TYPE_CHECKING:
     from core import ui

--- a/core/shell.py
+++ b/core/shell.py
@@ -573,6 +573,7 @@ def Main(
     b[builtin_i.trap] = trap_osh.Trap(trap_state, parse_ctx, tracer, errfmt)
 
     b[builtin_i.shvar] = pure_ysh.Shvar(mem, search_path, cmd_ev)
+    b[builtin_i.ctx] = pure_ysh.Ctx(mem, cmd_ev)
     b[builtin_i.push_registers] = pure_ysh.PushRegisters(mem, cmd_ev)
 
     # Hay

--- a/core/state.py
+++ b/core/state.py
@@ -1099,6 +1099,9 @@ class Mem(object):
         self.running_debug_trap = False  # set by ctx_DebugTrap()
         self.is_main = True  # we start out in main
 
+        # For the ctx builtin
+        self.ctx_stack = []  # List[Dict[str, value_t]]
+
     def __repr__(self):
         # type: () -> str
         parts = []  # type: List[str]
@@ -2208,6 +2211,21 @@ class Mem(object):
     def GetRegexMatch(self):
         # type: () -> regex_match_t
         return self.regex_match[-1]
+
+    def PushContextStack(self, context):
+        # type: (Dict[str, value_t]) -> None
+        self.ctx_stack.append(context)
+
+    def GetContext(self):
+        # type: () -> Optional[Dict[str, value_t]]
+        if len(self.ctx_stack):
+            return self.ctx_stack[-1]
+        return None
+
+    def PopContextStack(self):
+        # type: () -> Dict[str, value_t]
+        assert self.ctx_stack, "Empty context stack"
+        return self.ctx_stack.pop()
 
 
 #

--- a/core/state.py
+++ b/core/state.py
@@ -1100,7 +1100,7 @@ class Mem(object):
         self.is_main = True  # we start out in main
 
         # For the ctx builtin
-        self.ctx_stack = []  # List[Dict[str, value_t]]
+        self.ctx_stack = []  # type: List[Dict[str, value_t]]
 
     def __repr__(self):
         # type: () -> str

--- a/devtools/format.sh
+++ b/devtools/format.sh
@@ -66,6 +66,11 @@ yapf-known() {
     */NINJA_subgraph.py
 }
 
+yapf-changed() {
+  branch="${1:-master}"
+  yapf-files $(git diff --name-only .."$branch" '*.py')
+}
+
 #
 # C++
 #

--- a/doc/ref/toc-ysh.md
+++ b/doc/ref/toc-ysh.md
@@ -120,7 +120,7 @@ Siblings: [OSH Topics](toc-osh.html), [Data Topics](toc-data.html)
                   error                  error 'failed' (status=2)
   [Shell State]   ysh-cd   ysh-shopt     compatible, and takes a block
                   shvar                  Temporary modify global settings
-                  ctx                    Share and update a "context" across procs and funcs
+                  ctx                    Share and update a temporary "context"
                   push-registers         Save registers like $?, PIPESTATUS
   [Modules]       runproc                Run a proc; use as main entry point
                   module                 guard against duplicate 'source'

--- a/doc/ref/toc-ysh.md
+++ b/doc/ref/toc-ysh.md
@@ -120,6 +120,7 @@ Siblings: [OSH Topics](toc-osh.html), [Data Topics](toc-data.html)
                   error                  error 'failed' (status=2)
   [Shell State]   ysh-cd   ysh-shopt     compatible, and takes a block
                   shvar                  Temporary modify global settings
+                  ctx                    Share and update a "context" across procs and funcs
                   push-registers         Save registers like $?, PIPESTATUS
   [Modules]       runproc                Run a proc; use as main entry point
                   module                 guard against duplicate 'source'

--- a/frontend/builtin_def.py
+++ b/frontend/builtin_def.py
@@ -60,6 +60,7 @@ _NORMAL_BUILTINS = [
     'fork', 'forkwait',
     'fopen',
     'shvar',
+    'ctx',
 
     'runproc',
     'boolstatus',

--- a/frontend/flag_def.py
+++ b/frontend/flag_def.py
@@ -424,6 +424,8 @@ SHVAR_SPEC = FlagSpec('shvar')
 #SHVAR_SPEC.Flag('-env', args.String,
 #    help='Push a NAME=val binding and set the -x flag')
 
+CTX_SPEC = FlagSpec('ctx')
+
 PP_SPEC = FlagSpec('pp')
 
 SHVM_SPEC = FlagSpec('shvm')

--- a/spec/ysh-builtin-ctx.test.sh
+++ b/spec/ysh-builtin-ctx.test.sh
@@ -90,6 +90,20 @@ exit 0
 status=100
 ## END
 
+#### no context, set
+ctx set (bad=true)
+echo status=$_status
+## status: 3
+## STDOUT:
+## END
+
+#### no context, emit
+ctx emit bad (true)
+echo status=$_status
+## status: 3
+## STDOUT:
+## END
+
 #### mini-parseArgs
 proc parser (; place ; ; block_def) {
   var p = {}

--- a/spec/ysh-builtin-ctx.test.sh
+++ b/spec/ysh-builtin-ctx.test.sh
@@ -57,6 +57,39 @@ json write (p)
 }
 ## END
 
+#### nested ctx
+var a = {}
+var b = {}
+ctx push (a) {
+  ctx set (from="a")
+  ctx push (b) {
+    ctx set (from="b")
+  }
+}
+json write (a)
+json write (b)
+## STDOUT:
+{
+  "from": "a"
+}
+{
+  "from": "b"
+}
+## END
+
+#### error in context
+var a = {}
+try {
+  ctx push (a) {
+    error "Error from inside a context" (status=100)
+  }
+}
+echo status=$_status
+exit 0
+## STDOUT:
+status=100
+## END
+
 #### mini-argparse
 proc parser (; place ; ; block_def) {
   var p = {}

--- a/spec/ysh-builtin-ctx.test.sh
+++ b/spec/ysh-builtin-ctx.test.sh
@@ -58,32 +58,27 @@ json write (p)
 ## END
 
 #### mini-argparse
-proc parser (; place ; ; block_def) {    # place for parser, and block arg
-  var p = {}  # "flag spec", maybe call it parser now
-  ctx push (p) {
-    eval (block_def)
-    # the eval "expands" to calls like this:
-    # ctx emit flag ({short_name: '-v', long_name: '--verbose'})  # flag -v --verbose
-    # ctx emit flag ({long_name: '--count', type: Int, help: 'z'})  # flag --count (Int, help='z')
-    # ctx emit arg (name: 'src')  # arg src
-  }
-  call place->setValue(p)  # "return" the parser we constructed
+proc parser (; place ; ; block_def) {
+  var p = {}
+  ctx push (p, block_def)
+  call place->setValue(p)
 }
 
+var Bool = "Bool"
+var Int = "Int"
 proc flag (short_name, long_name; type; help) {
-  ctx emit flag ({short_name, long_name, type, help})  # using "punning"
+  ctx emit flag ({short_name, long_name, type, help})
 }
 
 proc arg (name) {
   ctx emit arg ({name})
 }
 
-var Bool = "Bool"
-
-parser (&spec) {  # call proc parser with place and block
-  flag -t --tsv (Bool, help='')
-  flag -r --rusage (Bool, help='')
-  arg file
+parser (&spec) {
+  flag -t --tsv (Bool, help='Output as a TSV')
+  flag -r --recursive (Bool, help='Recurse into the given directory')
+  flag -N --count (Int, help='Process no more than N files')
+  arg path
 }
 json write (spec)
 ## STDOUT:
@@ -93,18 +88,24 @@ json write (spec)
       "short_name": "-t",
       "long_name": "--tsv",
       "type": "Bool",
-      "help": ""
+      "help": "Output as a TSV"
     },
     {
       "short_name": "-r",
-      "long_name": "--rusage",
+      "long_name": "--recursive",
       "type": "Bool",
-      "help": ""
+      "help": "Recurse into the given directory"
+    },
+    {
+      "short_name": "-N",
+      "long_name": "--count",
+      "type": "Int",
+      "help": "Process no more than N files"
     }
   ],
   "arg": [
     {
-      "name": "file"
+      "name": "path"
     }
   ]
 }

--- a/spec/ysh-builtin-ctx.test.sh
+++ b/spec/ysh-builtin-ctx.test.sh
@@ -14,3 +14,45 @@ json write (mydict)
   "key2": "value2"
 }
 ## END
+
+#### ctx emit
+var p = {}
+ctx push (p) {
+  ctx emit flag ({short_name: '-v'})
+  # p => {'flag': [{short_name: '-v'}]}
+  json write (p)
+
+  ctx emit flag ({short_name: '-c'})
+  # p => {'flag': [{short_name: '-v'}, {short_name: '-c'}]}
+  json write (p)
+}
+json write (p)
+## STDOUT:
+{
+  "flag": [
+    {
+      "short_name": "-v"
+    }
+  ]
+}
+{
+  "flag": [
+    {
+      "short_name": "-v"
+    },
+    {
+      "short_name": "-c"
+    }
+  ]
+}
+{
+  "flag": [
+    {
+      "short_name": "-v"
+    },
+    {
+      "short_name": "-c"
+    }
+  ]
+}
+## END

--- a/spec/ysh-builtin-ctx.test.sh
+++ b/spec/ysh-builtin-ctx.test.sh
@@ -1,0 +1,16 @@
+## our_shell: ysh
+## oils_failures_allowed: 0
+
+#### ctx push and set
+var mydict = {}
+ctx push (mydict) {
+  ctx set (key1="value1")
+  ctx set (key2="value2")
+}
+json write (mydict)
+## STDOUT:
+{
+  "key1": "value1",
+  "key2": "value2"
+}
+## END

--- a/spec/ysh-builtin-ctx.test.sh
+++ b/spec/ysh-builtin-ctx.test.sh
@@ -90,7 +90,7 @@ exit 0
 status=100
 ## END
 
-#### mini-argparse
+#### mini-parseArgs
 proc parser (; place ; ; block_def) {
   var p = {}
   ctx push (p, block_def)

--- a/spec/ysh-builtin-ctx.test.sh
+++ b/spec/ysh-builtin-ctx.test.sh
@@ -56,3 +56,56 @@ json write (p)
   ]
 }
 ## END
+
+#### mini-argparse
+proc parser (; place ; ; block_def) {    # place for parser, and block arg
+  var p = {}  # "flag spec", maybe call it parser now
+  ctx push (p) {
+    eval (block_def)
+    # the eval "expands" to calls like this:
+    # ctx emit flag ({short_name: '-v', long_name: '--verbose'})  # flag -v --verbose
+    # ctx emit flag ({long_name: '--count', type: Int, help: 'z'})  # flag --count (Int, help='z')
+    # ctx emit arg (name: 'src')  # arg src
+  }
+  call place->setValue(p)  # "return" the parser we constructed
+}
+
+proc flag (short_name, long_name; type; help) {
+  ctx emit flag ({short_name, long_name, type, help})  # using "punning"
+}
+
+proc arg (name) {
+  ctx emit arg ({name})
+}
+
+var Bool = "Bool"
+
+parser (&spec) {  # call proc parser with place and block
+  flag -t --tsv (Bool, help='')
+  flag -r --rusage (Bool, help='')
+  arg file
+}
+json write (spec)
+## STDOUT:
+{
+  "flag": [
+    {
+      "short_name": "-t",
+      "long_name": "--tsv",
+      "type": "Bool",
+      "help": ""
+    },
+    {
+      "short_name": "-r",
+      "long_name": "--rusage",
+      "type": "Bool",
+      "help": ""
+    }
+  ],
+  "arg": [
+    {
+      "name": "file"
+    }
+  ]
+}
+## END

--- a/test/spec.sh
+++ b/test/spec.sh
@@ -911,6 +911,10 @@ ysh-user-feedback() {
   run-file ysh-user-feedback "$@"
 }
 
+ysh-builtin-ctx() {
+  run-file ysh-builtin-ctx "$@"
+}
+
 ysh-builtin-error() {
   run-file ysh-builtin-error "$@"
 }


### PR DESCRIPTION
This is a rough draft of the `ctx` builtin. It has implemented these verbs:

- `push`
- `set`
- `emit`

Here's an example which will now run:

```
var p = {}
ctx push (p) {
  ctx set (help="This is a help message")
  ctx emit flags ({short_name: '-v'})
  ctx emit flags ({short_name: '-h'})
}
# p => {'help': 'This is a help message', 'flag': [{short_name: '-v'}, {short_name: '-h'}]}
```