### PR TITLE
[translation] Make note of different with frontend/flag_spec

### DIFF
--- a/cpp/frontend_flag_spec.cc
+++ b/cpp/frontend_flag_spec.cc
@@ -234,8 +234,12 @@ args::_Attributes* Parse(BigStr* spec_name, args::Reader* arg_r) {
   return args::Parse(spec, arg_r);
 }
 
+// With optional arg
 Tuple2<args::_Attributes*, args::Reader*> ParseCmdVal(
-    BigStr* spec_name, runtime_asdl::cmd_value__Argv* cmd_val) {
+    BigStr* spec_name, runtime_asdl::cmd_value::Argv* cmd_val,
+    bool accept_typed_args) {
+  // TODO: disallow typed args like frontend/flag_spec.py
+
   auto arg_r = Alloc<args::Reader>(cmd_val->argv, cmd_val->arg_locs);
   arg_r->Next();  // move past the builtin name
 
@@ -245,16 +249,10 @@ Tuple2<args::_Attributes*, args::Reader*> ParseCmdVal(
                                                    arg_r);
 }
 
-// With optional arg
-Tuple2<args::_Attributes*, args::Reader*> ParseCmdVal(
-    BigStr* spec_name, runtime_asdl::cmd_value::Argv* cmd_val,
-    bool accept_typed_args) {
-  // TODO: disallow typed args!
-  return ParseCmdVal(spec_name, cmd_val);
-}
-
 Tuple2<args::_Attributes*, args::Reader*> ParseLikeEcho(
     BigStr* spec_name, runtime_asdl::cmd_value::Argv* cmd_val) {
+  // TODO: disallow typed args like frontend/flag_spec.py
+
   auto arg_r = Alloc<args::Reader>(cmd_val->argv, cmd_val->arg_locs);
   arg_r->Next();  // move past the builtin name
 

--- a/cpp/frontend_flag_spec.h
+++ b/cpp/frontend_flag_spec.h
@@ -145,12 +145,8 @@ flag_spec::_FlagSpecAndMore* LookupFlagSpec2(BigStr* spec_name);
 args::_Attributes* Parse(BigStr* spec_name, args::Reader* arg_r);
 
 Tuple2<args::_Attributes*, args::Reader*> ParseCmdVal(
-    BigStr* spec_name, runtime_asdl::cmd_value::Argv* cmd_val);
-
-// With optional arg
-Tuple2<args::_Attributes*, args::Reader*> ParseCmdVal(
     BigStr* spec_name, runtime_asdl::cmd_value::Argv* cmd_val,
-    bool accept_typed_args);
+    bool accept_typed_args = false);
 
 Tuple2<args::_Attributes*, args::Reader*> ParseLikeEcho(
     BigStr* spec_name, runtime_asdl::cmd_value::Argv* cmd_val);

--- a/frontend/flag_spec.py
+++ b/frontend/flag_spec.py
@@ -58,8 +58,6 @@ def _DoesNotAccept(arg_list):
 def ParseCmdVal(spec_name, cmd_val, accept_typed_args=False):
     # type: (str, cmd_value.Argv, bool) -> Tuple[args._Attributes, args.Reader]
 
-    #from frontend import typed_args  # break circular dependency
-
     if not accept_typed_args:
         _DoesNotAccept(cmd_val.typed_args)
 
@@ -72,8 +70,6 @@ def ParseCmdVal(spec_name, cmd_val, accept_typed_args=False):
 
 def ParseLikeEcho(spec_name, cmd_val):
     # type: (str, cmd_value.Argv) -> Tuple[args._Attributes, args.Reader]
-
-    #from frontend import typed_args  # break circular dependency
 
     _DoesNotAccept(cmd_val.typed_args)
 


### PR DESCRIPTION
We don't have a faithful translation of both ParseLikeEcho() and ParseCmdval().

Refactor to use default argument value.