### PR TITLE
Implement stdlib/termcodes

### DIFF
--- a/stdlib/draft-termcodes/ansi.ysh
+++ b/stdlib/draft-termcodes/ansi.ysh
@@ -64,13 +64,13 @@ func withFg(text, color) {
     } else {
       setvar sgr4_id += 90 - 8
     }
-    return ("$TERM_ESC[${sgr4_id}m${text}$TERM_ESC[m")
+    return ("${TERM_CSI}${sgr4_id}m${text}${TERM_CSI}m")
   }
 }
 
 func withBg(text, color) {
   if (type(color) === 'Str') {
-    return ("$TERM_ESC[48;${color}m${text}$TERM_ESC[m")
+    return ("${TERM_CSI}48;${color}m${text}${TERM_CSI}m")
   } else { # 4-bit color
     var sgr4_id = color[0]
     if (sgr4_id < 8) {
@@ -78,12 +78,12 @@ func withBg(text, color) {
     } else {
       setvar sgr4_id += 100 - 8
     }
-    return ("$TERM_ESC[;${sgr4_id}m${text}$TERM_ESC[m")
+    return ("${TERM_CSI};${sgr4_id}m${text}${TERM_CSI}m")
   }
 }
 
 func withLink(caption, address) {
-  return ("${TERM_CSI}8;;$address$TERM_ESC\\$caption${TERM_CSI}8;;$TERM_ESC\\")
+  return ("$TERM_ESC]8;;$address$TERM_ESC\\$caption$TERM_ESC]8;;$TERM_ESC\\")
 }
 
 proc bell() {

--- a/stdlib/draft-termcodes/ansi.ysh
+++ b/stdlib/draft-termcodes/ansi.ysh
@@ -12,6 +12,7 @@ const TERM_LF  = u'\u{0A}'
 const TERM_FF  = u'\u{0C}'
 const TERM_CR  = u'\u{0D}'
 const TERM_ESC = u'\u{1B}'
+const TERM_CSI = "$TERM_ESC["
 
 func srgRgb(r, g, b) {
   var channelName = ['Red', 'Green', 'Blue']
@@ -55,7 +56,7 @@ func sgr24(color_hex) {
 
 func withFg(color, text) {
   if (type(color) === 'Str') {
-    return ("$TERM_ESC[38;${color}m${text}$TERM_ESC[m")
+    return ("${TERM_CSI}38;${color}m${text}${TERM_CSI}m")
   } else { # 4-bit color
     var sgr4_id = color[0]
     if (sgr4_id < 8) {
@@ -82,9 +83,51 @@ func withBg(color, text) {
 }
 
 func withLink(address, caption) {
-  return ("$TERM_ESC]8;;$address$TERM_ESC\\$caption$TERM_ESC]8;;$TERM_ESC\\")
+  return ("${TERM_CSI}8;;$address$TERM_ESC\\$caption${TERM_CSI}8;;$TERM_ESC\\")
 }
 
 proc bell() {
-  echo $TERM_BEL
+  write -n $TERM_BEL
+}
+
+proc cursor-up() { # CUU
+  write -n "${TERM_CSI}nA"
+}
+
+proc cursor-down() { # CUD
+  write -n "${TERM_CSI}nB"
+}
+
+proc cursor-forward() { # CUF
+  write -n "${TERM_CSI}nC"
+}
+
+proc cursor-back() { # CUB
+  write -n "${TERM_CSI}nD"
+}
+
+proc cursor-next-line() { # CNL
+  write -n "${TERM_CSI}nE"
+}
+
+proc cursor-previous-line() { # CPL
+  write -n "${TERM_CSI}nF"
+}
+
+proc cursor-horizontal-absolute() { # CHA
+  write -n "${TERM_CSI}nG"
+}
+
+proc cursor-position(; row, col) { # CUP
+  write -n "$TERM_CSI$row;${col}H"
+}
+
+# NOTE: Clears part of the screen. If n is 0 (or missing), clear from cursor to end of screen. If n is 1, clear from cursor to beginning of the screen. If n is 2, clear entire screen (and moves cursor to upper left on DOS ANSI.SYS). If n is 3, clear entire screen and delete all lines saved in the scrollback buffer (this feature was added for xterm and is supported by other terminal applications).
+proc erase-in-display(; n) { # ED
+  write -n "$TERM_CSI${n}J"
+}
+
+# NOTE: Erases part of the line. If n is 0 (or missing), clear from cursor to the end of the line. If n is 1, clear from cursor to beginning of the line. If n is 2, clear entire line. Cursor position does not change.
+proc erase-in-line(; n) { # EL
+  write -n "$TERM_CSI${n}K"
 }

--- a/stdlib/draft-termcodes/ansi.ysh
+++ b/stdlib/draft-termcodes/ansi.ysh
@@ -54,7 +54,7 @@ func sgr24(color_hex) {
   return ("2;$r;$g;$b")
 }
 
-func withFg(color, text) {
+func withFg(text, color) {
   if (type(color) === 'Str') {
     return ("${TERM_CSI}38;${color}m${text}${TERM_CSI}m")
   } else { # 4-bit color
@@ -68,7 +68,7 @@ func withFg(color, text) {
   }
 }
 
-func withBg(color, text) {
+func withBg(text, color) {
   if (type(color) === 'Str') {
     return ("$TERM_ESC[48;${color}m${text}$TERM_ESC[m")
   } else { # 4-bit color
@@ -82,7 +82,7 @@ func withBg(color, text) {
   }
 }
 
-func withLink(address, caption) {
+func withLink(caption, address) {
   return ("${TERM_CSI}8;;$address$TERM_ESC\\$caption${TERM_CSI}8;;$TERM_ESC\\")
 }
 

--- a/stdlib/draft-termcodes/ansi.ysh
+++ b/stdlib/draft-termcodes/ansi.ysh
@@ -57,9 +57,13 @@ func withFg(color, text) {
   if (type(color) === 'Str') {
     return ("$TERM_ESC[38;${color}m${text}$TERM_ESC[m")
   } else { # 4-bit color
-    var sgr3_id = color[0]
-    echo Unimplemented
-    exit 1
+    var sgr4_id = color[0]
+    if (sgr4_id < 8) {
+      setvar sgr4_id += 30
+    } else {
+      setvar sgr4_id += 90 - 8
+    }
+    return ("$TERM_ESC[${sgr4_id}m${text}$TERM_ESC[m")
   }
 }
 
@@ -67,15 +71,20 @@ func withBg(color, text) {
   if (type(color) === 'Str') {
     return ("$TERM_ESC[48;${color}m${text}$TERM_ESC[m")
   } else { # 4-bit color
-    var sgr3_id = color[0]
-    echo Unimplemented
-    exit 1
+    var sgr4_id = color[0]
+    if (sgr4_id < 8) {
+      setvar sgr4_id += 40
+    } else {
+      setvar sgr4_id += 100 - 8
+    }
+    return ("$TERM_ESC[;${sgr4_id}m${text}$TERM_ESC[m")
   }
 }
 
 func withLink(address, caption) {
   return ("$TERM_ESC]8;;$address$TERM_ESC\\$caption$TERM_ESC]8;;$TERM_ESC\\")
 }
+
 proc bell() {
   echo $TERM_BEL
 }

--- a/stdlib/draft-termcodes/ansi.ysh
+++ b/stdlib/draft-termcodes/ansi.ysh
@@ -1,0 +1,81 @@
+#!/usr/bin/env ysh
+
+module stdlib/termcodes || return 0
+
+# Reference: https://en.wikipedia.org/wiki/ANSI_escape_code#C0_control_codes
+# NOTE: some non-standard constucts are included given they are the de facto standard
+
+const TERM_BEL = u'\u{07}'
+const TERM_BS  = u'\u{08}'
+const TERM_HT  = u'\u{09}'
+const TERM_LF  = u'\u{0A}'
+const TERM_FF  = u'\u{0C}'
+const TERM_CR  = u'\u{0D}'
+const TERM_ESC = u'\u{1B}'
+
+func srgRgb(r, g, b) {
+  var channelName = ['Red', 'Green', 'Blue']
+  for channel in $r $g $b {
+    if (channel < 0 or channel > 255) {
+      echo Channel $channelName has value $channel which is out of range of [0, 255].
+      exit 1
+    }
+  }
+  return ("2;$r;$g;$b")
+}
+
+# 0 ~ 7: Black, Red, Green, Yellow, Blue, Magenta, Cyan, White, 
+# 8 ~ 15: Bright Black (Gray), Bright Red, Bright Green, Bright Yellow, Bright Blue, Bright Magenta, Bright Cyan, Bright White
+func sgr4(color_id) {
+  if (color_id > 0xF or color_id < 0) {
+    echo Color $color_id is out of range of 4-bit colors
+    exit 1
+  }
+  return ([color_id])
+}
+
+func sgr8(color_id) {
+  if (color_id > 0xFF or color_id < 0) {
+    echo Color $color_id is out of range of 8-bit colors
+    exit 1
+  }
+  return ("5;$color_id")
+}
+
+func sgr24(color_hex) {
+  if (color_hex > 0xFFFFFF or color_hex < 0) {
+    echo Color $colorHex is out of range of 24-bit true colors
+    exit 1
+  }
+  var r = (color_hex >> 16)
+  var g = (color_hex >> 8) & 0xFF
+  var b = color_hex & 0xFF
+  return ("2;$r;$g;$b")
+}
+
+func withFg(color, text) {
+  if (type(color) === 'Str') {
+    return ("$TERM_ESC[38;${color}m${text}$TERM_ESC[m")
+  } else { # 4-bit color
+    var sgr3_id = color[0]
+    echo Unimplemented
+    exit 1
+  }
+}
+
+func withBg(color, text) {
+  if (type(color) === 'Str') {
+    return ("$TERM_ESC[48;${color}m${text}$TERM_ESC[m")
+  } else { # 4-bit color
+    var sgr3_id = color[0]
+    echo Unimplemented
+    exit 1
+  }
+}
+
+func withLink(address, caption) {
+  return ("$TERM_ESC]8;;$address$TERM_ESC\\$caption$TERM_ESC]8;;$TERM_ESC\\")
+}
+proc bell() {
+  echo $TERM_BEL
+}

--- a/stdlib/draft-termcodes/xterm.ysh
+++ b/stdlib/draft-termcodes/xterm.ysh
@@ -83,15 +83,27 @@ func withBg(text, color) {
   }
 }
 
-const FONT_NORMAL      = 0
-const FONT_BOLD        = 1
-const FONT_FAINT       = 2
-const FONT_ITALICIZED  = 3
-const FONT_UNDERLINED  = 4
-const FONT_BLINK       = 5
-const FONT_INVERSE     = 7
-const FONT_INVISIBLE   = 8
-const FONT_CROSSED_OUT = 9
+const STYLE_NORMAL            = 0
+const STYLE_BOLD              = 1
+const STYLE_FAINT             = 2
+const STYLE_ITALICIZED        = 3
+const STYLE_UNDERLINED        = 4
+const STYLE_BLINK             = 5
+const STYLE_INVERSE           = 7
+const STYLE_INVISIBLE         = 8
+const STYLE_CROSSED_OUT       = 9
+const STYLE_DOUBLY_UNDERLINED = 21
+
+# TODO: 
+# - What exaclty does 22 do? 
+# - The following doesn't seem to work as expected because they alter the style from that point on and there's no way to revert them.
+
+# const FONT_NOT_ITALICIZED    = 23
+# const FONT_NOT_UNDERLINED    = 24
+# const FONT_NOT_BLINK         = 25
+# const FONT_NOT_INVERSE       = 27
+# const FONT_NOT_INVISIBLE     = 28
+# const FONT_NOT_CROSSED_OUT   = 29
 
 func withStyle(text, style) {
   return ("${TERM_CSI}${style}m${text}${TERM_CSI}m")

--- a/stdlib/draft-termcodes/xterm.ysh
+++ b/stdlib/draft-termcodes/xterm.ysh
@@ -91,6 +91,7 @@ proc bell() {
   write -n $TERM_BEL
 }
 
+# TODO: use some language constructs to generate these biolerplates
 proc cursor-up() { # CUU
   write -n "${TERM_CSI}nA"
 }

--- a/stdlib/draft-termcodes/xterm.ysh
+++ b/stdlib/draft-termcodes/xterm.ysh
@@ -4,7 +4,7 @@ module stdlib/termcodes || return 0
 
 # NOTE: Reference
 # - https://en.wikipedia.org/wiki/ANSI_escape_code#C0_control_codes
-# - invisible-island.net/xterm/ctlseqs/ctlseqs.html
+# - https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
 
 const TERM_BEL = u'\u{07}'
 const TERM_BS  = u'\u{08}'

--- a/stdlib/draft-termcodes/xterm.ysh
+++ b/stdlib/draft-termcodes/xterm.ysh
@@ -2,8 +2,9 @@
 
 module stdlib/termcodes || return 0
 
-# Reference: https://en.wikipedia.org/wiki/ANSI_escape_code#C0_control_codes
-# NOTE: some non-standard constucts are included given they are the de facto standard
+# NOTE: Reference
+# - https://en.wikipedia.org/wiki/ANSI_escape_code#C0_control_codes
+# - invisible-island.net/xterm/ctlseqs/ctlseqs.html
 
 const TERM_BEL = u'\u{07}'
 const TERM_BS  = u'\u{08}'

--- a/stdlib/draft-termcodes/xterm.ysh
+++ b/stdlib/draft-termcodes/xterm.ysh
@@ -92,32 +92,32 @@ proc bell() {
 }
 
 # TODO: use some language constructs to generate these biolerplates
-proc cursor-up() { # CUU
-  write -n "${TERM_CSI}nA"
+proc cursor-up(; n) { # CUU
+  write -n "${TERM_CSI}${n}A"
 }
 
-proc cursor-down() { # CUD
-  write -n "${TERM_CSI}nB"
+proc cursor-down(; n) { # CUD
+  write -n "${TERM_CSI}${n}B"
 }
 
-proc cursor-forward() { # CUF
-  write -n "${TERM_CSI}nC"
+proc cursor-forward(; n) { # CUF
+  write -n "${TERM_CSI}${n}C"
 }
 
-proc cursor-back() { # CUB
-  write -n "${TERM_CSI}nD"
+proc cursor-back(; n) { # CUB
+  write -n "${TERM_CSI}${n}D"
 }
 
-proc cursor-next-line() { # CNL
-  write -n "${TERM_CSI}nE"
+proc cursor-next-line(; n) { # CNL
+  write -n "${TERM_CSI}${n}E"
 }
 
-proc cursor-previous-line() { # CPL
-  write -n "${TERM_CSI}nF"
+proc cursor-previous-line(; n) { # CPL
+  write -n "${TERM_CSI}${n}F"
 }
 
-proc cursor-horizontal-absolute() { # CHA
-  write -n "${TERM_CSI}nG"
+proc cursor-horizontal-absolute(; n) { # CHA
+  write -n "${TERM_CSI}${n}G"
 }
 
 proc cursor-position(; row, col) { # CUP

--- a/stdlib/draft-termcodes/xterm.ysh
+++ b/stdlib/draft-termcodes/xterm.ysh
@@ -83,6 +83,20 @@ func withBg(text, color) {
   }
 }
 
+const FONT_NORMAL      = 0
+const FONT_BOLD        = 1
+const FONT_FAINT       = 2
+const FONT_ITALICIZED  = 3
+const FONT_UNDERLINED  = 4
+const FONT_BLINK       = 5
+const FONT_INVERSE     = 7
+const FONT_INVISIBLE   = 8
+const FONT_CROSSED_OUT = 9
+
+func withStyle(text, style) {
+  return ("${TERM_CSI}${style}m${text}${TERM_CSI}m")
+}
+
 func withLink(caption, address) {
   return ("$TERM_ESC]8;;$address$TERM_ESC\\$caption$TERM_ESC]8;;$TERM_ESC\\")
 }


### PR DESCRIPTION
This is a draft PR. 

### Issues
- There's no way to actually test this because termcode commands has effect not on stdout/stderr but on other environments. 
- There's some biolerplates in the code. Begs macro system.
 #1872
 
### TODOs
- [ ] Auto adapting colors with `$COLORTERM`
- [ ] Maybe delegate jobs to `tput` from ncurses if it's present. Since it's not really part of coreutils so this better stay optional. Not sure yet. 
- [ ] Nesting styles doesn't need to be fixed. 

### Resources 
- https://en.wikipedia.org/wiki/ANSI_escape_code
- https://invisible-island.net/xterm/ctlseqs/ctlseqs.html

### Preview

```
source ./draft-termcodes/xterm.ysh 
echo $["I'm doubly underscorred" => withStyle(STYLE_DOUBLY_UNDERLINED)]
echo $["I'm clickable!" => withLink("https://www.google.com") => withFg(sgr24(0xff00ff))]
echo $["I'm crossed out" => withStyle(STYLE_CROSSED_OUT)]
```

![image](https://github.com/oilshell/oil/assets/12870742/807389e0-b75f-4372-9938-f34ee81bbe87)