### PR TITLE
always clean up child process on exit

### DIFF
--- a/core/process.py
+++ b/core/process.py
@@ -1154,7 +1154,8 @@ class Process(Job):
                     print_stderr('[%d] Done PID %d' % (self.job_id, self.pid))
 
                 self.job_list.RemoveJob(self.job_id)
-                self.job_list.RemoveChildProcess(self.pid)
+
+            self.job_list.RemoveChildProcess(self.pid)
 
             if not self.in_background:
                 self.job_control.MaybeTakeTerminal()


### PR DESCRIPTION
I only half-way fixed #1003 in 12697216532eea6b04c98a5f59015372b8efd27a. We should remove all processes from the child process map on exit, not just the ones that have been backgrounded and assigned job IDs.