### PR TITLE
[docs/error-catalogue] Add OILS-ERR-201, Str with arithmetic operators

### DIFF
--- a/doc/error-catalog.md
+++ b/doc/error-catalog.md
@@ -200,13 +200,13 @@ test/runtime-errors.sh test-arith_ops_str
 [ -c flag ]:1: fatal: Binary operator expected numbers, got Str and Str (OILS-ERR-201)
 ```
 
-- The `+`, `-`, `*` and `/` operators are intended to represent their
-  _arithmetic_ counterparts.
-- The arithmetic operators can be used on strings, provided that they are
-  formatted as numbers. You can explicitly parse a string into a number with the
+- Use `++` if you intended to _concatenate_ strings or lists.
+- The arithmetic operators (`+`, `-`, `*`, `/`) may be used on strings,
+  provided that they are formatted as numbers. For example, `= '10' + '1'` will
+  result in `(Int) 11`.
+- You can explicitly parse a string into a number with the
   [`int()`](ref/chap-builtin-func.html#int) and
   [`float()`](ref/chap-builtin-func.html#float) functions.
-- Use `++` if you intended to _concatentate_ strings or lists.
 
 ## Appendix
 

--- a/doc/error-catalog.md
+++ b/doc/error-catalog.md
@@ -195,18 +195,22 @@ test/runtime-errors.sh test-arith_ops_str
 -->
 
 ```
-  = "100" + "10a"
-          ^
-[ -c flag ]:1: fatal: Binary operator expected numbers, got Str and Str (OILS-ERR-201)
+  = "age: " + 100
+            ^
+[ -c flag ]:1: fatal: Binary operator expected numbers, got Str and Int (OILS-ERR-201)
+
+  = 100 + myvar
+        ^
+[ -c flag ]:2: fatal: Binary operator expected numbers, got Int and Str (OILS-ERR-201)
 ```
 
-- Use `++` if you intended to _concatenate_ strings or lists.
-- The arithmetic operators (`+`, `-`, `*`, `/`) may be used on strings,
-  provided that they are formatted as numbers. For example, `= '10' + '1'` will
-  result in `(Int) 11`.
-- You can explicitly parse a string into a number with the
-  [`int()`](ref/chap-builtin-func.html#int) and
-  [`float()`](ref/chap-builtin-func.html#float) functions.
+- Did you mean to use `++` to concatenate strings/lists?
+- The arithmetic operators (`+`, `-`, `*`, `/`) may be used with strings,
+  provided that they are formatted as numbers. For example, `= 10 + '1'  # =>
+  (Int) 11`. However, if you are operating on user provided input, it may be a
+  better idea to first parse that input with
+  [`int()`](ref/chap-builtin-func.html#int) or
+  [`float()`](ref/chap-builtin-func.html#float).
 
 ## Appendix
 

--- a/doc/error-catalog.md
+++ b/doc/error-catalog.md
@@ -205,10 +205,9 @@ test/runtime-errors.sh test-arith_ops_str
 ```
 
 - Did you mean to use `++` to concatenate strings/lists?
-- The arithmetic operators (`+`, `-`, `*`, `/`) may be used with strings,
-  provided that they are formatted as numbers. For example, `= 10 + '1'  # =>
-  (Int) 11`. However, if you are operating on user provided input, it may be a
-  better idea to first parse that input with
+- The arithmetic operators [can coerce string operands to
+  numbers](ref/chap-expr-lang.html#ysh-arith). However, if you are operating on
+  user provided input, it may be a better idea to first parse that input with
   [`int()`](ref/chap-builtin-func.html#int) or
   [`float()`](ref/chap-builtin-func.html#float).
 

--- a/doc/error-catalog.md
+++ b/doc/error-catalog.md
@@ -195,9 +195,9 @@ test/runtime-errors.sh test-arith_ops_str
 -->
 
 ```
-  = "age: " + 100
+  = "age: " + "100"
             ^
-[ -c flag ]:1: fatal: Binary operator expected numbers, got Str and Int (OILS-ERR-201)
+[ -c flag ]:1: fatal: Binary operator expected numbers, got Str and Str (OILS-ERR-201)
 
   = 100 + myvar
         ^

--- a/doc/error-catalog.md
+++ b/doc/error-catalog.md
@@ -187,6 +187,27 @@ test/runtime-errors.sh test-external_cmd_typed_args
 - Did you forget to source a file that contains the proc or shell function you
   wanted to run?
 
+### OILS-ERR-201
+
+<!--
+Generated with:
+test/runtime-errors.sh test-arith_ops_str
+-->
+
+```
+  = "100" + "10a"
+          ^
+[ -c flag ]:1: fatal: Binary operator expected numbers, got Str and Str (OILS-ERR-201)
+```
+
+- The `+`, `-`, `*` and `/` operators are intended to represent their
+  _arithmetic_ counterparts.
+- The arithmetic operators can be used on strings, provided that they are
+  formatted as numbers. You can explicitly parse a string into a number with the
+  [`int()`](ref/chap-builtin-func.html#int) and
+  [`float()`](ref/chap-builtin-func.html#float) functions.
+- Use `++` if you intended to _concatentate_ strings or lists.
+
 ## Appendix
 
 ### Kinds of Errors from Oils

--- a/doc/ref/chap-expr-lang.md
+++ b/doc/ref/chap-expr-lang.md
@@ -209,8 +209,9 @@ Note that these are distinct from `!  &&  ||`.
 
 ### ysh-arith
 
-YSH supports most of the arithmetic operators from Python. Notably, `%` differs
-from python as it represents remainder in YSH.
+YSH supports most of the arithmetic operators from Python. Notably, `/` and `%`
+differ from Python as [they round toward zero, not negative
+infinity](https://www.oilshell.org/blog/2024/03/release-0.21.0.html#integers-dont-do-whatever-python-or-c-does).
 
 Use `+ - *` for `Int` or `Float` addition, subtraction and multiplication. If
 any of the operands are `Float`s, then the output will also be a `Float`.
@@ -225,7 +226,7 @@ will _always_ result in a `Float`, meanwhile `//` will _always_ result in an
 Use `%` to compute the _remainder_ of integer division. The left operand must
 be an `Int` and the right a _positive_ `Int`.
 
-    = 1 % 2  # -> (Int) 1
+    = 1 % 2   # -> (Int) 1
     = -4 % 2  # -> (Int) 0
 
 Use `**` for exponentiation. The left operand must be an `Int` and the right a
@@ -234,7 +235,14 @@ _positive_ `Int`.
 All arithmetic operators may coerce either of their operands from strings to a
 number, provided those strings are formatted as numbers.
 
-    = 10 + '1' # => (Int) 11
+    = 10 + '1'  # => (Int) 11
+
+Operators like `+ - * /` will coerce strings to _either_ an `Int` or `Float`.
+However, operators like `// ** %` and bit shifts will coerce strings _only_ to
+an `Int`.
+
+    = '1.14' + '2'  # => (Float) 3.14
+    = '1.14' % '2'  # Type Error: Left operand is a Str
 
 ### ysh-bitwise
 

--- a/doc/ref/chap-expr-lang.md
+++ b/doc/ref/chap-expr-lang.md
@@ -209,7 +209,32 @@ Note that these are distinct from `!  &&  ||`.
 
 ### ysh-arith
 
-    +  -  *  /   //   %   **
+YSH supports most of the arithmetic operators from Python. Notably, `%` differs
+from python as it represents remainder in YSH.
+
+Use `+ - *` for `Int` or `Float` addition, subtraction and multiplication. If
+any of the operands are `Float`s, then the output will also be a `Float`.
+
+Use `/` and `//` for `Float` division and `Int` division, respectively. `/`
+will _always_ result in a `Float`, meanwhile `//` will _always_ result in an
+`Int`.
+
+    = 1 / 2   # => (Float) 0.5
+    = 1 // 2  # => (Int) 0
+
+Use `%` to compute the _remainder_ of integer division. The left operand must
+be an `Int` and the right a _positive_ `Int`.
+
+    = 1 % 2  # -> (Int) 1
+    = -4 % 2  # -> (Int) 0
+
+Use `**` for exponentiation. The left operand must be an `Int` and the right a
+_positive_ `Int`.
+
+All arithmetic operators may coerce either of their operands from strings to a
+number, provided those strings are formatted as numbers.
+
+    = 10 + '1' # => (Int) 11
 
 ### ysh-bitwise
 

--- a/test/runtime-errors.sh
+++ b/test/runtime-errors.sh
@@ -1072,7 +1072,7 @@ test-arith_ops_str() {
   _ysh-error-X 3 'var a = "100"; setvar a -= "10a"'
   _ysh-error-X 3 'var a = "100"; setvar a *= "10a"'
   _ysh-error-X 3 'var a = "100"; setvar a /= "10a"'
-  _ysh-error-X 3 '= "age: " + 100'
+  _ysh-error-X 3 '= "age: " + "100"'
   _ysh-error-X 3 'var myvar = "a string"
 = 100 + myvar'
 }

--- a/test/runtime-errors.sh
+++ b/test/runtime-errors.sh
@@ -1072,6 +1072,9 @@ test-arith_ops_str() {
   _ysh-error-X 3 'var a = "100"; setvar a -= "10a"'
   _ysh-error-X 3 'var a = "100"; setvar a *= "10a"'
   _ysh-error-X 3 'var a = "100"; setvar a /= "10a"'
+  _ysh-error-X 3 '= "age: " + 100'
+  _ysh-error-X 3 'var myvar = "a string"
+= 100 + myvar'
 }
 
 #

--- a/test/runtime-errors.sh
+++ b/test/runtime-errors.sh
@@ -1063,6 +1063,17 @@ test-external_cmd_typed_args() {
   _ysh-error-X 1 'cat ("myfile")'
 }
 
+test-arith_ops_str() {
+  _ysh-error-X 3 '= "100" + "10a"'
+  _ysh-error-X 3 '= "100" - "10a"'
+  _ysh-error-X 3 '= "100" * "10a"'
+  _ysh-error-X 3 '= "100" / "10a"'
+  _ysh-error-X 3 'var a = "100"; setvar a += "10a"'
+  _ysh-error-X 3 'var a = "100"; setvar a -= "10a"'
+  _ysh-error-X 3 'var a = "100"; setvar a *= "10a"'
+  _ysh-error-X 3 'var a = "100"; setvar a /= "10a"'
+}
+
 #
 # TEST DRIVER
 #

--- a/ysh/expr_eval.py
+++ b/ysh/expr_eval.py
@@ -474,7 +474,7 @@ class ExprEvaluator(object):
 
         else:
             raise error.TypeErrVerbose(
-                'Binary operator expected numbers, got %s and %s' %
+                'Binary operator expected numbers, got %s and %s (OILS-ERR-201)' %
                 (ui.ValType(left), ui.ValType(right)), op)
 
     def _ArithIntOnly(self, left, right, op):


### PR DESCRIPTION
From zulip: [#language-design > Awk has annoying string <-> int conversion](https://oilshell.zulipchat.com/#narrow/stream/384942-language-design/topic/Awk.20has.20annoying.20string.20.3C-.3E.20int.20conversion).

> ```
> ysh ysh-0.21.0$ = '100' + '10a'
>   = '100' + '10a'
>           ^
> [ interactive ]:6: fatal: Binary operator expected numbers, got Str and Str
> ```
> 
> Maybe worth an entry in the error catalogue? `+` technically works on number formatted strings, we should note that.