### PR TITLE
Fix nix-shell for `test/spec-py.sh ysh-all`

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -53,8 +53,17 @@ let
   #   Clang for coverage too
 
   # nixpkgs: busybox linux only; no smoosh
+
+  # busybox links xargs, we need that to run tests, though
+  busybox_no_symlinks = busybox.override {
+     extraConfig = ''
+       CONFIG_INSTALL_APPLET_DONT y
+       CONFIG_INSTALL_APPLET_SYMLINKS n
+     '';
+   };
+
   # could append something like: ++ lib.optionals stdenv.isLinux [ busybox ]
-  spec_tests = [ bash dash mksh zsh busybox ];
+  spec_tests = [ bash dash mksh zsh busybox_no_symlinks];
 
   static_analysis = [
     mypy # This is the Python 3 version


### PR DESCRIPTION
NOTE: `bin/ysh` does work for me, but `test/spec-py.sh` is still broken
@andychu Help wanted. 

Related https://github.com/oilshell/oil/issues/1918

https://oilshell.zulipchat.com/#narrow/stream/417617-help-wanted/topic/Fix.20nix-shell