### PR TITLE
mycpp: only emit StackRoots if Collect() possbile

### DIFF
--- a/mycpp/NINJA_subgraph.py
+++ b/mycpp/NINJA_subgraph.py
@@ -140,6 +140,11 @@ TRANSLATE_FILES = {
         'mycpp/testpkg/module2.py',
         'mycpp/examples/modules.py',
     ],
+    'test_root_call_graph': [
+        'mycpp/testpkg/module1.py',
+        'mycpp/testpkg/module2.py',
+        'mycpp/examples/test_root_call_graph.py',
+    ],
     'parse': [],  # added dynamically from mycpp/examples/parse.translate.txt
 }
 

--- a/mycpp/cppgen_pass.py
+++ b/mycpp/cppgen_pass.py
@@ -765,7 +765,7 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
     def add_to_call_graph(self, o):
         full_callee = None
         if isinstance(o.callee, NameExpr):
-            full_callee = self.current_func_name
+            full_callee = o.callee.fullname
 
         elif isinstance(o.callee, MemberExpr):
             if isinstance(o.callee.expr, NameExpr):
@@ -832,6 +832,9 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
 
     def call_path_exists(self, src, dst, visited):
         """Do a DFS from src to dst. Returns true if a path was found."""
+
+        if self.decl or self.forward_decl:
+            return False
 
         visited.add(src)
         if src not in self.call_graph:

--- a/mycpp/cppgen_pass.py
+++ b/mycpp/cppgen_pass.py
@@ -2666,7 +2666,7 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
 
             # List of field mask expressions
             mask_bits = []
-            full_class_name = _StripMycpp(o.fullname)
+            full_class_name = _StripMycpp(o.fullname).replace('.', '::')
             if self.virtual.CanReorderFields(full_class_name):
                 # No inheritance, so we are free to REORDER member vars, putting
                 # pointers at the front.

--- a/mycpp/cppgen_pass.py
+++ b/mycpp/cppgen_pass.py
@@ -2521,6 +2521,10 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
         self.current_func_name = func_name
 
         if self.decl:
+            # For virtual methods, pretend that the method on the base class
+            # calls the same method on every subclass. This way call sites using
+            # the abstract base class will over-approximate the set of call paths
+            # they can take when checking if they can reach MaybeCollect().
             if self.virtual.IsVirtual(full_class_name, o.name):
                 key = (full_class_name, o.name)
                 base = self.virtual.virtuals[key]

--- a/mycpp/examples/test_root_call_graph.py
+++ b/mycpp/examples/test_root_call_graph.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python2
+"""
+container_types.py
+"""
+from __future__ import print_function
+
+import os
+
+from mycpp import mylib
+from mylib import log
+from testpkg import module1
+from typing import List
+
+
+def foo():
+    # type: () -> None
+    s = 'foo'
+    f = [] # type: List[str]
+    for i in xrange(1000):
+        f.append('a')
+
+    mylib.MaybeCollect()
+    print(f[1])
+    print(s)
+
+
+def bar():
+    # type: () -> str
+    print('bar')
+    return 'it works?'
+
+
+def baz():
+    # type: () -> None
+    foo()
+    print('baz')
+
+
+def from_import1():
+    # type: () -> None
+    module1.does_collect('a string')
+    print('it worked')
+
+
+def from_import2(cat):
+    # type: (module1.Cat) -> None
+    cat.ThingThatCollects()
+    print('it worked again')
+
+
+def run_tests():
+    # type: () -> None
+
+    foo()
+    bar()
+    baz()
+    from_import1()
+    cat = module1.Cat()
+    from_import2(cat)
+    module1.does_collect(bar())
+
+
+def run_benchmarks():
+    # type: () -> None
+    pass
+
+
+if __name__ == '__main__':
+    if os.getenv('BENCHMARK'):
+        log('Benchmarking...')
+        run_benchmarks()
+    else:
+        run_tests()

--- a/mycpp/examples/test_root_call_graph.py
+++ b/mycpp/examples/test_root_call_graph.py
@@ -12,6 +12,17 @@ from testpkg import module1
 from typing import List
 
 
+class Lion(module1.Cat):
+
+    def __init__(self):
+        # type: () -> None
+        pass
+
+    def AbstractMethod(self):
+        # type: () -> None
+        mylib.MaybeCollect()
+
+
 def DoesCollect():
     # type: () -> None
     s = 'foo'
@@ -88,12 +99,16 @@ def MainLoop(n):
     print('%d items remaining out of %d' % (m, n))
 
 
-def VirtualFunctionTest():
-    # type: () -> None
+def VirtualFunctionTest(cat):
+    # type: (module1.Cat) -> None
 
     # Not doing virtual functions yet.
 
-    MainLoop(1000)
+    int_list = [] # type: List[int]
+
+    cat.AbstractMethod()
+
+    int_list.append(1)
 
 
 def run_tests():
@@ -101,7 +116,9 @@ def run_tests():
 
     FunctionModuleTest()
 
-    VirtualFunctionTest()
+    MainLoop(1000)
+
+    VirtualFunctionTest(Lion())
 
 
 

--- a/mycpp/examples/test_root_call_graph.py
+++ b/mycpp/examples/test_root_call_graph.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python2
 """
-container_types.py
+test_root_call_graph.py
 """
 from __future__ import print_function
 
@@ -12,7 +12,7 @@ from testpkg import module1
 from typing import List
 
 
-def foo():
+def DoesCollect():
     # type: () -> None
     s = 'foo'
     f = [] # type: List[str]
@@ -32,7 +32,7 @@ def bar():
 
 def baz():
     # type: () -> None
-    foo()
+    DoesCollect()
     print('baz')
 
 
@@ -48,16 +48,61 @@ def from_import2(cat):
     print('it worked again')
 
 
-def run_tests():
+def FunctionModuleTest():
     # type: () -> None
-
-    foo()
+    DoesCollect()
     bar()
     baz()
     from_import1()
     cat = module1.Cat()
     from_import2(cat)
     module1.does_collect(bar())
+
+
+def DoWorkThatCollects(item):
+    # type: (str) -> None
+
+    mylib.MaybeCollect()
+
+
+def MainLoop(n):
+    # type: (int) -> None
+
+    # Create some strings
+    big_list = []  # type: List[str]
+    for i in xrange(n):
+        # quadratically sized
+        big_list.append('loop' * i)
+
+    for i, item in enumerate(big_list):
+        if i % 3 == 0:
+            big_list[i] = None
+
+        if i % 5 == 0:
+            DoWorkThatCollects(item)
+
+    m = 0
+    for item in big_list:
+        if item is not None:
+            m += 1
+    print('%d items remaining out of %d' % (m, n))
+
+
+def VirtualFunctionTest():
+    # type: () -> None
+
+    # Not doing virtual functions yet.
+
+    MainLoop(1000)
+
+
+def run_tests():
+    # type: () -> None
+
+    FunctionModuleTest()
+
+    VirtualFunctionTest()
+
 
 
 def run_benchmarks():

--- a/mycpp/mycpp_main.py
+++ b/mycpp/mycpp_main.py
@@ -343,7 +343,7 @@ def main(argv):
 
     if 0:
         with open('_tmp/mycpp_call_graph.json', 'w') as graph_f:
-            json.dump(call_graph, graph_f, indent=2)
+            json.dump(call_graph.graph, graph_f, indent=2)
 
     log('\tmycpp pass: IMPL')
 

--- a/mycpp/mycpp_main.py
+++ b/mycpp/mycpp_main.py
@@ -321,7 +321,7 @@ def main(argv):
 
     # First generate ALL C++ declarations / "headers".
     # class Foo { void method(); }; class Bar { void method(); };
-    call_graph = {'xxx':{}}
+    call_graph = pass_state.CallGraph()
     for name, module in to_compile:
         #log('decl name %s', name)
         if name in to_header:

--- a/mycpp/mycpp_main.py
+++ b/mycpp/mycpp_main.py
@@ -320,6 +320,7 @@ def main(argv):
 
     # First generate ALL C++ declarations / "headers".
     # class Foo { void method(); }; class Bar { void method(); };
+    call_graph = {}
     for name, module in to_compile:
         #log('decl name %s', name)
         if name in to_header:
@@ -337,6 +338,7 @@ def main(argv):
 
         p3.visit_mypy_file(module)
         MaybeExitWithErrors(p3)
+        call_graph.update(p3.call_graph)
 
     log('\tmycpp pass: IMPL')
 
@@ -350,7 +352,8 @@ def main(argv):
                                   local_vars=local_vars,
                                   fmt_ids=fmt_ids,
                                   field_gc=field_gc,
-                                  stack_roots_warn=opts.stack_roots_warn)
+                                  stack_roots_warn=opts.stack_roots_warn,
+                                  call_graph=call_graph)
         p4.visit_mypy_file(module)
         MaybeExitWithErrors(p4)
 

--- a/mycpp/mycpp_main.py
+++ b/mycpp/mycpp_main.py
@@ -321,7 +321,7 @@ def main(argv):
 
     # First generate ALL C++ declarations / "headers".
     # class Foo { void method(); }; class Bar { void method(); };
-    call_graph = {}
+    call_graph = {'xxx':{}}
     for name, module in to_compile:
         #log('decl name %s', name)
         if name in to_header:
@@ -335,11 +335,11 @@ def main(argv):
                                   fmt_ids=fmt_ids,
                                   field_gc=field_gc,
                                   virtual=virtual,
-                                  decl=True)
+                                  decl=True,
+                                  call_graph=call_graph)
 
         p3.visit_mypy_file(module)
         MaybeExitWithErrors(p3)
-        call_graph.update(p3.call_graph)
 
     if 0:
         with open('_tmp/mycpp_call_graph.json', 'w') as graph_f:

--- a/mycpp/mycpp_main.py
+++ b/mycpp/mycpp_main.py
@@ -4,6 +4,7 @@ mycpp_main.py - Translate a subset of Python to C++, using MyPy's typed AST.
 """
 from __future__ import print_function
 
+import json
 import optparse
 import os
 import sys
@@ -339,6 +340,10 @@ def main(argv):
         p3.visit_mypy_file(module)
         MaybeExitWithErrors(p3)
         call_graph.update(p3.call_graph)
+
+    if 0:
+        with open('_tmp/mycpp_call_graph.json', 'w') as graph_f:
+            json.dump(call_graph, graph_f, indent=2)
 
     log('\tmycpp pass: IMPL')
 

--- a/mycpp/pass_state_test.py
+++ b/mycpp/pass_state_test.py
@@ -37,7 +37,7 @@ class VirtualTest(unittest.TestCase):
         v.Calculate()
 
         print(v.virtuals)
-        self.assertEqual([('Base', 'method'), ('Derived', 'method')],
+        self.assertEqual({('Base', 'method'): None, ('Derived', 'method'): ('Base', 'method')},
                          v.virtuals)
 
         self.assertEqual(True, v.IsVirtual('Base', 'method'))

--- a/mycpp/pass_state_test.py
+++ b/mycpp/pass_state_test.py
@@ -84,5 +84,35 @@ class VirtualTest(unittest.TestCase):
         self.assertEqual(True, v.CanReorderFields('Klass2'))
 
 
+class CallGraphTest(unittest.TestCase):
+
+    def testCallGraph(self):
+        g = pass_state.CallGraph()
+
+        g.OnCall('a', 'b')
+        g.OnCall('b', 'c')
+        g.OnCall('b', 'd')
+        g.OnCall('d', 'd')
+        g.OnCall('e', 'f')
+
+        self.assertEqual(True, g.PathExists('a', 'b'))
+        self.assertEqual(True, g.PathExists('a', 'c'))
+        self.assertEqual(True, g.PathExists('a', 'd'))
+        self.assertEqual(True, g.PathExists('b', 'c'))
+        self.assertEqual(True, g.PathExists('b', 'd'))
+        self.assertEqual(True, g.PathExists('d', 'd'))
+        self.assertEqual(True, g.PathExists('e', 'f'))
+
+        self.assertEqual(False, g.PathExists('b', 'a'))
+        self.assertEqual(False, g.PathExists('c', 'a'))
+        self.assertEqual(False, g.PathExists('d', 'a'))
+        self.assertEqual(False, g.PathExists('e', 'a'))
+        self.assertEqual(False, g.PathExists('f', 'a'))
+        self.assertEqual(False, g.PathExists('c', 'b'))
+        self.assertEqual(False, g.PathExists('d', 'b'))
+        self.assertEqual(False, g.PathExists('e', 'b'))
+        self.assertEqual(False, g.PathExists('d', 'c'))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/mycpp/testpkg/module1.py
+++ b/mycpp/testpkg/module1.py
@@ -1,6 +1,9 @@
 """
 module1.py
 """
+from __future__ import print_function
+
+import mylib
 from mylib import log
 from testpkg import module2
 
@@ -29,8 +32,16 @@ class Cat(object):
     # type: () -> None
     log('cat')
 
+  def ThingThatCollects(self):
+    # type: () -> None
+    mylib.MaybeCollect()
+
   def AbstractMethod(self):
     # type: () -> None
     raise NotImplementedError()
 
 
+def does_collect(s):
+    # type: (str) -> None
+    print(s)
+    module2.func3()

--- a/mycpp/testpkg/module2.py
+++ b/mycpp/testpkg/module2.py
@@ -1,6 +1,7 @@
 """
 module2.py
 """
+import mylib
 from mylib import log
 
 CONST2 = 'CONST module2'
@@ -11,3 +12,7 @@ def func2():
 
   from testpkg import module1
   log(module1.CONST1)
+
+def func3():
+  # type: () -> None
+  mylib.MaybeCollect()


### PR DESCRIPTION
Most instances of `StackRoot` are unnecessary because they are created in functions where there is no danger of the garbage collector being invoked. This commit changes mycpp to construct a graph of function calls across the entire program and uses it to decide if `StackRoot`s are necessary for a given function. An directed edge `u -> v` means `u` calls `v`. Mycpp builds up this graph during the declaration pass, and passes it to the definition pass, which uses it to search for a path from the body of a function to `mylib.MaybeCollect`, only emitting `StackRoot`s if a path is found.

This reduces the number of stack roots by almost ~10x~ (**EDIT:  The new examples caught a bug. This is actually ~5x. The performance impact is about the same, though.**) and has a noticeable impact on the wall time of workloads like the CPython configure script (see reports below. ~1-2% or 10-150ms). It's important to note, though that this optimization only considers the static call graph. Many of  the remaining functions with `StackRoot`s are functions in the `CommandEvaluator` that are mutually recursive. Reducing overhead from those will require a different approach.

**stats from master**
```
+ perf stat -r 20 -o perf-output.txt taskset -a -c 2 /home/melvin/workdir/oil/_bin/cxx-opt/osh /home/melvin/workdir/oil/testdata/osh-runtime/bin_true.sh 1000

 Performance counter stats for 'taskset -a -c 2 /home/melvin/workdir/oil/_bin/cxx-opt/osh /home/melvin/workdir/oil/testdata/osh-runtime/bin_true.sh 1000' (20 runs):

          1,019.89 msec task-clock                       #    0.969 CPUs utilized               ( +-  0.03% )
             1,138      context-switches                 #    1.116 K/sec                       ( +-  0.12% )
                 1      cpu-migrations                   #    0.980 /sec
           136,557      page-faults                      #  133.893 K/sec
     2,103,559,764      cycles                           #    2.063 GHz                         ( +-  0.95% )  (97.96%)
     1,086,119,441      stalled-cycles-frontend          #   51.63% frontend cycles idle        ( +-  1.38% )  (97.01%)
       591,005,976      stalled-cycles-backend           #   28.10% backend cycles idle         ( +-  2.17% )  (88.98%)
     1,793,734,183      instructions                     #    0.85  insn per cycle
                                                  #    0.61  stalled cycles per insn     ( +-  1.33% )  (98.37%)
       409,963,765      branches                         #  401.967 M/sec                       ( +-  1.01% )  (98.49%)
         9,663,067      branch-misses                    #    2.36% of all branches             ( +-  1.02% )  (98.04%)

          1.052296 +- 0.000366 seconds time elapsed  ( +-  0.03% )
```

```
+ perf stat -r 10 -o perf-output.txt taskset -a -c 2 /home/melvin/workdir/oil/_bin/cxx-opt/osh /home/melvin/workdir/oil/Python-2.7.13/configure

 Performance counter stats for 'taskset -a -c 2 /home/melvin/workdir/oil/_bin/cxx-opt/osh /home/melvin/workdir/oil/Python-2.7.13/configure' (10 runs):

         23,876.67 msec task-clock                       #    0.990 CPUs utilized               ( +-  0.01% )
            15,161      context-switches                 #  634.971 /sec                        ( +-  0.17% )
                 1      cpu-migrations                   #    0.042 /sec
         2,036,884      page-faults                      #   85.309 K/sec                       ( +-  0.00% )
    54,840,613,270      cycles                           #    2.297 GHz                         ( +-  0.09% )  (86.61%)
    26,062,053,505      stalled-cycles-frontend          #   47.52% frontend cycles idle        ( +-  0.14% )  (86.72%)
    16,536,908,235      stalled-cycles-backend           #   30.15% backend cycles idle         ( +-  0.18% )  (72.95%)
    57,104,919,153      instructions                     #    1.04  insn per cycle
                                                  #    0.46  stalled cycles per insn     ( +-  0.07% )  (86.88%)
    11,921,483,800      branches                         #  499.294 M/sec                       ( +-  0.05% )  (86.92%)
       336,030,711      branch-misses                    #    2.82% of all branches             ( +-  0.09% )  (86.38%)

          24.11207 +- 0.00243 seconds time elapsed  ( +-  0.01% )
```

**stats from this branch**
```
+ perf stat -r 20 -o perf-output.txt taskset -a -c 2 /home/melvin/workdir/oil/_bin/cxx-opt/osh /home/melvin/workdir/oil/testdata/osh-runtime/bin_true.sh 1000

 Performance counter stats for 'taskset -a -c 2 /home/melvin/workdir/oil/_bin/cxx-opt/osh /home/melvin/workdir/oil/testdata/osh-runtime/bin_true.sh 1000' (20 runs):

          1,002.17 msec task-clock                       #    0.969 CPUs utilized               ( +-  0.05% )
             1,131      context-switches                 #    1.129 K/sec                       ( +-  0.13% )
                 0      cpu-migrations                   #    0.000 /sec
           134,551      page-faults                      #  134.260 K/sec
     2,048,454,210      cycles                           #    2.044 GHz                         ( +-  1.16% )  (97.09%)
     1,056,078,784      stalled-cycles-frontend          #   51.55% frontend cycles idle        ( +-  1.62% )  (97.11%)
       566,911,785      stalled-cycles-backend           #   27.68% backend cycles idle         ( +-  2.48% )  (89.54%)
     1,711,132,647      instructions                     #    0.84  insn per cycle
                                                  #    0.62  stalled cycles per insn     ( +-  1.63% )  (94.09%)
       406,395,132      branches                         #  405.516 M/sec                       ( +-  1.13% )  (99.02%)
         9,807,102      branch-misses                    #    2.41% of all branches             ( +-  0.62% )  (98.15%)

          1.034549 +- 0.000544 seconds time elapsed  ( +-  0.05% )
```

```
+ perf stat -r 10 -o perf-output.txt taskset -a -c 2 /home/melvin/workdir/oil/_bin/cxx-opt/osh /home/melvin/workdir/oil/Python-2.7.13/configure

 Performance counter stats for 'taskset -a -c 2 /home/melvin/workdir/oil/_bin/cxx-opt/osh /home/melvin/workdir/oil/Python-2.7.13/configure' (10 runs):

         23,715.08 msec task-clock                       #    0.990 CPUs utilized               ( +-  0.02% )
            15,137      context-switches                 #  638.286 /sec                        ( +-  0.27% )
                 0      cpu-migrations                   #    0.000 /sec
         2,023,000      page-faults                      #   85.304 K/sec                       ( +-  0.00% )
    54,591,018,618      cycles                           #    2.302 GHz                         ( +-  0.06% )  (86.59%)
    25,806,949,417      stalled-cycles-frontend          #   47.27% frontend cycles idle        ( +-  0.13% )  (86.94%)
    16,316,561,268      stalled-cycles-backend           #   29.89% backend cycles idle         ( +-  0.20% )  (72.63%)
    56,691,411,513      instructions                     #    1.04  insn per cycle
                                                  #    0.46  stalled cycles per insn     ( +-  0.06% )  (87.01%)
    11,871,229,727      branches                         #  500.577 M/sec                       ( +-  0.04% )  (86.41%)
       335,151,243      branch-misses                    #    2.82% of all branches             ( +-  0.11% )  (86.52%)

          23.95348 +- 0.00476 seconds time elapsed  ( +-  0.02% )
```