### PR TITLE
[translation fix] Auto-translate more of frontend/flag_spec.py

### DIFF
--- a/builtin/assign_osh.py
+++ b/builtin/assign_osh.py
@@ -15,7 +15,7 @@ from core import error
 from core.error import e_usage
 from core import state
 from core import vm
-from frontend import flag_spec
+from frontend import flag_util
 from frontend import args
 from mycpp import mylib
 from mycpp.mylib import log
@@ -256,7 +256,7 @@ class Export(vm._AssignBuiltin):
         # type: (cmd_value.Assign) -> int
         arg_r = args.Reader(cmd_val.argv, locs=cmd_val.arg_locs)
         arg_r.Next()
-        attrs = flag_spec.Parse('export_', arg_r)
+        attrs = flag_util.Parse('export_', arg_r)
         arg = arg_types.export_(attrs.attrs)
         #arg = attrs
 
@@ -327,7 +327,7 @@ class Readonly(vm._AssignBuiltin):
         # type: (cmd_value.Assign) -> int
         arg_r = args.Reader(cmd_val.argv, locs=cmd_val.arg_locs)
         arg_r.Next()
-        attrs = flag_spec.Parse('readonly', arg_r)
+        attrs = flag_util.Parse('readonly', arg_r)
         arg = arg_types.readonly(attrs.attrs)
 
         if arg.p or len(cmd_val.pairs) == 0:
@@ -383,7 +383,7 @@ class NewVar(vm._AssignBuiltin):
         # type: (cmd_value.Assign) -> int
         arg_r = args.Reader(cmd_val.argv, locs=cmd_val.arg_locs)
         arg_r.Next()
-        attrs = flag_spec.Parse('new_var', arg_r)
+        attrs = flag_util.Parse('new_var', arg_r)
         arg = arg_types.new_var(attrs.attrs)
 
         status = 0
@@ -519,7 +519,7 @@ class Unset(vm._Builtin):
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        attrs, arg_r = flag_spec.ParseCmdVal('unset', cmd_val)
+        attrs, arg_r = flag_util.ParseCmdVal('unset', cmd_val)
         arg = arg_types.unset(attrs.attrs)
 
         argv, arg_locs = arg_r.Rest2()

--- a/builtin/completion_osh.py
+++ b/builtin/completion_osh.py
@@ -12,7 +12,7 @@ from core import ui
 from core import vm
 from mycpp import mylib
 from mycpp.mylib import log, print_stderr
-from frontend import flag_spec
+from frontend import flag_util
 from frontend import args
 from frontend import consts
 
@@ -298,7 +298,7 @@ class Complete(vm._Builtin):
         arg_r = args.Reader(cmd_val.argv, cmd_val.arg_locs)
         arg_r.Next()
 
-        attrs = flag_spec.ParseMore('complete', arg_r)
+        attrs = flag_util.ParseMore('complete', arg_r)
         arg = arg_types.complete(attrs.attrs)
         # TODO: process arg.opt_changes
 
@@ -350,7 +350,7 @@ class CompGen(vm._Builtin):
         arg_r = args.Reader(cmd_val.argv, cmd_val.arg_locs)
         arg_r.Next()
 
-        arg = flag_spec.ParseMore('compgen', arg_r)
+        arg = flag_util.ParseMore('compgen', arg_r)
 
         if arg_r.AtEnd():
             to_complete = ''
@@ -408,7 +408,7 @@ class CompOpt(vm._Builtin):
         arg_r = args.Reader(cmd_val.argv, cmd_val.arg_locs)
         arg_r.Next()
 
-        arg = flag_spec.ParseMore('compopt', arg_r)
+        arg = flag_util.ParseMore('compopt', arg_r)
 
         if not self.comp_state.currently_completing:  # bash also checks this.
             self.errfmt.Print_(
@@ -442,7 +442,7 @@ class CompAdjust(vm._Builtin):
         arg_r = args.Reader(cmd_val.argv, cmd_val.arg_locs)
         arg_r.Next()
 
-        attrs = flag_spec.ParseMore('compadjust', arg_r)
+        attrs = flag_util.ParseMore('compadjust', arg_r)
         arg = arg_types.compadjust(attrs.attrs)
         var_names = arg_r.Rest()  # Output variables to set
         for name in var_names:

--- a/builtin/completion_ysh.py
+++ b/builtin/completion_ysh.py
@@ -9,7 +9,7 @@ from core import vm
 from data_lang import j8
 from mycpp import mylib
 from mycpp.mylib import log
-from frontend import flag_spec
+from frontend import flag_util
 from frontend import args
 
 from typing import TYPE_CHECKING
@@ -29,7 +29,7 @@ class CompExport(vm._Builtin):
         arg_r = args.Reader(cmd_val.argv, cmd_val.arg_locs)
         arg_r.Next()
 
-        attrs = flag_spec.ParseMore('compexport', arg_r)
+        attrs = flag_util.ParseMore('compexport', arg_r)
         arg = arg_types.compexport(attrs.attrs)
 
         if arg.c is None:

--- a/builtin/dirs_osh.py
+++ b/builtin/dirs_osh.py
@@ -8,7 +8,7 @@ from core import pyos
 from core import state
 from core import ui
 from core import vm
-from frontend import flag_spec
+from frontend import flag_util
 from frontend import typed_args
 from mycpp.mylib import log
 from pylib import os_path
@@ -96,7 +96,7 @@ class Cd(vm._Builtin):
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        attrs, arg_r = flag_spec.ParseCmdVal('cd',
+        attrs, arg_r = flag_util.ParseCmdVal('cd',
                                              cmd_val,
                                              accept_typed_args=True)
         arg = arg_types.cd(attrs.attrs)
@@ -197,7 +197,7 @@ class Pushd(vm._Builtin):
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        _, arg_r = flag_spec.ParseCmdVal('pushd', cmd_val)
+        _, arg_r = flag_util.ParseCmdVal('pushd', cmd_val)
 
         dir_arg, dir_arg_loc = arg_r.Peek2()
         if dir_arg is None:
@@ -260,7 +260,7 @@ class Popd(vm._Builtin):
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        _, arg_r = flag_spec.ParseCmdVal('pushd', cmd_val)
+        _, arg_r = flag_util.ParseCmdVal('pushd', cmd_val)
 
         extra, extra_loc = arg_r.Peek2()
         if extra is not None:
@@ -286,7 +286,7 @@ class Dirs(vm._Builtin):
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        attrs, arg_r = flag_spec.ParseCmdVal('dirs', cmd_val)
+        attrs, arg_r = flag_util.ParseCmdVal('dirs', cmd_val)
         arg = arg_types.dirs(attrs.attrs)
 
         home_dir = state.MaybeString(self.mem, 'HOME')
@@ -320,7 +320,7 @@ class Pwd(vm._Builtin):
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        attrs, arg_r = flag_spec.ParseCmdVal('pwd', cmd_val)
+        attrs, arg_r = flag_util.ParseCmdVal('pwd', cmd_val)
         arg = arg_types.pwd(attrs.attrs)
 
         # NOTE: 'pwd' will succeed even if the directory has disappeared.  Other

--- a/builtin/error_ysh.py
+++ b/builtin/error_ysh.py
@@ -8,7 +8,7 @@ from core.error import e_die_status, e_usage
 from core import executor
 from core import state
 from core import vm
-from frontend import flag_spec
+from frontend import flag_util
 from frontend import typed_args
 from mycpp.mylib import log
 
@@ -81,7 +81,7 @@ class Try(vm._Builtin):
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        _, arg_r = flag_spec.ParseCmdVal('try_',
+        _, arg_r = flag_util.ParseCmdVal('try_',
                                          cmd_val,
                                          accept_typed_args=True)
 
@@ -145,7 +145,7 @@ class Error(vm._Builtin):
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        _, arg_r = flag_spec.ParseCmdVal('error',
+        _, arg_r = flag_util.ParseCmdVal('error',
                                          cmd_val,
                                          accept_typed_args=True)
 
@@ -183,7 +183,7 @@ class BoolStatus(vm._Builtin):
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
 
-        _, arg_r = flag_spec.ParseCmdVal('boolstatus', cmd_val)
+        _, arg_r = flag_util.ParseCmdVal('boolstatus', cmd_val)
 
         if arg_r.Peek() is None:
             e_usage('expected a command to run', loc.Missing)

--- a/builtin/io_osh.py
+++ b/builtin/io_osh.py
@@ -7,7 +7,7 @@ from _devbuild.gen.id_kind_asdl import Id
 from _devbuild.gen.value_asdl import (value, value_t)
 from builtin import read_osh
 from core.error import e_die_status
-from frontend import flag_spec
+from frontend import flag_util
 from frontend import lexer
 from frontend import match
 from frontend import typed_args
@@ -62,7 +62,7 @@ class Echo(vm._Builtin):
             typed_args.DoesNotAccept(cmd_val.typed_args)  # Disallow echo (42)
             arg = self._SimpleFlag()  # Avoid parsing -e -n
         else:
-            attrs, arg_r = flag_spec.ParseLikeEcho('echo', cmd_val)
+            attrs, arg_r = flag_util.ParseLikeEcho('echo', cmd_val)
             arg = arg_types.echo(attrs.attrs)
             argv = arg_r.Rest()
 
@@ -120,7 +120,7 @@ class MapFile(vm._Builtin):
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        attrs, arg_r = flag_spec.ParseCmdVal('mapfile', cmd_val)
+        attrs, arg_r = flag_util.ParseCmdVal('mapfile', cmd_val)
         arg = arg_types.mapfile(attrs.attrs)
 
         var_name, _ = arg_r.Peek2()

--- a/builtin/io_ysh.py
+++ b/builtin/io_ysh.py
@@ -15,7 +15,7 @@ from core import state
 from core import ui
 from core import vm
 from data_lang import j8
-from frontend import flag_spec
+from frontend import flag_util
 from frontend import match
 from frontend import typed_args
 from mycpp import mylib
@@ -54,7 +54,7 @@ class Pp(_Builtin):
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        arg, arg_r = flag_spec.ParseCmdVal('pp',
+        arg, arg_r = flag_util.ParseCmdVal('pp',
                                            cmd_val,
                                            accept_typed_args=True)
 
@@ -188,7 +188,7 @@ class Write(_Builtin):
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        attrs, arg_r = flag_spec.ParseCmdVal('write', cmd_val)
+        attrs, arg_r = flag_util.ParseCmdVal('write', cmd_val)
         arg = arg_types.write(attrs.attrs)
         #print(arg)
 
@@ -234,7 +234,7 @@ class Fopen(vm._Builtin):
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        _, arg_r = flag_spec.ParseCmdVal('fopen',
+        _, arg_r = flag_util.ParseCmdVal('fopen',
                                          cmd_val,
                                          accept_typed_args=True)
 

--- a/builtin/json_ysh.py
+++ b/builtin/json_ysh.py
@@ -11,7 +11,7 @@ from core import pyos
 from core import state
 from core import vm
 from data_lang import j8
-from frontend import flag_spec
+from frontend import flag_util
 from frontend import args
 from frontend import typed_args
 from mycpp import mylib
@@ -60,7 +60,7 @@ class Json(vm._Builtin):
             # NOTE slightly different flags
             # json write --surrogate-ok $'\udc00'
             # not valid for j8 write
-            attrs = flag_spec.Parse('json_write', arg_r)
+            attrs = flag_util.Parse('json_write', arg_r)
 
             arg_jw = arg_types.json_write(attrs.attrs)
 
@@ -95,7 +95,7 @@ class Json(vm._Builtin):
             self.stdout_.write('\n')
 
         elif action == 'read':
-            attrs = flag_spec.Parse('json_read', arg_r)
+            attrs = flag_util.Parse('json_read', arg_r)
             arg_jr = arg_types.json_read(attrs.attrs)
             # TODO:
             # Respect -validate=F

--- a/builtin/meta_osh.py
+++ b/builtin/meta_osh.py
@@ -19,7 +19,7 @@ from core import pyutil  # strerror
 from core import state
 from core import vm
 from data_lang import j8_lite
-from frontend import flag_spec
+from frontend import flag_util
 from frontend import consts
 from frontend import reader
 from frontend import typed_args
@@ -70,7 +70,7 @@ class Eval(vm._Builtin):
             return self.cmd_ev.EvalCommand(block)
 
         # There are no flags, but we need it to respect --
-        _, arg_r = flag_spec.ParseCmdVal('eval', cmd_val)
+        _, arg_r = flag_util.ParseCmdVal('eval', cmd_val)
 
         if self.exec_opts.simple_eval_builtin():
             code_str, eval_loc = arg_r.ReadRequired2('requires code string')
@@ -119,7 +119,7 @@ class Source(vm._Builtin):
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        attrs, arg_r = flag_spec.ParseCmdVal('source', cmd_val)
+        attrs, arg_r = flag_util.ParseCmdVal('source', cmd_val)
         arg = arg_types.source(attrs.attrs)
 
         path = arg_r.Peek()
@@ -251,7 +251,7 @@ class Command(vm._Builtin):
         # type: (cmd_value.Argv) -> int
 
         # accept_typed_args=True because we invoke other builtins
-        attrs, arg_r = flag_spec.ParseCmdVal('command',
+        attrs, arg_r = flag_util.ParseCmdVal('command',
                                              cmd_val,
                                              accept_typed_args=True)
         arg = arg_types.command(attrs.attrs)
@@ -346,7 +346,7 @@ class RunProc(vm._Builtin):
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        _, arg_r = flag_spec.ParseCmdVal('runproc',
+        _, arg_r = flag_util.ParseCmdVal('runproc',
                                          cmd_val,
                                          accept_typed_args=True)
         argv, locs = arg_r.Rest2()
@@ -426,7 +426,7 @@ class Type(vm._Builtin):
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        attrs, arg_r = flag_spec.ParseCmdVal('type', cmd_val)
+        attrs, arg_r = flag_util.ParseCmdVal('type', cmd_val)
         arg = arg_types.type(attrs.attrs)
 
         if arg.f:  # suppress function lookup

--- a/builtin/misc_osh.py
+++ b/builtin/misc_osh.py
@@ -14,7 +14,7 @@ from core import pyos
 from core import pyutil
 from core import util
 from core import vm
-from frontend import flag_spec
+from frontend import flag_util
 from mycpp import mylib
 from mycpp.mylib import log
 
@@ -92,7 +92,7 @@ class Help(vm._Builtin):
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
 
-        attrs, arg_r = flag_spec.ParseCmdVal('help', cmd_val)
+        attrs, arg_r = flag_util.ParseCmdVal('help', cmd_val)
         #arg = arg_types.help(attrs.attrs)
 
         topic_id, blame_loc = arg_r.Peek2()

--- a/builtin/module_ysh.py
+++ b/builtin/module_ysh.py
@@ -9,7 +9,7 @@ from core import state
 from core import ui
 from core import vm
 from frontend import args
-from frontend import flag_spec
+from frontend import flag_util
 from mycpp.mylib import log
 
 from typing import Dict, cast, TYPE_CHECKING
@@ -47,7 +47,7 @@ class Module(vm._Builtin):
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        _, arg_r = flag_spec.ParseCmdVal('module', cmd_val)
+        _, arg_r = flag_util.ParseCmdVal('module', cmd_val)
         name, _ = arg_r.ReadRequired2('requires a name')
         #log('modules %s', self.modules)
         if name in self.modules:

--- a/builtin/printf_osh.py
+++ b/builtin/printf_osh.py
@@ -26,7 +26,7 @@ from core import error
 from core.error import e_die, p_die
 from core import state
 from core import vm
-from frontend import flag_spec
+from frontend import flag_util
 from frontend import consts
 from frontend import lexer
 from frontend import match
@@ -458,9 +458,9 @@ class Printf(vm._Builtin):
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
         """
-    printf: printf [-v var] format [argument ...]
-    """
-        attrs, arg_r = flag_spec.ParseCmdVal('printf', cmd_val)
+        printf: printf [-v var] format [argument ...]
+        """
+        attrs, arg_r = flag_util.ParseCmdVal('printf', cmd_val)
         arg = arg_types.printf(attrs.attrs)
 
         fmt, fmt_loc = arg_r.ReadRequired2('requires a format string')

--- a/builtin/process_osh.py
+++ b/builtin/process_osh.py
@@ -17,7 +17,7 @@ from core.error import e_usage, e_die_status
 from core import process  # W1_OK, W1_ECHILD
 from core import vm
 from mycpp.mylib import log, tagswitch, print_stderr
-from frontend import flag_spec
+from frontend import flag_util
 from frontend import typed_args
 
 import posix_ as posix
@@ -39,7 +39,7 @@ class Jobs(vm._Builtin):
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
 
-        attrs, arg_r = flag_spec.ParseCmdVal('jobs', cmd_val)
+        attrs, arg_r = flag_util.ParseCmdVal('jobs', cmd_val)
         arg = arg_types.jobs(attrs.attrs)
 
         if arg.l:
@@ -137,7 +137,7 @@ class Fork(vm._Builtin):
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        _, arg_r = flag_spec.ParseCmdVal('fork',
+        _, arg_r = flag_util.ParseCmdVal('fork',
                                          cmd_val,
                                          accept_typed_args=True)
 
@@ -160,7 +160,7 @@ class ForkWait(vm._Builtin):
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        _, arg_r = flag_spec.ParseCmdVal('forkwait',
+        _, arg_r = flag_util.ParseCmdVal('forkwait',
                                          cmd_val,
                                          accept_typed_args=True)
         arg, location = arg_r.Peek2()
@@ -186,7 +186,7 @@ class Exec(vm._Builtin):
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        _, arg_r = flag_spec.ParseCmdVal('exec', cmd_val)
+        _, arg_r = flag_util.ParseCmdVal('exec', cmd_val)
 
         # Apply redirects in this shell.  # NOTE: Redirects were processed earlier.
         if arg_r.AtEnd():
@@ -243,7 +243,7 @@ class Wait(vm._Builtin):
 
     def _Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        attrs, arg_r = flag_spec.ParseCmdVal('wait', cmd_val)
+        attrs, arg_r = flag_util.ParseCmdVal('wait', cmd_val)
         arg = arg_types.wait(attrs.attrs)
 
         job_ids, arg_locs = arg_r.Rest2()

--- a/builtin/pure_osh.py
+++ b/builtin/pure_osh.py
@@ -21,7 +21,7 @@ from core import vm
 from data_lang import j8_lite
 from frontend import args
 from frontend import consts
-from frontend import flag_spec
+from frontend import flag_util
 from frontend import match
 from frontend import typed_args
 from mycpp import mylib
@@ -60,7 +60,7 @@ class Alias(vm._Builtin):
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        _, arg_r = flag_spec.ParseCmdVal('alias', cmd_val)
+        _, arg_r = flag_util.ParseCmdVal('alias', cmd_val)
         argv = arg_r.Rest()
 
         if len(argv) == 0:
@@ -98,7 +98,7 @@ class UnAlias(vm._Builtin):
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        _, arg_r = flag_spec.ParseCmdVal('unalias', cmd_val)
+        _, arg_r = flag_util.ParseCmdVal('unalias', cmd_val)
         argv = arg_r.Rest()
 
         if len(argv) == 0:
@@ -158,7 +158,7 @@ class Set(vm._Builtin):
 
         arg_r = args.Reader(cmd_val.argv, locs=cmd_val.arg_locs)
         arg_r.Next()  # skip 'set'
-        arg = flag_spec.ParseMore('set', arg_r)
+        arg = flag_util.ParseMore('set', arg_r)
 
         # 'set -o' shows options.  This is actually used by autoconf-generated
         # scripts!
@@ -189,7 +189,7 @@ class Shopt(vm._Builtin):
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        attrs, arg_r = flag_spec.ParseCmdVal('shopt',
+        attrs, arg_r = flag_util.ParseCmdVal('shopt',
                                              cmd_val,
                                              accept_typed_args=True)
 
@@ -268,7 +268,7 @@ class Hash(vm._Builtin):
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        attrs, arg_r = flag_spec.ParseCmdVal('hash', cmd_val)
+        attrs, arg_r = flag_util.ParseCmdVal('hash', cmd_val)
         arg = arg_types.hash(attrs.attrs)
 
         rest = arg_r.Rest()

--- a/builtin/pure_ysh.py
+++ b/builtin/pure_ysh.py
@@ -9,7 +9,7 @@ from _devbuild.gen.value_asdl import (value, value_e, value_t, LeftName)
 from core import error
 from core import state
 from core import vm
-from frontend import flag_spec
+from frontend import flag_util
 from frontend import location
 from frontend import typed_args
 from mycpp import mylib
@@ -70,7 +70,7 @@ class Shvar(vm._Builtin):
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        _, arg_r = flag_spec.ParseCmdVal('shvar',
+        _, arg_r = flag_util.ParseCmdVal('shvar',
                                          cmd_val,
                                          accept_typed_args=True)
 
@@ -167,7 +167,7 @@ class Ctx(vm._Builtin):
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
         rd = typed_args.ReaderForProc(cmd_val)
-        _, arg_r = flag_spec.ParseCmdVal('ctx',
+        _, arg_r = flag_util.ParseCmdVal('ctx',
                                          cmd_val,
                                          accept_typed_args=True)
 
@@ -211,7 +211,7 @@ class PushRegisters(vm._Builtin):
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        _, arg_r = flag_spec.ParseCmdVal('push-registers',
+        _, arg_r = flag_util.ParseCmdVal('push-registers',
                                          cmd_val,
                                          accept_typed_args=True)
 
@@ -245,7 +245,7 @@ class Append(vm._Builtin):
         # type: (cmd_value.Argv) -> int
 
         # This means we ignore -- , which is consistent
-        arg, arg_r = flag_spec.ParseCmdVal('append',
+        arg, arg_r = flag_util.ParseCmdVal('append',
                                            cmd_val,
                                            accept_typed_args=True)
 

--- a/builtin/read_osh.py
+++ b/builtin/read_osh.py
@@ -14,7 +14,7 @@ from core import pyutil
 from core import state
 from core import ui
 from core import vm
-from frontend import flag_spec
+from frontend import flag_util
 from frontend import reader
 from frontend import typed_args
 from mycpp import mylib
@@ -402,7 +402,7 @@ class Read(vm._Builtin):
 
     def _Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        attrs, arg_r = flag_spec.ParseCmdVal('read',
+        attrs, arg_r = flag_util.ParseCmdVal('read',
                                              cmd_val,
                                              accept_typed_args=True)
         arg = arg_types.read(attrs.attrs)

--- a/builtin/readline_osh.py
+++ b/builtin/readline_osh.py
@@ -9,7 +9,7 @@ from _devbuild.gen.syntax_asdl import loc
 from core.error import e_usage
 from core import pyutil
 from core import vm
-from frontend import flag_spec
+from frontend import flag_util
 from mycpp import mylib
 
 from typing import Optional, TYPE_CHECKING
@@ -61,7 +61,7 @@ class History(vm._Builtin):
             e_usage("is disabled because Oil wasn't compiled with 'readline'",
                     loc.Missing)
 
-        attrs, arg_r = flag_spec.ParseCmdVal('history', cmd_val)
+        attrs, arg_r = flag_util.ParseCmdVal('history', cmd_val)
         arg = arg_types.history(attrs.attrs)
 
         # Clear all history

--- a/builtin/trap_osh.py
+++ b/builtin/trap_osh.py
@@ -14,7 +14,7 @@ from core import main_loop
 from mycpp.mylib import log
 from core import pyos
 from core import vm
-from frontend import flag_spec
+from frontend import flag_util
 from frontend import signal_def
 from frontend import reader
 from mycpp import mylib
@@ -187,7 +187,7 @@ class Trap(vm._Builtin):
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
-        attrs, arg_r = flag_spec.ParseCmdVal('trap', cmd_val)
+        attrs, arg_r = flag_util.ParseCmdVal('trap', cmd_val)
         arg = arg_types.trap(attrs.attrs)
 
         if arg.p:  # Print registered handlers

--- a/core/shell.py
+++ b/core/shell.py
@@ -32,7 +32,7 @@ from frontend import args
 from frontend import flag_def  # side effect: flags are defined!
 
 unused1 = flag_def
-from frontend import flag_spec
+from frontend import flag_util
 from frontend import location
 from frontend import reader
 from frontend import parse_lib
@@ -304,7 +304,7 @@ def Main(
     assert lang in ('osh', 'ysh'), lang
 
     try:
-        attrs = flag_spec.ParseMore('main', arg_r)
+        attrs = flag_util.ParseMore('main', arg_r)
     except error.Usage as e:
         print_stderr('%s usage error: %s' % (lang, e.msg))
         return 2

--- a/cpp/frontend_flag_spec.cc
+++ b/cpp/frontend_flag_spec.cc
@@ -8,10 +8,8 @@
 // for definition of args::Reader, etc.
 #include "prebuilt/frontend/args.mycpp.h"
 
-namespace flag_spec {
+namespace flag_util {
 
-using arg_types::kFlagSpecs;
-using arg_types::kFlagSpecsAndMore;
 using runtime_asdl::flag_type_e;
 using value_asdl::value;
 using value_asdl::value_t;
@@ -191,6 +189,9 @@ flag_spec::_FlagSpecAndMore* CreateSpec2(FlagSpecAndMore_c* in) {
   return out;
 }
 
+using arg_types::kFlagSpecs;
+using arg_types::kFlagSpecsAndMore;
+
 flag_spec::_FlagSpec* LookupFlagSpec(BigStr* spec_name) {
   int i = 0;
   while (true) {
@@ -227,45 +228,4 @@ flag_spec::_FlagSpecAndMore* LookupFlagSpec2(BigStr* spec_name) {
   return nullptr;
 }
 
-args::_Attributes* Parse(BigStr* spec_name, args::Reader* arg_r) {
-  flag_spec::_FlagSpec* spec = LookupFlagSpec(spec_name);
-  assert(spec);  // should always be found
-
-  return args::Parse(spec, arg_r);
-}
-
-// With optional arg
-Tuple2<args::_Attributes*, args::Reader*> ParseCmdVal(
-    BigStr* spec_name, runtime_asdl::cmd_value::Argv* cmd_val,
-    bool accept_typed_args) {
-  // TODO: disallow typed args like frontend/flag_spec.py
-
-  auto arg_r = Alloc<args::Reader>(cmd_val->argv, cmd_val->arg_locs);
-  arg_r->Next();  // move past the builtin name
-
-  flag_spec::_FlagSpec* spec = LookupFlagSpec(spec_name);
-  assert(spec);  // should always be found
-  return Tuple2<args::_Attributes*, args::Reader*>(args::Parse(spec, arg_r),
-                                                   arg_r);
-}
-
-Tuple2<args::_Attributes*, args::Reader*> ParseLikeEcho(
-    BigStr* spec_name, runtime_asdl::cmd_value::Argv* cmd_val) {
-  // TODO: disallow typed args like frontend/flag_spec.py
-
-  auto arg_r = Alloc<args::Reader>(cmd_val->argv, cmd_val->arg_locs);
-  arg_r->Next();  // move past the builtin name
-
-  flag_spec::_FlagSpec* spec = LookupFlagSpec(spec_name);
-  assert(spec);  // should always be found
-  return Tuple2<args::_Attributes*, args::Reader*>(
-      args::ParseLikeEcho(spec, arg_r), arg_r);
-}
-
-args::_Attributes* ParseMore(BigStr* spec_name, args::Reader* arg_r) {
-  flag_spec::_FlagSpecAndMore* spec = LookupFlagSpec2(spec_name);
-  assert(spec);
-  return args::ParseMore(spec, arg_r);
-}
-
-}  // namespace flag_spec
+}  // namespace flag_util

--- a/cpp/frontend_flag_spec.h
+++ b/cpp/frontend_flag_spec.h
@@ -138,21 +138,14 @@ class _FlagSpecAndMore {
   }
 };
 
+}  // namespace flag_spec
+
+namespace flag_util {
+
 // for testing only
 flag_spec::_FlagSpec* LookupFlagSpec(BigStr* spec_name);
 flag_spec::_FlagSpecAndMore* LookupFlagSpec2(BigStr* spec_name);
 
-args::_Attributes* Parse(BigStr* spec_name, args::Reader* arg_r);
-
-Tuple2<args::_Attributes*, args::Reader*> ParseCmdVal(
-    BigStr* spec_name, runtime_asdl::cmd_value::Argv* cmd_val,
-    bool accept_typed_args = false);
-
-Tuple2<args::_Attributes*, args::Reader*> ParseLikeEcho(
-    BigStr* spec_name, runtime_asdl::cmd_value::Argv* cmd_val);
-
-args::_Attributes* ParseMore(BigStr* spec_name, args::Reader* arg_r);
-
-}  // namespace flag_spec
+}  // namespace flag_util
 
 #endif  // FRONTEND_FLAG_SPEC_H

--- a/cpp/frontend_flag_spec_test.cc
+++ b/cpp/frontend_flag_spec_test.cc
@@ -70,21 +70,21 @@ TEST flag_spec_test() {
 
   flag_spec::_FlagSpec* spec;
 
-  spec = flag_spec::LookupFlagSpec(StrFromC("new_var"));
+  spec = flag_util::LookupFlagSpec(StrFromC("new_var"));
   ASSERT(spec != nullptr);
 
-  spec = flag_spec::LookupFlagSpec(StrFromC("readonly"));
+  spec = flag_util::LookupFlagSpec(StrFromC("readonly"));
   ASSERT(spec != nullptr);
 
-  spec = flag_spec::LookupFlagSpec(StrFromC("zzz"));
+  spec = flag_util::LookupFlagSpec(StrFromC("zzz"));
   ASSERT(spec == nullptr);
 
   flag_spec::_FlagSpecAndMore* spec2;
 
-  spec2 = flag_spec::LookupFlagSpec2(StrFromC("main"));
+  spec2 = flag_util::LookupFlagSpec2(StrFromC("main"));
   ASSERT(spec2 != nullptr);
 
-  spec2 = flag_spec::LookupFlagSpec2(StrFromC("zzz"));
+  spec2 = flag_util::LookupFlagSpec2(StrFromC("zzz"));
   ASSERT(spec2 == nullptr);
 
   int i = 0;

--- a/frontend/flag_spec.py
+++ b/frontend/flag_spec.py
@@ -4,19 +4,13 @@ flag_spec.py -- Flag and arg defs for builtins.
 """
 from __future__ import print_function
 
-from _devbuild.gen.runtime_asdl import (
-    cmd_value,
-    flag_type_e,
-    flag_type_t,
-)
-from _devbuild.gen.syntax_asdl import ArgList
+from _devbuild.gen.runtime_asdl import flag_type_e, flag_type_t
 from _devbuild.gen.value_asdl import (value, value_t)
-from core.error import e_usage
 from frontend import args
 from mycpp import mylib
 from mycpp.mylib import log
 
-from typing import Union, List, Tuple, Dict, Any, Optional
+from typing import Union, List, Dict, Any, Optional
 
 _ = log
 
@@ -27,7 +21,7 @@ FLAG_SPEC_AND_MORE = {}
 
 def FlagSpec(builtin_name):
     # type: (str) -> _FlagSpec
-    """Define a flag language."""
+    """Define a flag parser."""
     arg_spec = _FlagSpec()
     FLAG_SPEC[builtin_name] = arg_spec
     return arg_spec
@@ -35,56 +29,13 @@ def FlagSpec(builtin_name):
 
 def FlagSpecAndMore(name, typed=True):
     # type: (str, bool) -> _FlagSpecAndMore
-    """For set, bin/oil.py ("main"), compgen -A, complete -A, etc."""
+    """Define a flag parser with -o +o options
+
+    For set, bin/oils_for_unix.py main, compgen -A, complete -A, etc.
+    """
     arg_spec = _FlagSpecAndMore()
     FLAG_SPEC_AND_MORE[name] = arg_spec
     return arg_spec
-
-
-def Parse(spec_name, arg_r):
-    # type: (str, args.Reader) -> args._Attributes
-    """Parse argv using a given FlagSpec."""
-    spec = FLAG_SPEC[spec_name]
-    return args.Parse(spec, arg_r)
-
-
-def _DoesNotAccept(arg_list):
-    # type: (Optional[ArgList]) -> None
-    """ Copy from frontend/typed_args.py, to break dependency """
-    if arg_list is not None:
-        e_usage('got unexpected typed args', arg_list.left)
-
-
-def ParseCmdVal(spec_name, cmd_val, accept_typed_args=False):
-    # type: (str, cmd_value.Argv, bool) -> Tuple[args._Attributes, args.Reader]
-
-    if not accept_typed_args:
-        _DoesNotAccept(cmd_val.typed_args)
-
-    arg_r = args.Reader(cmd_val.argv, locs=cmd_val.arg_locs)
-    arg_r.Next()  # move past the builtin name
-
-    spec = FLAG_SPEC[spec_name]
-    return args.Parse(spec, arg_r), arg_r
-
-
-def ParseLikeEcho(spec_name, cmd_val):
-    # type: (str, cmd_value.Argv) -> Tuple[args._Attributes, args.Reader]
-
-    _DoesNotAccept(cmd_val.typed_args)
-
-    arg_r = args.Reader(cmd_val.argv, locs=cmd_val.arg_locs)
-    arg_r.Next()  # move past the builtin name
-
-    spec = FLAG_SPEC[spec_name]
-    return args.ParseLikeEcho(spec, arg_r), arg_r
-
-
-def ParseMore(spec_name, arg_r):
-    # type: (str, args.Reader) -> args._Attributes
-    """Parse argv using a given FlagSpecAndMore."""
-    spec = FLAG_SPEC_AND_MORE[spec_name]
-    return args.ParseMore(spec, arg_r)
 
 
 def All():

--- a/frontend/flag_util.py
+++ b/frontend/flag_util.py
@@ -1,0 +1,68 @@
+"""
+flag_util.py - API for builtin commands
+"""
+from __future__ import print_function
+
+from _devbuild.gen.runtime_asdl import cmd_value
+from _devbuild.gen.syntax_asdl import ArgList
+from core.error import e_usage
+from frontend import args
+from frontend import flag_spec
+from mycpp import mylib
+
+from typing import Tuple, Optional
+
+if mylib.PYTHON:
+    def LookupFlagSpec(name):
+        # type: (str) -> flag_spec._FlagSpec
+        return flag_spec.FLAG_SPEC[name]
+
+    def LookupFlagSpec2(name):
+        # type: (str) -> flag_spec._FlagSpecAndMore
+        return flag_spec.FLAG_SPEC_AND_MORE[name]
+
+
+def _DoesNotAccept(arg_list):
+    # type: (Optional[ArgList]) -> None
+    """ Copy from frontend/typed_args.py, to break dependency """
+    if arg_list is not None:
+        e_usage('got unexpected typed args', arg_list.left)
+
+
+def ParseCmdVal(spec_name, cmd_val, accept_typed_args=False):
+    # type: (str, cmd_value.Argv, bool) -> Tuple[args._Attributes, args.Reader]
+
+    if not accept_typed_args:
+        _DoesNotAccept(cmd_val.typed_args)
+
+    arg_r = args.Reader(cmd_val.argv, locs=cmd_val.arg_locs)
+    arg_r.Next()  # move past the builtin name
+
+    spec = LookupFlagSpec(spec_name)
+    return args.Parse(spec, arg_r), arg_r
+
+
+def ParseLikeEcho(spec_name, cmd_val):
+    # type: (str, cmd_value.Argv) -> Tuple[args._Attributes, args.Reader]
+
+    _DoesNotAccept(cmd_val.typed_args)
+
+    arg_r = args.Reader(cmd_val.argv, locs=cmd_val.arg_locs)
+    arg_r.Next()  # move past the builtin name
+
+    spec = LookupFlagSpec(spec_name)
+    return args.ParseLikeEcho(spec, arg_r), arg_r
+
+
+def Parse(spec_name, arg_r):
+    # type: (str, args.Reader) -> args._Attributes
+    """Parse argv using a given FlagSpec."""
+    spec = LookupFlagSpec(spec_name)
+    return args.Parse(spec, arg_r)
+
+
+def ParseMore(spec_name, arg_r):
+    # type: (str, args.Reader) -> args._Attributes
+    """Parse argv using a given FlagSpecAndMore."""
+    spec = LookupFlagSpec2(spec_name)
+    return args.ParseMore(spec, arg_r)

--- a/pea/oils-typecheck.txt
+++ b/pea/oils-typecheck.txt
@@ -65,6 +65,7 @@ frontend/builtin_def.py
 frontend/consts.py
 frontend/flag_def.py
 frontend/flag_spec.py
+frontend/flag_util.py
 frontend/id_kind_def.py
 frontend/lexer.py
 frontend/lexer_def.py


### PR DESCRIPTION
Move it to frontend/flag_util.py.

This fixes a couple bugs in test/spec-cpp.sh runfile builtin-io.  And it reduces the amount of hand-written C++!