### PR TITLE
Add OILS-ERR-200 - Unexpected typed args passed to an external command

### DIFF
--- a/core/executor.py
+++ b/core/executor.py
@@ -311,8 +311,9 @@ class ShellExecutor(vm._Executor):
         environ = self.mem.GetExported()  # Include temporary variables
 
         if cmd_val.typed_args:
-            e_die('%r appears to be external. External commands don\'t accept typed args (OILS-ERR-200)' % arg0,
-                  cmd_val.typed_args.left)
+            e_die(
+                '%r appears to be external. External commands don\'t accept typed args (OILS-ERR-200)'
+                % arg0, cmd_val.typed_args.left)
 
         # Resolve argv[0] BEFORE forking.
         if run_flags & USE_DEFAULT_PATH:

--- a/core/executor.py
+++ b/core/executor.py
@@ -311,7 +311,7 @@ class ShellExecutor(vm._Executor):
         environ = self.mem.GetExported()  # Include temporary variables
 
         if cmd_val.typed_args:
-            e_die('Unexpected typed args passed to external command %r' % arg0,
+            e_die('Unexpected typed args passed to external command %r (OILS-ERR-200)' % arg0,
                   cmd_val.typed_args.left)
 
         # Resolve argv[0] BEFORE forking.

--- a/core/executor.py
+++ b/core/executor.py
@@ -311,7 +311,7 @@ class ShellExecutor(vm._Executor):
         environ = self.mem.GetExported()  # Include temporary variables
 
         if cmd_val.typed_args:
-            e_die('Unexpected typed args passed to external command %r (OILS-ERR-200)' % arg0,
+            e_die('%r appears to be external. External commands don\'t accept typed args (OILS-ERR-200)' % arg0,
                   cmd_val.typed_args.left)
 
         # Resolve argv[0] BEFORE forking.

--- a/doc/error-catalog.md
+++ b/doc/error-catalog.md
@@ -169,7 +169,21 @@ They're numbered starting from `200`.
 
 ### OILS-ERR-200
 
-Example TODO
+<!--
+Generated with:
+test/runtime-errors.sh test-external_cmd_typed_args
+-->
+
+```
+  cat ("myfile")
+      ^
+[ -c flag ]:1: fatal: Unexpected typed args passed to external command 'cat' (OILS-ERR-200)
+```
+
+- External programs cannot accept [typed
+  arguments](ref/chap-cmd-lang.html#typed-arg). Try passing untyped arguments
+  instead. (eg. `cat myfile`)
+- Did misspell a [YSH proc](ref/chap-cmd-lang.html#proc-def)?
 
 ## Appendix
 

--- a/doc/error-catalog.md
+++ b/doc/error-catalog.md
@@ -177,13 +177,15 @@ test/runtime-errors.sh test-external_cmd_typed_args
 ```
   cat ("myfile")
       ^
-[ -c flag ]:1: fatal: Unexpected typed args passed to external command 'cat' (OILS-ERR-200)
+[ -c flag ]:1: fatal: 'cat' appears to be external. External commands don't accept typed args (OILS-ERR-200)
 ```
 
-- External programs cannot accept [typed
-  arguments](ref/chap-cmd-lang.html#typed-arg). Try passing untyped arguments
-  instead. (eg. `cat myfile`)
-- Did misspell a [YSH proc](ref/chap-cmd-lang.html#proc-def)?
+- Builtin commands and user-defined procs may accept [typed
+  args](ref/chap-cmd-lang.html#typed-arg), but external commands never do.
+- Did you misspell a [YSH proc](ref/chap-cmd-lang.html#proc-def)? If a name is
+  not found, YSH assumes it's an external command.
+- Did you forget to source a file that contains the proc or shell function you
+  wanted to run?
 
 ## Appendix
 

--- a/test/runtime-errors.sh
+++ b/test/runtime-errors.sh
@@ -1059,6 +1059,10 @@ test-fallback_locations() {
   echo done
 }
 
+test-external_cmd_typed_args() {
+  _ysh-error-X 1 'cat ("myfile")'
+}
+
 #
 # TEST DRIVER
 #


### PR DESCRIPTION
I came across this while working on `args.ysh` and got this confusing error message when I forgot to `source --builtin args.ysh`:

```
  arg-parse (&spec) {
            ^
[ stdin ]:1: fatal: Unexpected typed args passed to external command 'arg-parse'
```