### PR TITLE
[fastfunc] Use the python2/oils string model in Utf8DecodeOne

### DIFF
--- a/cpp/data_lang.cc
+++ b/cpp/data_lang.cc
@@ -175,13 +175,6 @@ Tuple2<int, int> Utf8DecodeOne(BigStr* s, int start) {
     codepoint_or_error = decode_result.codepoint;
   }
 
-  // Follow the python2/oils string model. See func_Utf8DecodeOne in
-  // pyext/fastfunc.c for details.
-  if (decode_result.error == UTF8_ERR_END_OF_STREAM) {
-    codepoint_or_error = 0;
-    decode_result.bytes_read = 1;
-  }
-
   return Tuple2<int, int>(codepoint_or_error, decode_result.bytes_read);
 }
 

--- a/cpp/data_lang.cc
+++ b/cpp/data_lang.cc
@@ -162,7 +162,7 @@ BigStr* ShellEncodeString(BigStr* s, int ysh_fallback) {
 
 Tuple2<int, int> Utf8DecodeOne(BigStr* s, int start) {
   // Bounds check for safety
-  assert(0 <= start && start < len(s));
+  DCHECK(0 <= start && start < len(s));
 
   const unsigned char* string = reinterpret_cast<unsigned char*>(s->data());
 

--- a/cpp/data_lang_test.cc
+++ b/cpp/data_lang_test.cc
@@ -139,9 +139,6 @@ TEST utf8_decode_one_test() {
   ASSERT_DECODE(0x2840, 3, s, 1);
   ASSERT_DECODE(0x141, 2, s, 4);
 
-  // UTF8_ERR_END_OF_STREAM = 6
-  ASSERT_DECODE(-6, 0, s, 6);
-
   // UTF8_ERR_OVERLONG = 1
   ASSERT_DECODE(-1, 2, StrFromC("\xC1\x81"), 0);
 
@@ -156,6 +153,9 @@ TEST utf8_decode_one_test() {
 
   // UTF8_ERR_TRUNCATED_BYTES = 5
   ASSERT_DECODE(-5, 1, StrFromC("\xC2"), 0);
+
+  // Should follow the python2/oils string model wrt zero-bytes
+  ASSERT_DECODE(0, 1, StrFromC("\x00", 1), 0);
 
   PASS();
 #undef ASSERT_DECODE

--- a/cpp/data_lang_test.cc
+++ b/cpp/data_lang_test.cc
@@ -154,9 +154,6 @@ TEST utf8_decode_one_test() {
   // UTF8_ERR_TRUNCATED_BYTES = 5
   ASSERT_DECODE(-5, 1, StrFromC("\xC2"), 0);
 
-  // Should follow the python2/oils string model wrt zero-bytes
-  ASSERT_DECODE(0, 1, StrFromC("\x00", 1), 0);
-
   PASS();
 #undef ASSERT_DECODE
 }

--- a/data_lang/utf8.h
+++ b/data_lang/utf8.h
@@ -87,10 +87,11 @@ static inline void _cont(const unsigned char *input, Utf8Result_t *result) {
  * that string.
  *
  * It is required that `input` does not point to the nul-terminator. If
- * `*input = '\0'`, then it is assumed that the zero-byte is meant to encode
+ * `*input == '\0'`, then it is assumed that the zero-byte is meant to encode
  * U+00, not a sentinel. The nul-terminator is still necessary because we need
- * it to discriminate UTF8_ERR_TRUNCATED_BYTES from UTF8_ERR_BAD_ENCODING. This
- * oddity is to facilitate strings which may contain U+00 codepoints.
+ * it to prevent buffer overrun in the case of a truncated byte sequence, for
+ * example '\xC2'. This oddity is to facilitate strings which may contain U+00
+ * codepoints.
  *
  * If there was a surrogate, overlong or codepoint to large error then
  * `result.codepoint` will contain the recovered value.

--- a/data_lang/utf8.h
+++ b/data_lang/utf8.h
@@ -89,7 +89,7 @@ static inline void _cont(const unsigned char *input, Utf8Result_t *result) {
  * It is required that `input` does not point to the nul-terminator. If
  * `*input = '\0'`, then it is assumed that the zero-byte is meant to encode
  * U+00, not a sentinel. The nul-terminator is still necessary because we need
- * it to discrinate UTF8_ERR_TRUNCATED_BYTES from UTF8_ERR_BAD_ENCODING. This
+ * it to discriminate UTF8_ERR_TRUNCATED_BYTES from UTF8_ERR_BAD_ENCODING. This
  * oddity is to facilitate strings which may contain U+00 codepoints.
  *
  * If there was a surrogate, overlong or codepoint to large error then

--- a/data_lang/utf8_test.cc
+++ b/data_lang/utf8_test.cc
@@ -117,11 +117,6 @@ TEST truncated_test() {
     ASSERT_EQ(result.bytes_read, strlen(inputs[i]));
   }
 
-  // End of stream is separate from truncated
-  utf8_decode((unsigned char*)"", &result);
-  ASSERT_EQ(result.error, UTF8_ERR_END_OF_STREAM);
-  ASSERT_EQ(result.bytes_read, 0);
-
   PASS();
 }
 

--- a/osh/string_ops.py
+++ b/osh/string_ops.py
@@ -93,12 +93,6 @@ def DecodeUtf8Char(s, start):
     from {Next,Previous}Utf8Char which raises an `error.Strict` on encoding
     errors.)
     """
-    # The data_lang/utf8.h decoder treats nul-bytes as an end of string
-    # sentinel. However, they may not be the end of the string here. So we must
-    # special case the nul-byte.
-    if mylib.ByteAt(s, start) == 0:
-        return 0
-
     codepoint_or_error, _bytes_read = fastfunc.Utf8DecodeOne(s, start)
     if codepoint_or_error < 0:
         raise error.Expr(
@@ -116,10 +110,6 @@ def NextUtf8Char(s, i):
 
     Validates UTF-8.
     """
-    # Like in DecodeUtf8Char, this must be special-cased.
-    if mylib.ByteAt(s, i) == 0:
-        return 1
-
     codepoint_or_error, bytes_read = fastfunc.Utf8DecodeOne(s, i)
     if codepoint_or_error < 0:
         e_strict(

--- a/osh/string_ops.py
+++ b/osh/string_ops.py
@@ -42,7 +42,6 @@ UTF8_ERR_SURROGATE = -2  # Encodes a codepoint in the surrogate range (0xD800 to
 UTF8_ERR_TOO_LARGE = -3  # Encodes a value greater than the max codepoint U+10FFFF
 UTF8_ERR_BAD_ENCODING = -4  # Encoding doesn't conform to the UTF-8 bit patterns
 UTF8_ERR_TRUNCATED_BYTES = -5  # It looks like there is another codepoint, but it has been truncated
-UTF8_ERR_END_OF_STREAM = -6  # We are at the end of the string. (input_len = 0)
 
 
 def Utf8Error_str(error):
@@ -57,8 +56,6 @@ def Utf8Error_str(error):
         return "UTF-8 Error: Bad Encoding"
     if error == UTF8_ERR_TRUNCATED_BYTES:
         return "UTF-8 Error: Truncated Bytes"
-    if error == UTF8_ERR_END_OF_STREAM:
-        return "UTF-8 Error: End of Stream"
 
     raise AssertionError(0)
 

--- a/pyext/fastfunc.c
+++ b/pyext/fastfunc.c
@@ -102,8 +102,9 @@ func_Utf8DecodeOne(PyObject *self, PyObject *args) {
     codepoint_or_error = decode_result.codepoint;
   }
 
-  // utf8_decode treats zero-bytes as an end-of-string marker. But python2/oils
-  // strings do not. Translate END_OF_STREAM errors to valid zero-codepoints.
+  // utf8_decode treats zero-bytes as C-style NUL-terminators. But python2/oils
+  // strings treat these as zero-codepoints. Translate END_OF_STREAM errors
+  // (resulting from zero-bytes) to valid zero-codepoints.
   if (decode_result.error == UTF8_ERR_END_OF_STREAM) {
     codepoint_or_error = 0;
     decode_result.bytes_read = 1;  // Read past that zero-byte

--- a/pyext/fastfunc.c
+++ b/pyext/fastfunc.c
@@ -102,14 +102,6 @@ func_Utf8DecodeOne(PyObject *self, PyObject *args) {
     codepoint_or_error = decode_result.codepoint;
   }
 
-  // utf8_decode treats zero-bytes as C-style NUL-terminators. But python2/oils
-  // strings treat these as zero-codepoints. Translate END_OF_STREAM errors
-  // (resulting from zero-bytes) to valid zero-codepoints.
-  if (decode_result.error == UTF8_ERR_END_OF_STREAM) {
-    codepoint_or_error = 0;
-    decode_result.bytes_read = 1;  // Read past that zero-byte
-  }
-
   PyObject *ret_val = PyTuple_New(2);
   PyTuple_SET_ITEM(ret_val, 0, PyInt_FromLong(codepoint_or_error));
   PyTuple_SET_ITEM(ret_val, 1, PyInt_FromLong(decode_result.bytes_read));

--- a/pyext/fastfunc_test.py
+++ b/pyext/fastfunc_test.py
@@ -48,9 +48,6 @@ class FastfuncTest(unittest.TestCase):
     self.assertEqual((0x2840, 3), fastfunc.Utf8DecodeOne(s, 1))
     self.assertEqual((0x141, 2), fastfunc.Utf8DecodeOne(s, 4))
 
-    # UTF8_ERR_END_OF_STREAM = 6
-    self.assertEqual((-6, 0), fastfunc.Utf8DecodeOne(s, 6))
-
     # UTF8_ERR_OVERLONG = 1
     self.assertEqual((-1, 2), fastfunc.Utf8DecodeOne("\xC1\x81", 0))
 
@@ -65,6 +62,9 @@ class FastfuncTest(unittest.TestCase):
 
     # UTF8_ERR_TRUNCATED_BYTES = 5
     self.assertEqual((-5, 1), fastfunc.Utf8DecodeOne("\xC2", 0))
+
+    # Should follow the python2/oils string model wrt zero-bytes
+    self.assertEqual((0, 1), fastfunc.Utf8DecodeOne("\x00", 0))
 
   def testCanOmit(self):
     self.assertEqual(True, fastfunc.CanOmitQuotes('foo'))

--- a/pyext/fastfunc_test.py
+++ b/pyext/fastfunc_test.py
@@ -63,9 +63,6 @@ class FastfuncTest(unittest.TestCase):
     # UTF8_ERR_TRUNCATED_BYTES = 5
     self.assertEqual((-5, 1), fastfunc.Utf8DecodeOne("\xC2", 0))
 
-    # Should follow the python2/oils string model wrt zero-bytes
-    self.assertEqual((0, 1), fastfunc.Utf8DecodeOne("\x00", 0))
-
   def testCanOmit(self):
     self.assertEqual(True, fastfunc.CanOmitQuotes('foo'))
     self.assertEqual(False, fastfunc.CanOmitQuotes('foo bar'))

--- a/spec/ysh-methods.test.sh
+++ b/spec/ysh-methods.test.sh
@@ -318,7 +318,7 @@ status=0
 status=3
 ## END
 
-#### Str => trimStart(), unicode decoding incorrect
+#### Str => trimStart(), unicode decoding error types
 var badStrs = [
   b'\yF4\yA2\yA4\yB0',  # Too large of a codepoint
   b'\yED\yBF\y80',      # Surrogate
@@ -339,7 +339,7 @@ status=3
 status=3
 ## END
 
-#### Str => trimEnd(), unicode decoding incorrect
+#### Str => trimEnd(), unicode decoding error types
 # Tests the backwards UTF-8 decoder
 var badStrs = [
   b'\yF4\yA2\yA4\yB0',  # Too large of a codepoint
@@ -359,6 +359,16 @@ status=3
 status=3
 status=3
 status=3
+## END
+
+#### Str => trim*(), zero-codepoints are not NUL-terminators
+json write (b' \y00 ' => trim())
+json write (b' \y00 ' => trimStart())
+json write (b' \y00 ' => trimEnd())
+## STDOUT:
+"\u0000"
+"\u0000 "
+" \u0000"
 ## END
 
 #### Dict => keys()


### PR DESCRIPTION
Per the discussion in #1965, I've made the following updates:

- Made the `fastfunc.Utf8DecodeOne` "safe" by exposing the python2/oils string model (over the C one)
- Removed the NUL special casing in our `osh/string_ops.py` UTF-8 functions (`fastfunc.Utf8DecodeOne` now handles that)
- Added some tests to validate that string APIs like `Str => trim*()` are resilient to zero-codepoints