### PR TITLE
Misc. Argparse Updates

### DIFF
--- a/doc/ref/chap-builtin-cmd.md
+++ b/doc/ref/chap-builtin-cmd.md
@@ -1187,7 +1187,7 @@ Flags:
 Bash has this, but OSH won't implement it.
 
 
-## Args
+## Args Parser
 
 YSH includes a command-line argument parsing utility called `parseArgs`. This
 is intended to be used for command-line interfaces to YSH programs.
@@ -1300,7 +1300,6 @@ Default values for an argument can be set with the `default` named argument.
     # => args.count = 2
     # => args.optimize = true
 
-
 Each name passed to `flag` must be unique to that specific `parser`. Calling
 `flag` with the same name twice will raise an error inside of `parser`.
 
@@ -1351,7 +1350,7 @@ strings (usually `ARGV`.)
 
 The returned `args` is a dictionary mapping the names of each `arg`, `flag` and
 `rest` to their captured values. (See the example at the [start of this
-topic](#Args).)
+topic](#Args-Parser).)
 
 `parseArgs` will raise an error if the `ARGV` is invalid per the parser
 specification. For example, if it's missing a required positional argument:

--- a/doc/ref/chap-builtin-cmd.md
+++ b/doc/ref/chap-builtin-cmd.md
@@ -1214,7 +1214,6 @@ Then, create an argument "spec":
 
       arg src (help='Source')
       arg dest (help='Dest')
-      arg times (help='Foo')
 
       rest files
     }
@@ -1224,17 +1223,16 @@ Finally, parse `ARGV` (or any other array of strings) with:
     var opt, i = parseArgs(spec, ARGV)
 
 The returned `opt` is a `Dict` containing key-value pairs with the parsed
-values (or defaults) for each flag and argument. For example, given `ARGV = :|
--v -P 12 |`, `opt` would be:
+values (or defaults) for each flag and argument. For example, given
+`ARGV = :| mysrc -P 12 mydest a b c |`, `opt` would be:
 
     {
-        "verbose": true,
+        "verbose": false,
         "max-procs": 12,
         "invert": true,
-        "src": null,
-        "dest": null,
-        "times": null,
-        "files": [],
+        "src": "mysrc",
+        "dest": "mydest",
+        "files": ["a", "b", "c"]
     }
 
 `i` is the last parsed index into `ARGV` which is useful if you wanted to do
@@ -1242,6 +1240,6 @@ further parsing of `ARGV` after `parseArgs`.
 
 Inside of `arg-parse`, there are three ways you can add to the spec:
 
-- `flag (short, long ; type='bool' ; default=null, help=null)` -- For "flags" like `--verbose` or `-N`
-- `arg (name ; ; default=null, help=null)` -- For positional arguments
+- `flag (short, long ; type='bool' ; default=null, help=null, required=false)` -- For "flags" like `--verbose` or `-N`
+- `arg (name ; ; default=null, help=null, required=true)` -- For positional arguments
 - `rest (name)` -- Take the remaining positional arguments and store them in `opts[name]`

--- a/doc/ref/chap-builtin-cmd.md
+++ b/doc/ref/chap-builtin-cmd.md
@@ -1277,7 +1277,7 @@ The above example declares a flag "--verbose" and a short alias "-v".
 - `true` if the flag was passed at least once
 - `false` otherwise
 
-Flags can also accept values, for example, if you wanted to accept an integer count:
+Flags can also accept values. For example, if you wanted to accept an integer count:
 
     parser (&spec) {
       flag -N --count ('int')
@@ -1337,6 +1337,9 @@ Capture zero or more positional arguments not already captured by `arg`. So,
 for `ARGV = :| hello file.txt message.txt README.md |`, we would have
 `args.query = "file.txt"` and `args.files = ["file.txt", "message.txt",
 "README.md"]`.
+
+Without rest, passing extraneous arguments will raise an error in
+`parseArgs()`.
 
 `rest` can only be called _once_ within a `parser`. Calling it multiple times
 will raise an error in `parser`.

--- a/doc/ref/chap-builtin-cmd.md
+++ b/doc/ref/chap-builtin-cmd.md
@@ -1186,3 +1186,62 @@ Flags:
 
 Bash has this, but OSH won't implement it.
 
+
+## Flags
+
+### parseArgs()
+
+YSH includes a `argparse`-like utility called `parseArgs`. This is intended to
+be used for command-line interfaces to programs.
+
+To use it, first import `args.ysh`:
+
+    source --builtin args.ysh
+
+Then, create an argument "spec":
+
+    arg-parse (&spec) {
+      flag -v --verbose (help="Verbosely")  # default is Bool, false
+
+      flag -P --max-procs ('int', default=-1, doc='''
+        Run at most P processes at a time
+        ''')
+
+      flag -i --invert ('bool', default=true, doc='''
+        Long multiline
+        Description
+        ''')
+
+      arg src (help='Source')
+      arg dest (help='Dest')
+      arg times (help='Foo')
+
+      rest files
+    }
+
+Finally, parse `ARGV` (or any other array of strings) with:
+
+    var opt, i = parseArgs(spec, ARGV)
+
+The returned `opt` is a `Dict` containing key-value pairs with the parsed
+values (or defaults) for each flag and argument. For example, given `ARGV = :|
+-v -P 12 |`, `opt` would be:
+
+    {
+        "verbose": true,
+        "max-procs": 12,
+        "invert": true,
+        "src": null,
+        "dest": null,
+        "times": null,
+        "files": [],
+    }
+
+`i` is the last parsed index into `ARGV` which is useful if you wanted to do
+further parsing of `ARGV` after `parseArgs`.
+
+Inside of `arg-parse`, there are three ways you can add to the spec:
+
+- `flag (short, long ; type='bool' ; default=null, help=null)` -- For "flags" like `--verbose` or `-N`
+- `arg (name ; ; default=null, help=null)` -- For positional arguments
+- `rest (name)` -- Take the remaining positional arguments and store them in `opts[name]`

--- a/doc/ref/chap-builtin-cmd.md
+++ b/doc/ref/chap-builtin-cmd.md
@@ -1203,11 +1203,11 @@ Then, create an argument "spec":
     arg-parse (&spec) {
       flag -v --verbose (help="Verbosely")  # default is Bool, false
 
-      flag -P --max-procs ('int', default=-1, doc='''
+      flag -P --max-procs ('int', default=-1, help='''
         Run at most P processes at a time
         ''')
 
-      flag -i --invert ('bool', default=true, doc='''
+      flag -i --invert ('bool', default=true, help='''
         Long multiline
         Description
         ''')

--- a/doc/ref/chap-builtin-cmd.md
+++ b/doc/ref/chap-builtin-cmd.md
@@ -1191,16 +1191,16 @@ Bash has this, but OSH won't implement it.
 
 ### parseArgs()
 
-YSH includes a `argparse`-like utility called `parseArgs`. This is intended to
-be used for command-line interfaces to programs.
+YSH includes a command-line argument parsing utility called `parseArgs`. This
+is intended to be used for command-line interfaces to YSH programs.
 
 To use it, first import `args.ysh`:
 
     source --builtin args.ysh
 
-Then, create an argument "spec":
+Then, create an argument parser:
 
-    arg-parse (&spec) {
+    arg-parse (&parser) {
       flag -v --verbose (help="Verbosely")  # default is Bool, false
 
       flag -P --max-procs ('int', default=-1, help='''
@@ -1220,9 +1220,9 @@ Then, create an argument "spec":
 
 Finally, parse `ARGV` (or any other array of strings) with:
 
-    var opt, i = parseArgs(spec, ARGV)
+    var args, last_idx = parseArgs(parser, ARGV)
 
-The returned `opt` is a `Dict` containing key-value pairs with the parsed
+The returned `args` is a `Dict` containing key-value pairs with the parsed
 values (or defaults) for each flag and argument. For example, given
 `ARGV = :| mysrc -P 12 mydest a b c |`, `opt` would be:
 
@@ -1235,11 +1235,11 @@ values (or defaults) for each flag and argument. For example, given
         "files": ["a", "b", "c"]
     }
 
-`i` is the last parsed index into `ARGV` which is useful if you wanted to do
-further parsing of `ARGV` after `parseArgs`.
+`last_idx` is the last parsed index into `ARGV` which is useful if you wanted
+to do further parsing of `ARGV` after `parseArgs`.
 
-Inside of `arg-parse`, there are three ways you can add to the spec:
+Inside of `arg-parse`, there are three ways you can add to the parser:
 
-- `flag (short, long ; type='bool' ; default=null, help=null, required=false)` -- For "flags" like `--verbose` or `-N`
-- `arg (name ; ; default=null, help=null, required=true)` -- For positional arguments
+- `flag (short, long ; type='bool' ; default=null, help=null)` -- For "flags" like `--verbose` or `-N`
+- `arg (name ; ; help=null)` -- For positional arguments
 - `rest (name)` -- Take the remaining positional arguments and store them in `opts[name]`

--- a/doc/ref/chap-builtin-cmd.md
+++ b/doc/ref/chap-builtin-cmd.md
@@ -1187,9 +1187,7 @@ Flags:
 Bash has this, but OSH won't implement it.
 
 
-## Flags
-
-### parseArgs()
+## Args
 
 YSH includes a command-line argument parsing utility called `parseArgs`. This
 is intended to be used for command-line interfaces to YSH programs.
@@ -1198,9 +1196,9 @@ To use it, first import `args.ysh`:
 
     source --builtin args.ysh
 
-Then, create an argument parser:
+Then, create an argument parser **spec**ification:
 
-    arg-parse (&parser) {
+    parser (&spec) {
       flag -v --verbose (help="Verbosely")  # default is Bool, false
 
       flag -P --max-procs ('int', default=-1, help='''
@@ -1220,11 +1218,11 @@ Then, create an argument parser:
 
 Finally, parse `ARGV` (or any other array of strings) with:
 
-    var args, last_idx = parseArgs(parser, ARGV)
+    var args = parseArgs(spec, ARGV)
 
 The returned `args` is a `Dict` containing key-value pairs with the parsed
 values (or defaults) for each flag and argument. For example, given
-`ARGV = :| mysrc -P 12 mydest a b c |`, `opt` would be:
+`ARGV = :| mysrc -P 12 mydest a b c |`, `args` would be:
 
     {
         "verbose": false,
@@ -1235,11 +1233,139 @@ values (or defaults) for each flag and argument. For example, given
         "files": ["a", "b", "c"]
     }
 
-`last_idx` is the last parsed index into `ARGV` which is useful if you wanted
-to do further parsing of `ARGV` after `parseArgs`.
+### parser
 
-Inside of `arg-parse`, there are three ways you can add to the parser:
+`parseArgs()` requires a parser specification to indicate how to parse the
+`ARGV` array. This specification should be constructed using the `parser` proc.
 
-- `flag (short, long ; type='bool' ; default=null, help=null)` -- For "flags" like `--verbose` or `-N`
-- `arg (name ; ; help=null)` -- For positional arguments
-- `rest (name)` -- Take the remaining positional arguments and store them in `opts[name]`
+    parser (&spec) {
+      flag -f --my-flag
+      arg myarg
+      rest otherArgs
+    }
+
+In the above example, `parser` takes in a place `&spec`, which will store the
+resulting specification and a block which is evaluated to build that
+specification.
+
+Inside of a `parser` block, you should call the following procs:
+
+- `flag` to add `--flag` options
+- `arg` to add positional arguments
+- `rest` to capture remaining positional arguments into a list
+
+`parser` will validate the parser specification for errors such as duplicate
+flag or argument names.
+
+    parser (&spec) {
+      flag -n --name
+      flag -n --name  # Duplicate!
+    }
+
+    # => raises "Duplicate flag/arg name 'name' in spec" (status = 3)
+
+### flag
+
+`flag` should be called within a `parser` block.
+
+    parser (&spec) {
+      flag -v --verbose
+    }
+
+The above example declares a flag "--verbose" and a short alias "-v".
+`parseArgs()` will then store a boolean value under `args.verbose`:
+- `true` if the flag was passed at least once
+- `false` otherwise
+
+Flags can also accept values, for example, if you wanted to accept an integer count:
+
+    parser (&spec) {
+      flag -N --count ('int')
+    }
+
+Calling `parseArgs` with `ARGV = :| -n 5 |` or `ARGV = :| --count 5 |` will
+store the integer `5` under `args.count`. If the user passes in a non-integer
+value like `ARGV = :| --count abc |`, `parseArgs` will raise an error.
+
+Default values for an argument can be set with the `default` named argument.
+
+    parser (&spec) {
+      flag -N --count ('int', default=2)
+
+      # Boolean flags can be given default values too
+      flag -O --optimize ('bool', default=true)
+    }
+
+    var args = parseArgs(spec, :| -n 3 |)
+    # => args.count = 2
+    # => args.optimize = true
+
+
+Each name passed to `flag` must be unique to that specific `parser`. Calling
+`flag` with the same name twice will raise an error inside of `parser`.
+
+<!-- TODO: how can we explicitly pass false to a boolean flag? -->
+<!-- TODO: how about --no-XXXX variants of flags? -->
+
+### arg
+
+`arg` should be called within a `parser` block.
+
+    parser (&spec) {
+      arg query
+      arg path
+    }
+
+The above example declares two positional arguments called "query" and "path".
+`parseArgs()` will then store strings under `args.query` and `args.path`. Order
+matters, so the first positional argument will be stored to `query` and the
+second to `path`. If not enough positional arguments are passed, then
+`parseArgs` will raise an error.
+
+Similar to `flag`, each `arg` name must be unique. Calling `arg` with the same
+name twice will cause `parser` to raise an error.
+
+### rest
+
+`rest` should be called within a `parser` block.
+
+    parser (&spec) {
+      arg query
+      rest files
+    }
+
+Capture zero or more positional arguments not already captured by `arg`. So,
+for `ARGV = :| hello file.txt message.txt README.md |`, we would have
+`args.query = "file.txt"` and `args.files = ["file.txt", "message.txt",
+"README.md"]`.
+
+`rest` can only be called _once_ within a `parser`. Calling it multiple times
+will raise an error in `parser`.
+
+### parseArgs()
+
+Given a parser specification `spec` produced by `parser`, parse a list of
+strings (usually `ARGV`.)
+
+    var args = parseArgs(spec, ARGV)
+
+The returned `args` is a dictionary mapping the names of each `arg`, `flag` and
+`rest` to their captured values. (See the example at the [start of this
+topic](#Args).)
+
+`parseArgs` will raise an error if the `ARGV` is invalid per the parser
+specification. For example, if it's missing a required positional argument:
+
+    parser (&spec) {
+      arg path
+    }
+
+    var args = parseArgs(spec, [])
+    # => raises an error about the missing 'path' (status = 2)
+
+<!--
+TODO: Document chaining parsers / sub-commands
+      - Either will allow parser nesting
+      - Or can use `rest rest` and `parseArgs` again on `rest`
+TODO: Document the help named argument. Punting while we do not generate help messages
+-->

--- a/doc/ref/toc-ysh.md
+++ b/doc/ref/toc-ysh.md
@@ -143,7 +143,7 @@ X [TSV8]          rows                   pick rows; dplyr filter()
                   group-by               add a column with a group ID [ext]
                   sort-by                sort by columns; dplyr arrange() [ext]
                   summary                count, sum, histogram, etc. [ext]
-  [Args]          parser                 Argument parsing
+  [Args Parser]   parser                 Parse command line arguments
                   flag
                   arg
                   rest

--- a/doc/ref/toc-ysh.md
+++ b/doc/ref/toc-ysh.md
@@ -143,8 +143,11 @@ X [TSV8]          rows                   pick rows; dplyr filter()
                   group-by               add a column with a group ID [ext]
                   sort-by                sort by columns; dplyr arrange() [ext]
                   summary                count, sum, histogram, etc. [ext]
-  [Flags]         X Flags                getopts replacement: flag arg
-                  parseArgs()            
+  [Args]          X parser               argument parsing
+                  X flag
+                  X arg
+                  X rest
+                  X parseArgs()
 X [Testing]       describe               Test harness
                   assert                 takes an expression
 X [External Lang] BEGIN   END   when (awk)

--- a/doc/ref/toc-ysh.md
+++ b/doc/ref/toc-ysh.md
@@ -143,11 +143,11 @@ X [TSV8]          rows                   pick rows; dplyr filter()
                   group-by               add a column with a group ID [ext]
                   sort-by                sort by columns; dplyr arrange() [ext]
                   summary                count, sum, histogram, etc. [ext]
-  [Args]          X parser               argument parsing
-                  X flag
-                  X arg
-                  X rest
-                  X parseArgs()
+  [Args]          parser                 Argument parsing
+                  flag
+                  arg
+                  rest
+                  parseArgs()
 X [Testing]       describe               Test harness
                   assert                 takes an expression
 X [External Lang] BEGIN   END   when (awk)

--- a/doc/ref/toc-ysh.md
+++ b/doc/ref/toc-ysh.md
@@ -143,7 +143,7 @@ X [TSV8]          rows                   pick rows; dplyr filter()
                   group-by               add a column with a group ID [ext]
                   sort-by                sort by columns; dplyr arrange() [ext]
                   summary                count, sum, histogram, etc. [ext]
-X [Flags]         Flags                  getopts replacement: flag arg
+  [Flags]         X Flags                getopts replacement: flag arg
                   parseArgs()            
 X [Testing]       describe               Test harness
                   assert                 takes an expression

--- a/spec/ysh-stdlib-args.test.sh
+++ b/spec/ysh-stdlib-args.test.sh
@@ -265,12 +265,34 @@ pp line (args)
 #### Duplicate argument/flag names
 source --builtin args.ysh
 
-parser (&spec) {
-  flag -n --name
-  arg name
+try {
+  parser (&spec) {
+    flag -n --name
+    flag -N --name
+  }
 }
-## status: 3
+echo status=$_status
+
+try {
+  parser (&spec) {
+    flag -n --name
+    arg name
+  }
+}
+echo status=$_status
+
+try {
+  parser (&spec) {
+    arg name
+    flag -o --other
+    arg name
+  }
+}
+echo status=$_status
 ## STDOUT:
+status=3
+status=3
+status=3
 ## END
 
 #### Error cases

--- a/spec/ysh-stdlib-args.test.sh
+++ b/spec/ysh-stdlib-args.test.sh
@@ -7,11 +7,11 @@ source --builtin args.ysh
 arg-parse (&spec) {
   flag -v --verbose (help="Verbosely")  # default is Bool, false
 
-  flag -P --max-procs ('int', default=-1, doc='''
+  flag -P --max-procs ('int', default=-1, help='''
     Run at most P processes at a time
     ''')
 
-  flag -i --invert ('bool', default=true, doc='''
+  flag -i --invert ('bool', default=true, help='''
     Long multiline
     Description
     ''')

--- a/spec/ysh-stdlib-args.test.sh
+++ b/spec/ysh-stdlib-args.test.sh
@@ -4,7 +4,7 @@
 #### args.ysh example usage
 source --builtin args.ysh
 
-arg-parse (&spec) {
+parser (&spec) {
   flag -v --verbose (help="Verbosely")  # default is Bool, false
 
   flag -P --max-procs ('int', default=-1, help='''
@@ -22,10 +22,10 @@ arg-parse (&spec) {
   rest files
 }
 
-var opt, i = parseArgs(spec, :| mysrc -P 12 mydest a b c |)
+var args = parseArgs(spec, :| mysrc -P 12 mydest a b c |)
 
-echo "Verbose $[opt.verbose]"
-pp line (opt)
+echo "Verbose $[args.verbose]"
+pp line (args)
 ## STDOUT:
 Verbose false
 (Dict)   {"src":"mysrc","max-procs":12,"dest":"mydest","files":["a","b","c"],"verbose":false,"invert":true}
@@ -35,7 +35,7 @@ Verbose false
 
 source --builtin args.ysh
 
-arg-parse (&spec) {
+parser (&spec) {
   flag -v --verbose ('bool')
   arg src
   arg dst
@@ -46,30 +46,28 @@ arg-parse (&spec) {
 
 var argv = ['-v', 'src/path', 'dst/path', 'x', 'y', 'z']
 
-var arg, i = parseArgs(spec, argv)
+var args = parseArgs(spec, argv)
 
-pp line (arg)
-pp line (i)
+pp line (args)
 
-if (arg.verbose) {
-  echo "$[arg.src] -> $[arg.dst]"
-  write -- @[arg.more]
+if (args.verbose) {
+  echo "$[args.src] -> $[args.dst]"
+  write -- @[args.more]
 }
 
 ## STDOUT:
 (Dict)   {"verbose":true,"src":"src/path","dst":"dst/path","more":["x","y","z"]}
-(Int)   6
 src/path -> dst/path
 x
 y
 z
 ## END
 
-#### Test multiple command lines against a parser
+#### Test multiple ARGVs against a parser
 
 source --builtin args.ysh
 
-arg-parse (&spec) {
+parser (&spec) {
   flag -v --verbose ('bool', default=false)
   flag -c --count ('int', default=120)
   arg file
@@ -92,15 +90,15 @@ for args in (argsCases) {
 ## STDOUT:
 ----------  -v --count 120 example.sh  ----------
 $ bin/ysh example.sh -v --count 120 example.sh
-(List)   [{"verbose":true,"count":120,"file":"example.sh"},4]
+(Dict)   {"verbose":true,"count":120,"file":"example.sh"}
 
 ----------  -v --count 120 example.sh -v  ----------
 $ bin/ysh example.sh -v --count 120 example.sh -v
-(List)   [{"verbose":true,"count":120,"file":"example.sh"},5]
+(Dict)   {"verbose":true,"count":120,"file":"example.sh"}
 
 ----------  -v --count 120 example.sh -v --count 150  ----------
 $ bin/ysh example.sh -v --count 120 example.sh -v --count 150
-(List)   [{"verbose":true,"count":150,"file":"example.sh"},7]
+(Dict)   {"verbose":true,"count":150,"file":"example.sh"}
 
 ## END
 
@@ -108,7 +106,7 @@ $ bin/ysh example.sh -v --count 120 example.sh -v --count 150
 
 source --builtin args.ysh
 
-arg-parse (&spec) {
+parser (&spec) {
   # TODO: implement description, prog and help message
   description '''
      Reference Implementation
@@ -122,7 +120,7 @@ arg-parse (&spec) {
 var argv = ['-h', 'src', 'dst']
 
 # Help
-var arg, _ = parseArgs(spec, argv)
+var args = parseArgs(spec, argv)
 
 ## STDOUT:
 usage: program-name [-h] [-v] src dst
@@ -188,21 +186,21 @@ for args in (argsCases) {
 ## STDOUT:
 ----------  -v --count 120 example.sh  ----------
 $ bin/ysh example.sh -v --count 120 example.sh
-(List)   [{"verbose":true,"count":120,"file":"example.sh"},4]
+(Dict)   {"verbose":true,"count":120,"file":"example.sh"}
 
 $ python3 example.py -v --count 120 example.sh
 Namespace(filename='example.sh', count='120', verbose=True)
 
 ----------  -v --count 120 example.sh -v  ----------
 $ bin/ysh example.sh -v --count 120 example.sh -v
-(List)   [{"verbose":true,"count":120,"file":"example.sh"},5]
+(Dict)   {"verbose":true,"count":120,"file":"example.sh"}
 
 $ python3 example.py -v --count 120 example.sh -v
 Namespace(filename='example.sh', count='120', verbose=True)
 
 ----------  -v --count 120 example.sh -v --count 150  ----------
 $ bin/ysh example.sh -v --count 120 example.sh -v --count 150
-(List)   [{"verbose":true,"count":150,"file":"example.sh"},7]
+(Dict)   {"verbose":true,"count":150,"file":"example.sh"}
 
 $ python3 example.py -v --count 120 example.sh -v --count 150
 Namespace(filename='example.sh', count='150', verbose=True)
@@ -213,7 +211,7 @@ Namespace(filename='example.sh', count='150', verbose=True)
 
 source --builtin args.ysh
 
-arg-parse (&spec) {
+parser (&spec) {
   flag -v --verbose ('bool')
   arg src
   arg dst
@@ -251,15 +249,15 @@ json write (spec)
 #### Default values
 source --builtin args.ysh
 
-arg-parse (&spec) {
+parser (&spec) {
   flag -S --sanitize ('bool', default=false)
   flag -v --verbose ('bool', default=false)
   flag -P --max-procs ('int')  # Will set to null (the default default)
 }
 
-var opt, i = parseArgs(spec, [])
+var args = parseArgs(spec, [])
 
-pp line (opt)
+pp line (args)
 ## STDOUT:
 (Dict)   {"sanitize":false,"verbose":false,"max-procs":null}
 ## END
@@ -267,7 +265,7 @@ pp line (opt)
 #### Duplicate argument/flag names
 source --builtin args.ysh
 
-arg-parse (&spec) {
+parser (&spec) {
   flag -n --name
   arg name
 }
@@ -278,7 +276,7 @@ arg-parse (&spec) {
 #### Error cases
 source --builtin args.ysh
 
-arg-parse (&spec) {
+parser (&spec) {
   flag -v --verbose
   flag -n --num ('int', required=true)
 

--- a/spec/ysh-stdlib-args.test.sh
+++ b/spec/ysh-stdlib-args.test.sh
@@ -40,8 +40,8 @@ z
 source --builtin args.ysh
 
 arg-parse (&spec) {
-  flag -v --verbose ('bool', false)
-  flag -c --count ('int', 120)
+  flag -v --verbose ('bool', default=false)
+  flag -c --count ('int', default=120)
   arg file
 }
 
@@ -220,6 +220,23 @@ json write (spec)
 }
 ## END
 
+#### Default values
+source --builtin args.ysh
+
+arg-parse (&spec) {
+  flag -S --sanitize ('bool', default=false)
+  flag -v --verbose ('bool', default=false)
+  flag -P --max-procs ('int')  # Will set to null (the default default)
+
+  arg action (default="compile")
+}
+
+var opt, i = parseArgs(spec, [])
+
+pp line (opt)
+## STDOUT:
+(Dict)   {"sanitize":false,"verbose":false,"max-procs":null,"action":"compile"}
+## END
 
 #### Duplicate argument/flag names
 source --builtin args.ysh

--- a/spec/ysh-stdlib-args.test.sh
+++ b/spec/ysh-stdlib-args.test.sh
@@ -231,22 +231,17 @@ json write (spec)
       "name": "verbose",
       "type": "bool",
       "default": false,
-      "help": null,
-      "required": false
+      "help": null
     }
   ],
   "args": [
     {
       "name": "src",
-      "default": null,
-      "help": null,
-      "required": true
+      "help": null
     },
     {
       "name": "dst",
-      "default": null,
-      "help": null,
-      "required": true
+      "help": null
     }
   ],
   "rest": "more"
@@ -260,15 +255,13 @@ arg-parse (&spec) {
   flag -S --sanitize ('bool', default=false)
   flag -v --verbose ('bool', default=false)
   flag -P --max-procs ('int')  # Will set to null (the default default)
-
-  arg action (default="compile", required=false)
 }
 
 var opt, i = parseArgs(spec, [])
 
 pp line (opt)
 ## STDOUT:
-(Dict)   {"sanitize":false,"verbose":false,"max-procs":null,"action":"compile"}
+(Dict)   {"sanitize":false,"verbose":false,"max-procs":null}
 ## END
 
 #### Duplicate argument/flag names

--- a/spec/ysh-stdlib-args.test.sh
+++ b/spec/ysh-stdlib-args.test.sh
@@ -114,8 +114,8 @@ source --builtin args.ysh
 
 var spec = {
   flags: [
-    {short: '-v', long: '--verbose', type: null, default: '', help: 'Enable verbose logging'},
-    {short: '-c', long: '--count', type: 'int', default: 80, help: 'Maximum line length'},
+    {short: '-v', long: '--verbose', name: 'verbose', type: null, default: '', help: 'Enable verbose logging'},
+    {short: '-c', long: '--count', name: 'count', type: 'int', default: 80, help: 'Maximum line length'},
   ],
   args: [
     {name: 'file', type: 'str', help: 'File to check line lengths of'}
@@ -198,6 +198,7 @@ json write (spec)
     {
       "short": "-v",
       "long": "--verbose",
+      "name": "verbose",
       "type": "bool",
       "default": null,
       "help": null
@@ -219,3 +220,14 @@ json write (spec)
 }
 ## END
 
+
+#### Duplicate argument/flag names
+source --builtin args.ysh
+
+arg-parse (&spec) {
+  flag -n --name
+  arg name
+}
+## status: 3
+## STDOUT:
+## END

--- a/spec/ysh-stdlib-args.test.sh
+++ b/spec/ysh-stdlib-args.test.sh
@@ -1,6 +1,37 @@
 ## our_shell: ysh
 ## oils_failures_allowed: 1
 
+#### args.ysh example usage
+source --builtin args.ysh
+
+arg-parse (&spec) {
+  flag -v --verbose (help="Verbosely")  # default is Bool, false
+
+  flag -P --max-procs ('int', default=-1, doc='''
+    Run at most P processes at a time
+    ''')
+
+  flag -i --invert ('bool', default=true, doc='''
+    Long multiline
+    Description
+    ''')
+
+  arg src (help='Source')
+  arg dest (help='Dest')
+  arg times (help='Foo')
+
+  rest files
+}
+
+var opt, i = parseArgs(spec, :| -v -P 12 |)
+
+echo "Verbose $[opt.verbose]"
+pp line (opt)
+## STDOUT:
+Verbose true
+(Dict)   {"verbose":true,"max-procs":12,"files":[],"invert":true,"src":null,"dest":null,"times":null}
+## END
+
 #### Bool flag, positional args, more positional
 
 source --builtin args.ysh

--- a/stdlib/args.ysh
+++ b/stdlib/args.ysh
@@ -3,21 +3,23 @@
 # Usage:
 #   source --builtin args.sh
 #
-# Args :spec {
-#   flag -v --verbose "Verbosely"  # default is Bool, false
+# arg-parse (&spec) {
+#   flag -v --verbose (help="Verbosely")  # default is Bool, false
 #
-#   flag -P --max-procs '''
+#   flag -P --max-procs ('int', default=-1, doc='''
 #     Run at most P processes at a time
-#     ''' (Int, default=-1)
+#     ''')
 #
-#   flag -i --invert '''
+#   flag -i --invert ('bool', default=true, doc='''
 #     Long multiline
 #     Description
-#     ''' (Bool, default = true)
+#     ''')
 #
-#   arg src 'Source'
-#   arg src 'Dest'
-#   arg times 'Foo' (Int)
+#   arg src (help='Source')
+#   arg dest (help='Dest')
+#   arg times (help='Foo')
+#
+#   rest files
 # }
 #
 # var opt, i = parseArgs(spec, ARGV)
@@ -27,12 +29,6 @@
 # TODO: See list
 # - It would be nice to keep `flag` and `arg` private, injecting them into the
 #   proc namespace only within `Args`
-# - We need a mechanism to share state between Args and `flag`/`arg` that is
-#   run in the block passed to it
-#   - It would be nice if _this was a magic param?
-#     - it would be nice if 'flag' was a "method" on something?
-#     - that's what it's doing, it's mutating "self"
-#     - _this is the thing we're currently creating
 
 proc arg-parse (; place ; ; block_def) {
   ## Create an args spec which can be passed to parseArgs.
@@ -88,6 +84,7 @@ proc flag (short, long ; type='bool' ; default=null, help=null) {
   # TODO: handle only long flag or only short flag
   # TODO: flag aliases
 
+  # Should use "trimPrefix"
   var name = long[2:]
 
   # TODO: type objects (ie. Bool, Int, Str)

--- a/stdlib/args.ysh
+++ b/stdlib/args.ysh
@@ -46,7 +46,7 @@ proc arg-parse (; place ; ; block_def) {
   ##
   ##   var flag, i = parseArgs(spec, ARGV)
 
-  var p = {}
+  var p = {flags: [], args: []}
   ctx push (p, block_def)
 
   # Validate that p.rest = [name] or null and reduce p.rest into name or null.
@@ -74,7 +74,7 @@ proc arg-parse (; place ; ; block_def) {
   call place->setValue(p)
 }
 
-proc flag (short, long ; type='bool' ; default=null, help=null, required=false) {
+proc flag (short, long ; type='bool' ; default=null, help=null) {
   ## Declare a flag within an `arg-parse`.
   ##
   ## Examples:
@@ -93,10 +93,10 @@ proc flag (short, long ; type='bool' ; default=null, help=null, required=false) 
   # TODO: Should use "trimPrefix"
   var name = long[2:]
 
-  ctx emit flags ({short, long, name, type, default, help, required})
+  ctx emit flags ({short, long, name, type, default, help})
 }
 
-proc arg (name ; ; default=null, help=null, required=true) {
+proc arg (name ; ; help=null) {
   ## Declare a positional argument within an `arg-parse`.
   ##
   ## Examples:
@@ -104,10 +104,9 @@ proc arg (name ; ; default=null, help=null, required=true) {
   ##   arg-parse (&spec) {
   ##     arg name
   ##     arg config (help="config file path")
-  ##     arg out (default="a.out", help="output file path")
   ##   }
 
-  ctx emit args ({name, default, help, required})
+  ctx emit args ({name, help})
 }
 
 proc rest (name) {
@@ -190,24 +189,17 @@ func parseArgs(spec, argv) {
     setvar args[spec.rest] = rest
   }
 
-  # Set defaults for flags and args
+  # Set defaults for flags
   for flag in (spec.flags) {
     if (flag.name not in args) {
-      if (flag.required) {
-        error "Usage Error: Missing required flag $[flag.name]" (status=2)
-      }
-
       setvar args[flag.name] = flag.default
     }
   }
 
+  # Raise error on missing args
   for arg in (spec.args) {
     if (arg.name not in args) {
-      if (arg.required) {
-        error "Usage Error: Missing required argument $[arg.name]" (status=2)
-      }
-
-      setvar args[arg.name] = arg.default
+      error "Usage Error: Missing required argument $[arg.name]" (status=2)
     }
   }
 

--- a/stdlib/args.ysh
+++ b/stdlib/args.ysh
@@ -102,6 +102,8 @@ proc arg (name ; ; default=null, help=null) {
   ##     arg out (default="a.out", help="output file path")
   ##   }
 
+  # TODO: need to add required arguments
+
   ctx emit args ({name, default, help})
 }
 

--- a/stdlib/args.ysh
+++ b/stdlib/args.ysh
@@ -29,6 +29,10 @@
 # TODO: See list
 # - It would be nice to keep `flag` and `arg` private, injecting them into the
 #   proc namespace only within `Args`
+# - We need "type object" to replace the strings 'int', 'bool', etc.
+# - flag builtin:
+#   - handle only long flag or only short flag
+#   - flag aliases
 
 proc arg-parse (; place ; ; block_def) {
   ## Create an args spec which can be passed to parseArgs.
@@ -70,7 +74,7 @@ proc arg-parse (; place ; ; block_def) {
   call place->setValue(p)
 }
 
-proc flag (short, long ; type='bool' ; default=null, help=null) {
+proc flag (short, long ; type='bool' ; default=null, help=null, required=false) {
   ## Declare a flag within an `arg-parse`.
   ##
   ## Examples:
@@ -81,17 +85,18 @@ proc flag (short, long ; type='bool' ; default=null, help=null) {
   ##     flag -f --file ('str', help="File to process")
   ##   }
 
-  # TODO: handle only long flag or only short flag
-  # TODO: flag aliases
+  # bool has a default of false, not null
+  if (type === 'bool' and default === null) {
+    setvar default = false
+  }
 
-  # Should use "trimPrefix"
+  # TODO: Should use "trimPrefix"
   var name = long[2:]
 
-  # TODO: type objects (ie. Bool, Int, Str)
-  ctx emit flags ({short, long, name, type, default, help})
+  ctx emit flags ({short, long, name, type, default, help, required})
 }
 
-proc arg (name ; ; default=null, help=null) {
+proc arg (name ; ; default=null, help=null, required=true) {
   ## Declare a positional argument within an `arg-parse`.
   ##
   ## Examples:
@@ -102,9 +107,7 @@ proc arg (name ; ; default=null, help=null) {
   ##     arg out (default="a.out", help="output file path")
   ##   }
 
-  # TODO: need to add required arguments
-
-  ctx emit args ({name, default, help})
+  ctx emit args ({name, default, help, required})
 }
 
 proc rest (name) {
@@ -134,9 +137,12 @@ func parseArgs(spec, argv) {
   var rest = []
 
   var value
+  var found
   while (i < argc) {
     var arg = argv[i]
     if (arg->startsWith('-')) {
+      setvar found = false
+
       for flag in (spec.flags) {
         if ( (flag.short and flag.short === arg) or
              (flag.long and flag.long === arg) ) {
@@ -144,16 +150,29 @@ func parseArgs(spec, argv) {
             ('bool') | (null) { setvar value = true }
             int {
               setvar i += 1
-              setvar value = int(argv[i])
+              if (i >= len(argv)) {
+                error "Expected integer after '$arg'" (status=2)
+              }
+
+              try { setvar value = int(argv[i]) }
+              if (_status !== 0) {
+                error "Expected integer after '$arg', got '$[argv[i]]'" (status=2)
+              }
             }
           }
 
           setvar args[flag.name] = value
+          setvar found = true
+          break
         }
+      }
+
+      if (not found) {
+        error "Unknown flag '$arg'" (status=2)
       }
     } elif (positionalPos >= len(spec.args)) {
       if (not spec.rest) {
-        error ("Too many arguments, unexpected '$arg'")
+        error "Too many arguments, unexpected '$arg'" (status=2)
       }
 
       call rest->append(arg)
@@ -174,12 +193,20 @@ func parseArgs(spec, argv) {
   # Set defaults for flags and args
   for flag in (spec.flags) {
     if (flag.name not in args) {
+      if (flag.required) {
+        error "Usage Error: Missing required flag $[flag.name]" (status=2)
+      }
+
       setvar args[flag.name] = flag.default
     }
   }
 
   for arg in (spec.args) {
     if (arg.name not in args) {
+      if (arg.required) {
+        error "Usage Error: Missing required argument $[arg.name]" (status=2)
+      }
+
       setvar args[arg.name] = arg.default
     }
   }

--- a/stdlib/args.ysh
+++ b/stdlib/args.ysh
@@ -74,7 +74,7 @@ proc arg-parse (; place ; ; block_def) {
   call place->setValue(p)
 }
 
-proc flag (short, long ; type='bool', default=null, help=null) {
+proc flag (short, long ; type='bool' ; default=null, help=null) {
   ## Declare a flag within an `arg-parse`.
   ##
   ## Examples:
@@ -170,6 +170,19 @@ func parseArgs(spec, argv) {
 
   if (spec.rest) {
     setvar args[spec.rest] = rest
+  }
+
+  # Set defaults for flags and args
+  for flag in (spec.flags) {
+    if (flag.name not in args) {
+      setvar args[flag.name] = flag.default
+    }
+  }
+
+  for arg in (spec.args) {
+    if (arg.name not in args) {
+      setvar args[arg.name] = arg.default
+    }
   }
 
   return ([args, i])

--- a/stdlib/args.ysh
+++ b/stdlib/args.ysh
@@ -3,7 +3,7 @@
 # Usage:
 #   source --builtin args.sh
 #
-# arg-parse (&spec) {
+# parser (&spec) {
 #   flag -v --verbose (help="Verbosely")  # default is Bool, false
 #
 #   flag -P --max-procs ('int', default=-1, doc='''
@@ -22,9 +22,9 @@
 #   rest files
 # }
 #
-# var opt, i = parseArgs(spec, ARGV)
+# var args = parseArgs(spec, ARGV)
 #
-# echo "Verbose $[opt.verbose]"
+# echo "Verbose $[args.verbose]"
 
 # TODO: See list
 # - It would be nice to keep `flag` and `arg` private, injecting them into the
@@ -34,17 +34,17 @@
 #   - handle only long flag or only short flag
 #   - flag aliases
 
-proc arg-parse (; place ; ; block_def) {
+proc parser (; place ; ; block_def) {
   ## Create an args spec which can be passed to parseArgs.
   ##
   ## Example:
   ##
   ##   # NOTE: &spec will create a variable named spec
-  ##   arg-parse (&spec) {
+  ##   parser (&spec) {
   ##     flag -v --verbose ('bool')
   ##   }
   ##
-  ##   var flag, i = parseArgs(spec, ARGV)
+  ##   var args = parseArgs(spec, ARGV)
 
   var p = {flags: [], args: []}
   ctx push (p, block_def)
@@ -71,6 +71,8 @@ proc arg-parse (; place ; ; block_def) {
     }
   }
 
+  # TODO: what about `flag --name` and then `arg name`?
+
   call place->setValue(p)
 }
 
@@ -89,6 +91,8 @@ proc flag (short, long ; type='bool' ; default=null, help=null) {
   if (type === 'bool' and default === null) {
     setvar default = false
   }
+
+  # TODO: validate `type`
 
   # TODO: Should use "trimPrefix"
   var name = long[2:]
@@ -124,10 +128,10 @@ proc rest (name) {
 }
 
 func parseArgs(spec, argv) {
-  ## Given a spec created by `arg-parse`. Parse an array of strings `argv` per
+  ## Given a spec created by `parser`. Parse an array of strings `argv` per
   ## that spec.
   ##
-  ## See `arg-parse` for examples of use.
+  ## See `parser` for examples of use.
 
   var i = 0
   var positionalPos = 0
@@ -203,5 +207,5 @@ func parseArgs(spec, argv) {
     }
   }
 
-  return ([args, i])
+  return (args)
 }

--- a/stdlib/args.ysh
+++ b/stdlib/args.ysh
@@ -60,6 +60,17 @@ proc arg-parse (; place ; ; block_def) {
     setvar p.rest = null
   }
 
+  var names = {}
+  for items in ([p.flags, p.args]) {
+    for x in (items) {
+      if (x.name in names) {
+        error "Duplicate flag/arg name $[x.name] in spec" (status=3)
+      }
+
+      setvar names[x.name] = null
+    }
+  }
+
   call place->setValue(p)
 }
 
@@ -74,8 +85,13 @@ proc flag (short, long ; type='bool', default=null, help=null) {
   ##     flag -f --file ('str', help="File to process")
   ##   }
 
+  # TODO: handle only long flag or only short flag
+  # TODO: flag aliases
+
+  var name = long[2:]
+
   # TODO: type objects (ie. Bool, Int, Str)
-  ctx emit flags ({short, long, type, default, help})
+  ctx emit flags ({short, long, name, type, default, help})
 }
 
 proc arg (name ; ; default=null, help=null) {
@@ -106,16 +122,6 @@ proc rest (name) {
   ctx emit rest (name)
 }
 
-func __args_getFlagName(flag) {
-  if (flag.long) {
-    return (flag.long[2:])
-  } elif (flag.short) {
-    return (flag.short[1:])
-  }
-
-  error ('No flag.long or flag.short')
-}
-
 func parseArgs(spec, argv) {
   ## Given a spec created by `arg-parse`. Parse an array of strings `argv` per
   ## that spec.
@@ -143,8 +149,7 @@ func parseArgs(spec, argv) {
             }
           }
 
-          var name = __args_getFlagName(flag)
-          setvar args[name] = value
+          setvar args[flag.name] = value
         }
       }
     } elif (positionalPos >= len(spec.args)) {


### PR DESCRIPTION
I started adding support for `default` in `parseArgs`, but then got carried away :P

## Changes

- Set `default` values for flags and args in `parseArgs`
- Add `doc/ref` entries for `Args Parser`, `parser`, `flag`, `arg`, `rest` and `parseArgs()`
- Enforce required positional arguments
- Move default and help into named arguments for `flag` and `arg`
- Raise an error on duplicate flag/arg names