### PR TITLE
direnv support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+. build/dev-shell.sh 

--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,12 @@
 #!/usr/bin/env bash
 
+#### Description
+# Direnv is a tool for user to separate their shell config into different folder specific profile. When `cd`ing into the `oil` folder, if direnv is allowed to run the script, it will automatically run the `build/dev-shell.sh` script. and dump environment variables into current shell.
+
+#### Usage
+# - Install direnv and its shell hook on https://direnv.net/#getting-started
+# - cd into git repo root
+# - Run `direnv allow`
+# - Now whenever you cd into oil repo or one of its subdirs, direnv will load environment variables directly for you.
+
 . build/dev-shell.sh 

--- a/.envrc
+++ b/.envrc
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-if [ ! -d "~/wedge" -o ! -d "/wedge" ]; then
-  echo "Wedge dir is missing, run 'build/deps.sh fetch && build/deps.sh install-wedges' in shell to pull wedge."
-fi
-
 . build/dev-shell.sh 

--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,7 @@
+#!/usr/bin/env bash
+
+if [ ! -d "~/wedge" -o ! -d "/wedge" ]; then
+  echo "Wedge dir is missing, run 'build/deps.sh fetch && build/deps.sh install-wedges' in shell to pull wedge."
+fi
+
 . build/dev-shell.sh 


### PR DESCRIPTION
### Status
Ready for merge.

### Description
Direnv is a tool for user to separate their shell config into different folder specific profile. When `cd`ing into the `oil` folder, if direnv is allowed to run the script, it will automatically run the `build/dev-shell.sh` script. and dump environment variables into current shell.

### Usage
- [Install direnv and its shell hook](https://direnv.net/#getting-started)
- cd into git repo root
- Run `direnv allow`
- Now whenever you cd into oil repo or one of its subdirs, direnv will load environment variables directly for you. 