### PR TITLE
[toc-ysh] relatable 'echo' and 'write' short descriptions

### DIFF
--- a/doc/ref/toc-ysh.md
+++ b/doc/ref/toc-ysh.md
@@ -127,8 +127,8 @@ Siblings: [OSH Topics](toc-osh.html), [Data Topics](toc-data.html)
                   is-main                false when sourcing a file
                   use                    change first word lookup
   [I/O]           ysh-read               flags --all, -0
-                  ysh-echo               print args on line, flawless simple_echo <!-- after #1772: print args on line, no echo_flags flaws -->
-                  write                  Like echo, with --, --sep, --end
+                  ysh-echo               (args on a line) no flags simple_echo   <!-- after #1772: (args on a line) no echo_flags bugs  -->
+                  write                  (a line per arg) -n --sep --end --
                   fork   forkwait        Replace & and (), and takes a block
                   fopen                  Open multiple streams, takes a block
                   X dbg                  Only thing that can be used in funcs

--- a/doc/ref/toc-ysh.md
+++ b/doc/ref/toc-ysh.md
@@ -127,7 +127,7 @@ Siblings: [OSH Topics](toc-osh.html), [Data Topics](toc-data.html)
                   is-main                false when sourcing a file
                   use                    change first word lookup
   [I/O]           ysh-read               flags --all, -0
-                  ysh-echo               no -e -n -E drops with simple_echo <!-- after #1772: echo_flags off (no -e -n -E soup drops) -->
+                  ysh-echo               no -e -n -E drops with simple_echo <!-- after #1772: echo_flags off (no -e -n -E spaghetti drops) -->
                   write                  Like echo, with --, --sep, --end
                   fork   forkwait        Replace & and (), and takes a block
                   fopen                  Open multiple streams, takes a block

--- a/doc/ref/toc-ysh.md
+++ b/doc/ref/toc-ysh.md
@@ -127,8 +127,8 @@ Siblings: [OSH Topics](toc-osh.html), [Data Topics](toc-data.html)
                   is-main                false when sourcing a file
                   use                    change first word lookup
   [I/O]           ysh-read               flags --all, -0
-                  ysh-echo               (args on a line) no flags simple_echo   <!-- after #1772: (args on a line) no echo_flags bugs  -->
-                  write                  (a line per arg) -- -n --sep --end
+                  ysh-echo               args on a line, no-flags simple_echo   <!-- after #1772: args on a line, no echo_flags, no bugs  -->
+                  write                  a line per arg, -- -n --sep --end
                   fork   forkwait        Replace & and (), and takes a block
                   fopen                  Open multiple streams, takes a block
                   X dbg                  Only thing that can be used in funcs

--- a/doc/ref/toc-ysh.md
+++ b/doc/ref/toc-ysh.md
@@ -127,7 +127,7 @@ Siblings: [OSH Topics](toc-osh.html), [Data Topics](toc-data.html)
                   is-main                false when sourcing a file
                   use                    change first word lookup
   [I/O]           ysh-read               flags --all, -0
-                  ysh-echo               no -e -n -E with simple_echo <!-- after #1772: echo_flags off (any -e -n -E soup) -->
+                  ysh-echo               no -e -n -E drops with simple_echo <!-- after #1772: echo_flags off (no -e -n -E soup drops) -->
                   write                  Like echo, with --, --sep, --end
                   fork   forkwait        Replace & and (), and takes a block
                   fopen                  Open multiple streams, takes a block

--- a/doc/ref/toc-ysh.md
+++ b/doc/ref/toc-ysh.md
@@ -127,7 +127,7 @@ Siblings: [OSH Topics](toc-osh.html), [Data Topics](toc-data.html)
                   is-main                false when sourcing a file
                   use                    change first word lookup
   [I/O]           ysh-read               flags --all, -0
-                  ysh-echo               args on a line, no-flags simple_echo   <!-- after #1772: args on a line, no echo_flags, no bugs  -->
+                  ysh-echo               args on a line, simple_echo, no -enE   <!-- after #1772: args on a line, no -enE echo_flags bug  -->
                   write                  a line per arg, -- -n --sep --end
                   fork   forkwait        Replace & and (), and takes a block
                   fopen                  Open multiple streams, takes a block

--- a/doc/ref/toc-ysh.md
+++ b/doc/ref/toc-ysh.md
@@ -127,7 +127,7 @@ Siblings: [OSH Topics](toc-osh.html), [Data Topics](toc-data.html)
                   is-main                false when sourcing a file
                   use                    change first word lookup
   [I/O]           ysh-read               flags --all, -0
-                  ysh-echo               no -e -n -E drops with simple_echo <!-- after #1772: echo_flags off (no -e -n -E spaghetti drops) -->
+                  ysh-echo               print args on line, flawless simple_echo <!-- after #1772: print args on line, no echo_flags flaws -->
                   write                  Like echo, with --, --sep, --end
                   fork   forkwait        Replace & and (), and takes a block
                   fopen                  Open multiple streams, takes a block

--- a/doc/ref/toc-ysh.md
+++ b/doc/ref/toc-ysh.md
@@ -128,7 +128,7 @@ Siblings: [OSH Topics](toc-osh.html), [Data Topics](toc-data.html)
                   use                    change first word lookup
   [I/O]           ysh-read               flags --all, -0
                   ysh-echo               (args on a line) no flags simple_echo   <!-- after #1772: (args on a line) no echo_flags bugs  -->
-                  write                  (a line per arg) -n --sep --end --
+                  write                  (a line per arg) -- -n --sep --end
                   fork   forkwait        Replace & and (), and takes a block
                   fopen                  Open multiple streams, takes a block
                   X dbg                  Only thing that can be used in funcs

--- a/doc/ref/toc-ysh.md
+++ b/doc/ref/toc-ysh.md
@@ -127,7 +127,7 @@ Siblings: [OSH Topics](toc-osh.html), [Data Topics](toc-data.html)
                   is-main                false when sourcing a file
                   use                    change first word lookup
   [I/O]           ysh-read               flags --all, -0
-                  ysh-echo               no -e -n with simple_echo
+                  ysh-echo               no -e -n -E with simple_echo <!-- after #1772: echo_flags off (any -e -n -E soup) -->
                   write                  Like echo, with --, --sep, --end
                   fork   forkwait        Replace & and (), and takes a block
                   fopen                  Open multiple streams, takes a block


### PR DESCRIPTION
Have short descriptions in overview that are useful for comparing.

ysh-echo: The  -E flag is also part of the flag permutations dropped when printing, but at the end not listing flags here, instead mentioning their default print operation mode (to contrast write and echo) and saying echo to have no flags, and later no echo_flags bugs.

For osh-echo the -E flag might rather be a not too significant *missing feature*, so also not worth mentioning in the docs.
