### PR TITLE
add some statically defined tracepoints

### DIFF
--- a/build/deps.sh
+++ b/build/deps.sh
@@ -129,6 +129,7 @@ readonly -a WEDGE_DEPS_DEBIAN=(
     ninja-build
     cmake
     libreadline-dev 
+    systemtap-sdt-dev
     "${PY3_BUILD_DEPS[@]}"
 )
 

--- a/build/detect-systemtap-sdt.c
+++ b/build/detect-systemtap-sdt.c
@@ -1,0 +1,6 @@
+#include <sys/sdt.h>
+
+int main(void) {
+  DTRACE_PROBE(test, main);
+  return 0;
+}

--- a/configure
+++ b/configure
@@ -43,6 +43,8 @@ Optional features:
   --without-readline            Don't compile with readline, even if it's available.
                                 The shell won't have any interactive features.
   --readline=DIR                An alternative readline installation to link against
+  --with-systemtap-sdt          Fail unless systemtap-sdt is available.
+  --without-systemtap-sdt       Don't compile with systemtap-sdt, even if it's available.
 EOF
 }
 
@@ -62,12 +64,16 @@ FLAG_datarootdir=''  # default initialized after processing flags
 FLAG_with_readline=''  # Fail if it's not available.
 FLAG_without_readline=''  # Don't even check if it's available
 FLAG_readline=''
+FLAG_with_systemtap_sdt=''  # Fail if it's not available.
+FLAG_without_systemtap_sdt=''  # Don't even check if it's available
 
 # These variables are set by detect_readline and used by echo_cpp and
 # echo_shell_vars
-detected_readline=''
+detected_deps=''
 have_readline=''
 readline_dir=''
+
+have_systemtap_sdt=''
 
 parse_flags() {
   while true; do
@@ -98,6 +104,14 @@ parse_flags() {
         fi
         shift
         FLAG_readline=$1
+        ;;
+
+      --with-systemtap_sdt)
+        FLAG_with_systemtap_sdt=1
+        ;;
+
+      --without-systemtap_sdt)
+        FLAG_without_systemtap_sdt=1
         ;;
 
       # TODO: Maybe prefix only needs to be part of the install step?  I'm not
@@ -204,7 +218,7 @@ cc_header_file() {
 }
 
 detect_readline() {
-  detected_readline=1  # for assertions in echo_shell_vars and echo_cpp
+  detected_deps=1  # for assertions in echo_shell_vars and echo_cpp
 
   # User disabled readline
   if test -n "$FLAG_without_readline"; then
@@ -237,8 +251,21 @@ detect_readline() {
   fi
 }
 
+detect_systemtap_sdt() {
+  detected_deps=1  # for assertions in echo_shell_vars and echo_cpp
+
+  if test -n "$FLAG_without_systemtap_sdt"; then
+    return
+  fi
+
+  if cc_quiet build/detect-systemtap-sdt.c; then
+    have_systemtap_sdt=1
+    return
+  fi
+}
+
 echo_shell_vars() {
-  if test "$detected_readline" != 1; then
+  if test "$detected_deps" != 1; then
     die 'called echo_shell_vars before detecting readline.'
   fi
   if test "$have_readline" = 1; then
@@ -248,6 +275,11 @@ echo_shell_vars() {
     echo 'HAVE_READLINE='
     # Present a consistent interface to build/ninja-rules-cpp.sh
     echo 'READLINE_DIR='
+  fi
+  if test "$have_systemtap_sdt" = 1; then
+    echo 'HAVE_SYSTEMTAP_SDT=1'
+  else
+    echo 'HAVE_SYSTEMTAP_SDT='
   fi
   echo "PREFIX=$FLAG_prefix"
   echo "DATAROOTDIR=$FLAG_datarootdir"
@@ -381,7 +413,7 @@ EOF
 }
 
 echo_cpp() {
-  if test "$detected_readline" != 1; then
+  if test "$detected_deps" != 1; then
     die 'called echo_cpp before detecting readline.'
   fi
   # Dev builds can use non-portable clock_gettime()
@@ -394,6 +426,12 @@ echo_cpp() {
     echo '#define HAVE_READLINE 1'
   else
     echo '/* #undef HAVE_READLINE */'
+  fi
+
+  if test "$have_systemtap_sdt" = 1; then
+    echo '#define HAVE_SYSTEMTAP_SDT 1'
+  else
+    echo '/* #undef HAVE_SYSTEMTAP_SDT */'
   fi
 
   # Check if pwent is callable. E.g. bionic libc (Android) doesn't have it
@@ -418,6 +456,8 @@ main() {
 
   # Sets globals $have_readline and $readline_dir
   detect_readline
+
+  detect_systemtap_sdt
 
   # Generate configuration for oil-native
   local cpp_out=_build/detected-cpp-config.h

--- a/configure-test.sh
+++ b/configure-test.sh
@@ -72,8 +72,8 @@ test_echo_cpp() {
     die "Unexpected echo_cpp output: $output"
   fi
 
-  # pretend detected_readline was called
-  detected_readline=1
+  # pretend detected_deps was called
+  detected_deps=1
 
   # no readline
   output="$(echo_cpp)"
@@ -97,7 +97,7 @@ test_echo_cpp() {
   esac
 
   # clean-up
-  detected_readline=''
+  detected_deps=''
   have_readline=''
 }
 
@@ -114,7 +114,7 @@ test_echo_vars() {
   fi
 
   # pretend detect_readline was called
-  detected_readline=1
+  detected_deps=1
 
   # no readline
   output="$(echo_shell_vars)"
@@ -123,6 +123,7 @@ test_echo_vars() {
   fi
   if ! test "$output" = 'HAVE_READLINE=
 READLINE_DIR=
+HAVE_SYSTEMTAP_SDT=
 PREFIX=/usr/local
 DATAROOTDIR=
 STRIP_FLAGS=--gc-sections'; then
@@ -137,6 +138,7 @@ STRIP_FLAGS=--gc-sections'; then
   fi
   if ! test "$output" = 'HAVE_READLINE=1
 READLINE_DIR=
+HAVE_SYSTEMTAP_SDT=
 PREFIX=/usr/local
 DATAROOTDIR=
 STRIP_FLAGS=--gc-sections'; then
@@ -152,6 +154,7 @@ STRIP_FLAGS=--gc-sections'; then
   fi
   if ! test "$output" = 'HAVE_READLINE=1
 READLINE_DIR=/path/to/readline
+HAVE_SYSTEMTAP_SDT=
 PREFIX=/usr/local
 DATAROOTDIR=
 STRIP_FLAGS=--gc-sections'; then
@@ -159,9 +162,10 @@ STRIP_FLAGS=--gc-sections'; then
   fi
 
   # clean-up
-  detected_readline=''
+  detected_deps=''
   have_readline=''
   readline_dir=''
+  have_systemtap_sdt=''
 }
 
 soil_run() {

--- a/core/process.py
+++ b/core/process.py
@@ -40,7 +40,7 @@ from data_lang import j8_lite
 from frontend import location
 from frontend import match
 from mycpp import mylib
-from mycpp.mylib import log, print_stderr, tagswitch, iteritems
+from mycpp.mylib import log, print_stderr, probe, tagswitch, iteritems
 
 import posix_ as posix
 from posix_ import (
@@ -678,6 +678,7 @@ class ExternalProgram(object):
 
         Called by:   ls /   exec ls /   ( ls / )
         """
+        probe('process', 'ExternalProgram_Exec', argv0_path)
         self._Exec(argv0_path, cmd_val.argv, cmd_val.arg_locs[0], environ,
                    True)
         assert False, "This line should never execute"  # NO RETURN
@@ -824,6 +825,7 @@ class SubProgramThunk(Thunk):
     def Run(self):
         # type: () -> None
         #self.errfmt.OneLineErrExit()  # don't quote code in child processes
+        probe('process', 'SubProgramThunk_Run')
 
         # TODO: break circular dep.  Bit flags could go in ASDL or headers.
         from osh import cmd_eval
@@ -888,6 +890,7 @@ class _HereDocWriterThunk(Thunk):
     def Run(self):
         # type: () -> None
         """do_exit: For small pipelines."""
+        probe('process', 'HereDocWriterThunk_Run')
         #log('Writing %r', self.body_str)
         posix.write(self.w, self.body_str)
         #log('Wrote %r', self.body_str)

--- a/deps/from-apt.sh
+++ b/deps/from-apt.sh
@@ -70,6 +70,9 @@ layer-wedge-builder() {
     # requires path in uftrace source
     libpython3.7
 
+    # for USDT probes
+    systemtap-sdt-dev
+
     # Dependencies for building our own Python3 wedge.  Otherwise 'pip install'
     # won't work.
     # TODO: We should move 'pip install' to build time.
@@ -208,6 +211,9 @@ cpp-small() {
 
     # for test/ltrace
     ltrace
+
+    # for USDT probes
+    systemtap-sdt-dev
   )
 
   apt-install "${packages[@]}"

--- a/mycpp/const_pass.py
+++ b/mycpp/const_pass.py
@@ -163,6 +163,9 @@ class Collect(ExpressionVisitor[T], StatementVisitor[None]):
     def visit_call_expr(self, o: 'mypy.nodes.CallExpr') -> T:
         self.log('CallExpr')
         self.accept(o.callee)  # could be f() or obj.method()
+        if o.callee.name == 'probe':
+            # don't generate constants for probe names
+            return
 
         self.indent += 1
         for arg in o.args:

--- a/mycpp/mylib.py
+++ b/mycpp/mylib.py
@@ -475,6 +475,13 @@ class UniqueObjects(object):
     # Note: self.memo.clear() doesn't appear to be used
 
 
+def probe(provider, name, *args):
+    # type: (str, str, Any) -> None
+    """Create a probe for use with profilers like linux perf and ebpf or dtrace."""
+    # Noop. Just a marker for mycpp to emit a DTRACE_PROBE()
+    return
+
+
 if 0:
     # Prototype of Unix file descriptor I/O, compared with FILE* libc I/O.
     # Doesn't seem like we need this now.

--- a/mycpp/probes.h
+++ b/mycpp/probes.h
@@ -1,0 +1,24 @@
+#ifndef MYCPP_PROBES_H
+#define MYCPP_PROBES_H
+
+#include "_build/detected-cpp-config.h"  // for HAVE_SYSTEMTAP_SDT
+
+#if HAVE_SYSTEMTAP_SDT
+#include <sys/sdt.h>
+#else
+#define DTRACE_PROBE(provider,probe)
+#define DTRACE_PROBE1(provider,probe,parm1)
+#define DTRACE_PROBE2(provider,probe,parm1,parm2)
+#define DTRACE_PROBE3(provider,probe,parm1,parm2,parm3)
+#define DTRACE_PROBE4(provider,probe,parm1,parm2,parm3,parm4)
+#define DTRACE_PROBE5(provider,probe,parm1,parm2,parm3,parm4,parm5)
+#define DTRACE_PROBE6(provider,probe,parm1,parm2,parm3,parm4,parm5,parm6)
+#define DTRACE_PROBE7(provider,probe,parm1,parm2,parm3,parm4,parm5,parm6,parm7)
+#define DTRACE_PROBE8(provider,probe,parm1,parm2,parm3,parm4,parm5,parm6,parm7,parm8)
+#define DTRACE_PROBE9(provider,probe,parm1,parm2,parm3,parm4,parm5,parm6,parm7,parm8,parm9)
+#define DTRACE_PROBE10(provider,probe,parm1,parm2,parm3,parm4,parm5,parm6,parm7,parm8,parm9,parm10)
+#define DTRACE_PROBE11(provider,probe,parm1,parm2,parm3,parm4,parm5,parm6,parm7,parm8,parm9,parm10,parm11)
+#define DTRACE_PROBE12(provider,probe,parm1,parm2,parm3,parm4,parm5,parm6,parm7,parm8,parm9,parm10,parm11,parm12)
+#endif
+
+#endif  // MYCPP_PROBES_H

--- a/mycpp/runtime.h
+++ b/mycpp/runtime.h
@@ -17,6 +17,8 @@
 #include "mycpp/gc_mylib.h"  // Python-like file I/O, etc.
 #include "mycpp/hash.h"
 
+#include "mycpp/probes.h"
+
 // clang-format on
 
 #endif  // MYCPP_RUNTIME_H

--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -84,7 +84,7 @@ from osh import braces
 from osh import sh_expr_eval
 from osh import word_eval
 from mycpp import mylib
-from mycpp.mylib import log, switch, tagswitch
+from mycpp.mylib import log, probe, switch, tagswitch
 from ysh import expr_eval
 from ysh import func_proc
 from ysh import val_ops
@@ -831,6 +831,7 @@ class CommandEvaluator(object):
 
     def _DoSimple(self, node, cmd_st):
         # type: (command.Simple, CommandStatus) -> int
+        probe('cmd_eval', '_DoSimple_enter')
         cmd_st.check_errexit = True
 
         # PROBLEM: We want to log argv in 'xtrace' mode, but we may have already
@@ -891,6 +892,7 @@ class CommandEvaluator(object):
         else:
             status = self._RunSimpleCommand(cmd_val, cmd_st, run_flags)
 
+        probe('cmd_eval', '_DoSimple_exit', status)
         return status
 
     def _DoExpandedAlias(self, node):
@@ -1487,6 +1489,7 @@ class CommandEvaluator(object):
         # If we call RunCommandSub in a recursive call to the executor, this will
         # be set true (if strict_errexit is false).  But it only lasts for one
         # command.
+        probe('cmd_eval', '_Dispatch', node.tag())
         self.check_command_sub_status = False
 
         UP_node = node


### PR DESCRIPTION
This commit adds some infrastructure for adding static tracepoints to the shell runtime and a few examples of how to use it.

These trace points can be used with tools like linux perf/ebpf and dtrace to give us a better idea about what the shell is doing at runtime.

These should impose no overhead when compiled in unless they are being actively instrumented with a tool. See the output below for two of the workloads tracked by CI. Each were measured ten times and all starts are reported with their standard deviations.

# Performance Counters before this patch

## testdata/osh-runtime/bin_true.sh
```
$ perf stat -r 10 -o perf-output.txt taskset -a -c 2 /home/melvin/workdir/oil/_bin/cxx-opt/osh /home/melvin/workdir/oil/testdata/osh-runtime/bin_true.sh 1000                                                                          [136/137]
 Performance counter stats for 'taskset -a -c 2 /home/melvin/workdir/oil/_bin/cxx-opt/osh /home/melvin/workdir/oil/testdata/osh-runtime/bin_true.sh 1000' (10 runs):

          1,032.55 msec task-clock                       #    0.970 CPUs utilized               ( +-  0.09% )
             1,148      context-switches                 #    1.112 K/sec                       ( +-  0.25% )
                 0      cpu-migrations                   #    0.000 /sec
           141,765      page-faults                      #  137.295 K/sec
     2,000,976,240      cycles                           #    1.938 GHz                         ( +-  2.05% )  (93.99%)
     1,097,585,842      stalled-cycles-frontend          #   54.85% frontend cycles idle        ( +-  1.75% )  (96.34%)
       628,551,323      stalled-cycles-backend           #   31.41% backend cycles idle         ( +-  2.17% )  (92.73%)
     1,825,643,486      instructions                     #    0.91  insn per cycle
                                                  #    0.60  stalled cycles per insn     ( +-  1.76% )  (98.40%)
       415,463,227      branches                         #  402.365 M/sec                       ( +-  2.22% )  (99.28%)
         9,932,210      branch-misses                    #    2.39% of all branches             ( +-  1.30% )  (98.20%)

          1.064795 +- 0.000924 seconds time elapsed  ( +-  0.09% )
```

## CPython configure
```
$ perf stat -r 10 -o perf-output.txt taskset -a -c 2 /home/melvin/workdir/oil/_bin/cxx-opt/osh /home/melvin/workdir/oil/Python-2.7.13/configure
 Performance counter stats for 'taskset -a -c 2 /home/melvin/workdir/oil/_bin/cxx-opt/osh /home/melvin/workdir/oil/Python-2.7.13/configure' (10 runs):

         24,071.87 msec task-clock                       #    0.990 CPUs utilized               ( +-  0.02% )
            15,257      context-switches                 #  633.810 /sec                        ( +-  0.16% )
                 1      cpu-migrations                   #    0.042 /sec
         2,107,019      page-faults                      #   87.530 K/sec                       ( +-  0.00% )
    55,243,063,638      cycles                           #    2.295 GHz                         ( +-  0.13% )  (86.59%)
    26,293,987,961      stalled-cycles-frontend          #   47.60% frontend cycles idle        ( +-  0.11% )  (86.99%)
    16,676,322,048      stalled-cycles-backend           #   30.19% backend cycles idle         ( +-  0.29% )  (72.48%)
    57,350,459,289      instructions                     #    1.04  insn per cycle
                                                  #    0.46  stalled cycles per insn     ( +-  0.06% )  (86.94%)
    11,984,012,735      branches                         #  497.843 M/sec                       ( +-  0.06% )  (87.12%)
       336,018,570      branch-misses                    #    2.80% of all branches             ( +-  0.07% )  (86.33%)

          24.31397 +- 0.00771 seconds time elapsed  ( +-  0.03% )
```

# Performance Counters after this patch

## testdata/osh-runtime/bin_true.sh
```
$ perf stat -r 10 -o perf-output.txt taskset -a -c 2 /home/melvin/workdir/oil/_bin/cxx-opt/osh /home/melvin/workdir/oil/testdata/osh-runtime/bin_true.sh 1000

 Performance counter stats for 'taskset -a -c 2 /home/melvin/workdir/oil/_bin/cxx-opt/osh /home/melvin/workdir/oil/testdata/osh-runtime/bin_true.sh 1000' (10 runs):

          1,031.58 msec task-clock                       #    0.969 CPUs utilized               ( +-  0.09% )
             1,143      context-switches                 #    1.108 K/sec                       ( +-  0.18% )
                 1      cpu-migrations                   #    0.969 /sec
           141,765      page-faults                      #  137.425 K/sec
     2,096,639,172      cycles                           #    2.032 GHz                         ( +-  2.06% )  (96.88%)
     1,125,757,115      stalled-cycles-frontend          #   53.69% frontend cycles idle        ( +-  2.21% )  (97.65%)
       606,397,176      stalled-cycles-backend           #   28.92% backend cycles idle         ( +-  3.03% )  (93.27%)
     1,802,121,761      instructions                     #    0.86  insn per cycle
                                                  #    0.62  stalled cycles per insn     ( +-  1.81% )  (96.33%)
       412,611,623      branches                         #  399.978 M/sec                       ( +-  1.05% )  (97.10%)
         9,531,129      branch-misses                    #    2.31% of all branches             ( +-  1.58% )  (97.14%)

           1.06404 +- 0.00101 seconds time elapsed  ( +-  0.09% )
```

## CPython configure
```
$ perf stat -r 10 -o perf-output.txt taskset -a -c 2 /home/melvin/workdir/oil/_bin/cxx-opt/osh /home/melvin/workdir/oil/Python-2.7.13/configure
 Performance counter stats for 'taskset -a -c 2 /home/melvin/workdir/oil/_bin/cxx-opt/osh /home/melvin/workdir/oil/Python-2.7.13/configure' (10 runs):

         24,071.87 msec task-clock                       #    0.990 CPUs utilized               ( +-  0.02% )
            15,257      context-switches                 #  633.810 /sec                        ( +-  0.16% )
                 1      cpu-migrations                   #    0.042 /sec
         2,107,019      page-faults                      #   87.530 K/sec                       ( +-  0.00% )
    55,243,063,638      cycles                           #    2.295 GHz                         ( +-  0.13% )  (86.59%)
    26,293,987,961      stalled-cycles-frontend          #   47.60% frontend cycles idle        ( +-  0.11% )  (86.99%)
    16,676,322,048      stalled-cycles-backend           #   30.19% backend cycles idle         ( +-  0.29% )  (72.48%)
    57,350,459,289      instructions                     #    1.04  insn per cycle
                                                  #    0.46  stalled cycles per insn     ( +-  0.06% )  (86.94%)
    11,984,012,735      branches                         #  497.843 M/sec                       ( +-  0.06% )  (87.12%)
       336,018,570      branch-misses                    #    2.80% of all branches             ( +-  0.07% )  (86.33%)

          24.31397 +- 0.00771 seconds time elapsed  ( +-  0.03% )
```
