### PR TITLE
[data_lang/utf8] Create UTF8 decoder to round-trip surrogates. Fix J8 lone surrogate spec test

### DIFF
--- a/data_lang/NINJA_subgraph.py
+++ b/data_lang/NINJA_subgraph.py
@@ -23,7 +23,7 @@ def NinjaGraph(ru):
 
     ru.cc_binary(
         'data_lang/utf8_test.cc',
-        deps=['//data_lang/utf8_impls/utf8_decode'],
+        deps=['//data_lang/utf8_impls/utf8_decode', '//data_lang/utf8'],
         # Add tcmalloc for malloc_address_test
         matrix=ninja_lib.COMPILERS_VARIANTS + [('cxx', 'tcmalloc')])
 
@@ -38,6 +38,12 @@ def NinjaGraph(ru):
         '//data_lang/j8',
         srcs=[],
         headers=['data_lang/j8.h'],
+        deps=['//data_lang/utf8'],
+    )
+    ru.cc_library(
+        '//data_lang/utf8',
+        srcs=[],
+        headers=['data_lang/utf8.h'],
         deps=[],
     )
 

--- a/data_lang/j8.h
+++ b/data_lang/j8.h
@@ -91,7 +91,8 @@ static inline int J8EncodeOne(unsigned char** p_in, unsigned char** p_out,
   //
   // UTF-8 encoded runes and invalid bytes
   //
-  Utf8Result_t result = utf8_decode(*p_in);
+  Utf8Result_t result;
+  utf8_decode(*p_in, &result);
 
   if (result.error == UTF8_OK) {
     memcpy(*p_out, *p_in, result.bytes_read);

--- a/data_lang/utf8.h
+++ b/data_lang/utf8.h
@@ -6,10 +6,6 @@
 #include <stdint.h> // uint32_t
 #include <stddef.h> // size_t
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /**
  *              ---- Quick reference about the encoding ----
  *
@@ -170,9 +166,5 @@ static inline Utf8Result_t utf8_decode(const unsigned char *input) {
   result.error = UTF8_ERR_BAD_ENCODING;
   return result;
 }
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif  // DATA_LANG_UTF8_H

--- a/data_lang/utf8.h
+++ b/data_lang/utf8.h
@@ -136,7 +136,7 @@ static inline Utf8Result_t utf8_decode(const unsigned char *input) {
       result.error = UTF8_ERR_OVERLONG;
     }
 
-    if (result.codepoint >= 0xD800 && result.codepoint <= 0xDFFF) {
+    if (0xD800 <= result.codepoint && result.codepoint <= 0xDFFF) {
       result.error = UTF8_ERR_SURROGATE;
     }
 

--- a/data_lang/utf8.h
+++ b/data_lang/utf8.h
@@ -1,0 +1,178 @@
+#ifndef DATA_LANG_UTF8_H
+#define DATA_LANG_UTF8_H
+
+#include <stdio.h>
+
+#include <stdint.h> // uint32_t
+#include <stddef.h> // size_t
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ *              ---- Quick reference about the encoding ----
+ *
+ * First, all valid UTF-8 sequences follow of bit "patterns" (Table 3-6.) The
+ * first byte determines the length of the sequence and then the next 0-3 bytes
+ * are "continuation bytes."
+ *
+ * +----------------------------+----------+----------+----------+----------+
+ * | Scalar Value               | 1st Byte | 2nd Byte | 3rd Byte | 4th Byte |
+ * +----------------------------+----------+----------+----------+----------+
+ * | 00000000 0xxxxxxx          | 0xxxxxxx |          |          |          |
+ * | 00000yyy yyxxxxxx          | 110yyyyy | 10xxxxxx |          |          |
+ * | zzzzyyyy yyxxxxxx          | 1110zzzz | 10yyyyyy | 10xxxxxx |          |
+ * | 000uuuuu zzzzyyyy yyxxxxxx | 11110uuu | 10uuzzzz | 10yyyyyy | 10xxxxxx |
+ * +----------------------------+----------+----------+----------+----------+
+ *
+ *      Table 3-6 from Unicode Standard 15.0.0 Ch3. UTF-8 bit patterns
+ *
+ * There are 3 further restrictions which make some valid bit patterns
+ * *invalid*:
+ *  1. Overlongs: eg, <0x41> and <0xC1 0x81> both store U+41, but the second
+ *     sequence is longer and thus an error.
+ *  2. Surrogates: Any codepoint between U+D800 and U+DFFF (inclusive) is a
+ *     surrogate. It is an error to encode surrogates in UTF-8.
+ *  3. Too Large: Any decoded value over 0x10FFFF is not a Unicode codepoint,
+ *     and must be rejected as an error.
+ *
+ * See https://aolsen.ca/writings/everything-about-utf8 for more details about
+ * the encoding.
+ */
+
+typedef enum Utf8Error {
+  UTF8_OK = 0,
+
+  // Encodes a codepoint in more bytes than necessary
+  UTF8_ERR_OVERLONG,
+
+  // Encodes a codepoint in the surrogate range (0xD800 to 0xDFFF, inclusive)
+  UTF8_ERR_SURROGATE,
+
+  // Encodes a value greater than the max codepoint U+10FFFF
+  UTF8_ERR_TOO_LARGE,
+
+  // Encoding doesn't conform to the UTF-8 bit patterns
+  UTF8_ERR_BAD_ENCODING,
+
+  // It looks like there is another codepoint, but it has been truncated.
+  UTF8_ERR_TRUNCATED_BYTES,
+
+  // We are at the end of the string. (input_len = 0)
+  UTF8_ERR_END_OF_STREAM,
+} Utf8Error_t;
+
+typedef struct Utf8Result {
+  Utf8Error_t error;
+  uint32_t codepoint;
+  size_t bytes_read;
+} Utf8Result_t;
+
+static inline void _cont(const unsigned char *input, Utf8Result_t *result) {
+  if (result->error) {
+    return;
+  }
+
+  int byte = input[result->bytes_read];
+  if (byte == '\0') {
+    result->error = UTF8_ERR_TRUNCATED_BYTES;
+    return;
+  }
+  result->bytes_read += 1;
+
+  // Continuation bytes follow the bit pattern 10xx_xxxx. We need to a)
+  // validate the pattern and b) remove the leading '10'.
+  if ((byte & 0xC0) == 0x80) {
+    result->codepoint <<= 6;
+    result->codepoint |= byte & 0x3F;
+  } else {
+    result->error = UTF8_ERR_BAD_ENCODING;
+  }
+}
+
+/**
+ * Given a nul-terminated string `input`, try to decode the next codepoint from
+ * that string.
+ *
+ * If there was a surrogate, overlong or codepoint to large error then
+ * `result.codepoint` will contain the recovered value.
+ */
+static inline Utf8Result_t utf8_decode(const unsigned char *input) {
+  Utf8Result_t result = {UTF8_OK, 0, 0};
+
+  int first = *input;
+  if (first == '\0') {
+    result.error = UTF8_ERR_END_OF_STREAM;
+    return result;
+  }
+  result.bytes_read = 1;
+
+  if ((first & 0x80) == 0) {
+    // 1-byte long (ASCII subset)
+    result.codepoint = first;
+    return result;
+  }
+
+  if ((first & 0xE0) == 0xC0) {
+    // 2-bytes long
+    result.codepoint = first & 0x1F;
+
+    _cont(input, &result);
+    if (result.error) return result;
+
+    if (result.codepoint < 0x80) {
+      result.error = UTF8_ERR_OVERLONG;
+    }
+
+    return result;
+  }
+
+  if ((first & 0xF0) == 0xE0) {
+    // 3-bytes long
+    result.codepoint = first & 0x0F;
+
+    _cont(input, &result);
+    _cont(input, &result);
+    if (result.error) return result;
+
+    if (result.codepoint < 0x800) {
+      result.error = UTF8_ERR_OVERLONG;
+    }
+
+    if (result.codepoint >= 0xD800 && result.codepoint <= 0xDFFF) {
+      result.error = UTF8_ERR_SURROGATE;
+    }
+
+    return result;
+  }
+
+  if ((first & 0xF8) == 0xF0) {
+    // 4-bytes long
+    result.codepoint = first & 0x07;
+
+    _cont(input, &result);
+    _cont(input, &result);
+    _cont(input, &result);
+    if (result.error) return result;
+
+    if (result.codepoint < 0x10000) {
+      result.error = UTF8_ERR_OVERLONG;
+    }
+
+    if (result.codepoint > 0x10FFFF) {
+      result.error = UTF8_ERR_TOO_LARGE;
+    }
+
+    return result;
+  }
+
+  result.error = UTF8_ERR_BAD_ENCODING;
+  return result;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // DATA_LANG_UTF8_H

--- a/data_lang/utf8_test.cc
+++ b/data_lang/utf8_test.cc
@@ -2,6 +2,7 @@
 
 #include "data_lang/utf8_impls/bjoern_dfa.h"
 #include "data_lang/utf8_impls/utf8_decode.h"
+#include "data_lang/utf8.h"
 
 //#include "mycpp/runtime.h"
 #include "vendor/greatest.h"
@@ -332,6 +333,94 @@ TEST surrogate_test() {
   PASS();
 }
 
+TEST identity_test() {
+  // check that decode(encode(x)) = x for all code-points (and surrogates)
+  uint8_t buf[5] = {0};
+  for (uint32_t cp = 1; cp < 0x10FFFF; ++cp) {
+    int len = utf8proc_encode_char(cp, buf);
+    Utf8Result result = utf8_decode(buf);
+
+    if (cp < 0xD800 || cp > 0xDFFF) {
+      ASSERT_EQ(result.error, UTF8_OK);
+    } else {
+      ASSERT_EQ(result.error, UTF8_ERR_SURROGATE);
+    }
+    ASSERT_EQ(result.codepoint, cp);
+    ASSERT_EQ(result.bytes_read, static_cast<size_t>(len));
+  }
+
+  PASS();
+}
+
+TEST overlong_test() {
+  // All encode U+41 ('A')
+  Utf8Result ok = utf8_decode((unsigned char*)"\x41");
+  Utf8Result overlong2 = utf8_decode((unsigned char*)"\xC1\x81");
+  Utf8Result overlong3 = utf8_decode((unsigned char*)"\xE0\x81\x81");
+  Utf8Result overlong4 = utf8_decode((unsigned char*)"\xF0\x80\x81\x81");
+
+  ASSERT_EQ(ok.error, UTF8_OK);
+  ASSERT_EQ(overlong2.error, UTF8_ERR_OVERLONG);
+  ASSERT_EQ(overlong3.error, UTF8_ERR_OVERLONG);
+  ASSERT_EQ(overlong4.error, UTF8_ERR_OVERLONG);
+
+  ASSERT_EQ(ok.codepoint, 0x41);
+  ASSERT_EQ(overlong2.codepoint, 0x41);
+  ASSERT_EQ(overlong3.codepoint, 0x41);
+  ASSERT_EQ(overlong4.codepoint, 0x41);
+
+  ASSERT_EQ(ok.bytes_read, 1);
+  ASSERT_EQ(overlong2.bytes_read, 2);
+  ASSERT_EQ(overlong3.bytes_read, 3);
+  ASSERT_EQ(overlong4.bytes_read, 4);
+
+  PASS();
+}
+
+TEST too_large_test() {
+  // Encoding of 0x111111 (via Table 3-6)
+  //  = 00010001 00010001 00010001
+  //   uuuuu -> 10001
+  //    zzzz -> 00001
+  //  yyyyyy -> 000100
+  //  xxxxxx -> 010001
+  //
+  //  -> 11110100 10010001 10000100 10010001
+  //   = F4 91 84 91
+  Utf8Result result = utf8_decode((unsigned char*)"\xF4\x91\x84\x91");
+
+  ASSERT_EQ(result.error, UTF8_ERR_TOO_LARGE);
+  ASSERT_EQ(result.codepoint, 0x111111);
+  ASSERT_EQ(result.bytes_read, 4);
+
+  PASS();
+}
+
+TEST truncated_test() {
+  constexpr const int NUM_INPUTS = 6;
+  const char *inputs[NUM_INPUTS] = {
+    "\xC5",
+    "\xED",
+    "\xED\x9F",
+    "\xF4",
+    "\xF4\x80",
+    "\xF4\x80\x80",
+  };
+
+  for (int i = 0; i < NUM_INPUTS; i++) {
+    Utf8Result result = utf8_decode((unsigned char*)inputs[i]);
+    ASSERT_EQ(result.error, UTF8_ERR_TRUNCATED_BYTES);
+    ASSERT_EQ(result.bytes_read, strlen(inputs[i]));
+  }
+
+  // End of stream is separate from truncated
+  Utf8Result result = utf8_decode((unsigned char*)"");
+  ASSERT_EQ(result.error, UTF8_ERR_END_OF_STREAM);
+  ASSERT_EQ(result.bytes_read, 0);
+
+  PASS();
+}
+
 GREATEST_MAIN_DEFS();
 
 int main(int argc, char** argv) {
@@ -343,6 +432,11 @@ int main(int argc, char** argv) {
   RUN_TEST(enumerate_utf8_test);
   RUN_TEST(crockford_test);
   RUN_TEST(surrogate_test);
+
+  RUN_TEST(identity_test);
+  RUN_TEST(overlong_test);
+  RUN_TEST(too_large_test);
+  RUN_TEST(truncated_test);
 
   GREATEST_MAIN_END();
   return 0;

--- a/spec/ysh-json.test.sh
+++ b/spec/ysh-json.test.sh
@@ -1,4 +1,4 @@
-## oils_failures_allowed: 2
+## oils_failures_allowed: 1
 ## tags: dev-minimal
 
 #### usage errors
@@ -592,9 +592,9 @@ for j in '"\ud83e"' '"\udd26"' {
 }
 
 ## STDOUT:
-(Str)   b'\ya0\ybe'
+(Str)   b'\yed\ya0\ybe'
 "\ud83e"
-(Str)   b'\yb4\ya6'
+(Str)   b'\yed\yb4\ya6'
 "\udd26"
 ## END
 

--- a/spec/ysh-json.test.sh
+++ b/spec/ysh-json.test.sh
@@ -576,26 +576,31 @@ json write (c4)
 
 #### round trip: decode surrogate half and encode
 
-# TODO: Weird Python allows this to be decoded, but I think the Bjoern state
-# machine will not!
-
 shopt -s ysh:upgrade
 
 for j in '"\ud83e"' '"\udd26"' {
   var s = fromJson(j)
+  write -- "$j"
   pp line (s)
 
-  # TODO: modify DFA to return the code point in the surrogate range, and
-  # print it in JSON mode
-  # j8 mode could possibly use byte strings
-  json write (s)
+  write -n 'json ';  json write (s)
+
+  write -n 'json8 '; json8 write (s)
+
+  echo
 }
 
 ## STDOUT:
-(Str)   b'\yed\ya0\ybe'
 "\ud83e"
-(Str)   b'\yed\yb4\ya6'
+(Str)   b'\yed\ya0\ybe'
+json "\ud83e"
+json8 b'\yed\ya0\ybe'
+
 "\udd26"
+(Str)   b'\yed\yb4\ya6'
+json "\udd26"
+json8 b'\yed\yb4\ya6'
+
 ## END
 
 #### toJson() toJson8()


### PR DESCRIPTION
I ended up writing a new UTF-8 decoder from scratch. It follows the Crockford style but 1) is stateless and 2) can round-trip surrogates. I've also written some fairly comprehensive tests for the decoder.

Now the `J8EncodeOne` function is able round-trip surrogates!