### PR TITLE
mycpp: avoid subclass name colissions

### DIFF
--- a/mycpp/cppgen_pass.py
+++ b/mycpp/cppgen_pass.py
@@ -18,7 +18,7 @@ from mypy.nodes import (Expression, Statement, NameExpr, IndexExpr, MemberExpr,
 
 from mycpp import format_strings
 from mycpp.crash import catch_errors
-from mycpp.util import log, join_name_cpp, split_py_name
+from mycpp.util import log, join_name, split_py_name
 from mycpp import util
 
 from typing import Tuple, List
@@ -2414,7 +2414,7 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
         if not self.decl and self.current_class_name:
             # definition looks like
             # void Class::method(...);
-            func_name = join_name_cpp((self.current_class_name[-1], o.name))
+            func_name = join_name((self.current_class_name[-1], o.name))
         else:
             # declaration inside class { }
             func_name = o.name
@@ -2502,7 +2502,8 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
 
             # e.g. class TextOutput : public ColorOutput
             if base_class_name:
-                self.always_write(' : public %s', join_name_cpp(base_class_name, True))
+                self.always_write(' : public %s', join_name(base_class_name,
+                                                            strip_package=True))
 
             self.always_write(' {\n')
             self.always_write_ind(' public:\n')
@@ -2582,7 +2583,7 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
                 # field mask.
                 if base_class_name:
                     mask_bits.append('%s::field_mask()' %
-                                     join_name_cpp(base_class_name, True))
+                                     join_name(base_class_name, strip_package=True))
 
                 for name in sorted(self.member_vars):
                     c_type = GetCType(self.member_vars[name])
@@ -2688,7 +2689,8 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
                                 callee.name == '__init__'):
                             base_constructor_args = expr.args
                             #log('ARGS %s', base_constructor_args)
-                            self.def_write(' : %s(', join_name_cpp(base_class_name, True))
+                            self.def_write(' : %s(', join_name(base_class_name,
+                                                               strip_package=True))
                             for i, arg in enumerate(base_constructor_args):
                                 if i == 0:
                                     continue  # Skip 'this'

--- a/mycpp/cppgen_pass.py
+++ b/mycpp/cppgen_pass.py
@@ -18,7 +18,7 @@ from mypy.nodes import (Expression, Statement, NameExpr, IndexExpr, MemberExpr,
 
 from mycpp import format_strings
 from mycpp.crash import catch_errors
-from mycpp.util import log
+from mycpp.util import log, join_name_cpp, split_py_name
 from mycpp import util
 
 from typing import Tuple, List
@@ -2414,7 +2414,7 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
         if not self.decl and self.current_class_name:
             # definition looks like
             # void Class::method(...);
-            func_name = '%s::%s' % (self.current_class_name, o.name)
+            func_name = join_name_cpp((self.current_class_name[-1], o.name))
         else:
             # declaration inside class { }
             func_name = o.name
@@ -2479,18 +2479,18 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
             if isinstance(b, NameExpr):
                 # TODO: inherit from std::exception?
                 if b.name != 'object' and b.name != 'Exception':
-                    base_class_name = b.name
+                    base_class_name = split_py_name(b.fullname)
             elif isinstance(b, MemberExpr):  # vm._Executor -> vm::_Executor
                 assert isinstance(b.expr, NameExpr), b
-                base_class_name = '%s::%s' % (b.expr.name, b.name)
+                base_class_name = split_py_name(b.expr.fullname) + (b.name,)
 
         # Forward declare types because they may be used in prototypes
         if self.forward_decl:
             self.always_write_ind('class %s;\n', o.name)
             if base_class_name:
-                self.virtual.OnSubclass(base_class_name, o.name)
+                self.virtual.OnSubclass(base_class_name, split_py_name(o.fullname))
             # Visit class body so we get method declarations
-            self.current_class_name = o.name
+            self.current_class_name = split_py_name(o.fullname)
             self._write_body(o.defs.body)
             self.current_class_name = None
             return
@@ -2502,7 +2502,7 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
 
             # e.g. class TextOutput : public ColorOutput
             if base_class_name:
-                self.always_write(' : public %s', base_class_name)
+                self.always_write(' : public %s', join_name_cpp(base_class_name, True))
 
             self.always_write(' {\n')
             self.always_write_ind(' public:\n')
@@ -2510,7 +2510,7 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
             block = o.defs
 
             self.indent += 1
-            self.current_class_name = o.name
+            self.current_class_name = split_py_name(o.fullname)
             for stmt in block.body:
 
                 # Ignore things that look like docstrings
@@ -2557,7 +2557,7 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
 
             # List of field mask expressions
             mask_bits = []
-            if self.virtual.CanReorderFields(o.name):
+            if self.virtual.CanReorderFields(split_py_name(o.name)):
                 # No inheritance, so we are free to REORDER member vars, putting
                 # pointers at the front.
 
@@ -2581,7 +2581,8 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
                 # The field mask of a derived class is unioned with its base's
                 # field mask.
                 if base_class_name:
-                    mask_bits.append('%s::field_mask()' % base_class_name)
+                    mask_bits.append('%s::field_mask()' %
+                                     join_name_cpp(base_class_name, True))
 
                 for name in sorted(self.member_vars):
                     c_type = GetCType(self.member_vars[name])
@@ -2649,7 +2650,7 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
 
             return
 
-        self.current_class_name = o.name
+        self.current_class_name = split_py_name(o.fullname)
 
         #
         # Now we're visiting for definitions (not declarations).
@@ -2687,7 +2688,7 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
                                 callee.name == '__init__'):
                             base_constructor_args = expr.args
                             #log('ARGS %s', base_constructor_args)
-                            self.def_write(' : %s(', base_class_name)
+                            self.def_write(' : %s(', join_name_cpp(base_class_name, True))
                             for i, arg in enumerate(base_constructor_args):
                                 if i == 0:
                                     continue  # Skip 'this'
@@ -2880,9 +2881,8 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
             if len(roots):
                 if (self.stack_roots_warn and
                         len(roots) > self.stack_roots_warn):
-                    log('WARNING: %s::%s() has %d stack roots. Consider refactoring this function.'
-                        % (self.current_class_name or
-                           '', self.current_func_node.name, len(roots)))
+                    log('WARNING: %s() has %d stack roots. Consider refactoring this function.'
+                        % (self.current_func_node.fullname, len(roots)))
 
                 for i, r in enumerate(roots):
                     self.def_write_ind('StackRoot _root%d(&%s);\n' % (i, r))

--- a/mycpp/cppgen_pass.py
+++ b/mycpp/cppgen_pass.py
@@ -2557,7 +2557,7 @@ class Generate(ExpressionVisitor[T], StatementVisitor[None]):
 
             # List of field mask expressions
             mask_bits = []
-            if self.virtual.CanReorderFields(split_py_name(o.name)):
+            if self.virtual.CanReorderFields(split_py_name(o.fullname)):
                 # No inheritance, so we are free to REORDER member vars, putting
                 # pointers at the front.
 

--- a/mycpp/pass_state.py
+++ b/mycpp/pass_state.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 
 from collections import defaultdict
 
-from mycpp.util import log
+from mycpp.util import log, SymbolPath
 
 from typing import Optional
 
@@ -18,17 +18,17 @@ class Virtual(object):
   """
 
     def __init__(self) -> None:
-        self.methods: dict[tuple[str], list[str]] = defaultdict(list)
-        self.subclasses: dict[tuple[str], list[tuple[str]]] = defaultdict(list)
-        self.virtuals: dict[tuple[tuple[str], str], Optional[tuple[str, str]]] = {}
-        self.has_vtable: dict[tuple[str], bool] = {}
-        self.can_reorder_fields: dict[tuple[str], bool] = {}
+        self.methods: dict[SymbolPath, list[str]] = defaultdict(list)
+        self.subclasses: dict[SymbolPath, list[tuple[str]]] = defaultdict(list)
+        self.virtuals: dict[tuple[SymbolPath, str], Optional[tuple[SymbolPath, str]]] = {}
+        self.has_vtable: dict[SymbolPath, bool] = {}
+        self.can_reorder_fields: dict[SymbolPath, bool] = {}
 
         # _Executor -> vm::_Executor
-        self.base_class_unique: dict[str, tuple[str]] = {}
+        self.base_class_unique: dict[str, SymbolPath] = {}
 
     # These are called on the Forward Declare pass
-    def OnMethod(self, class_name: tuple[str], method_name: str) -> None:
+    def OnMethod(self, class_name: SymbolPath, method_name: str) -> None:
         #log('OnMethod %s %s', class_name, method_name)
 
         # __init__ and so forth don't count
@@ -37,7 +37,7 @@ class Virtual(object):
 
         self.methods[class_name].append(method_name)
 
-    def OnSubclass(self, base_class: tuple[str], subclass: tuple[str]) -> None:
+    def OnSubclass(self, base_class: SymbolPath, subclass: SymbolPath) -> None:
         if len(base_class) > 1:
             # Hack for
             #
@@ -82,13 +82,13 @@ class Virtual(object):
                     self.has_vtable[subclass] = True
 
     # These is called on the Decl pass
-    def IsVirtual(self, class_name: tuple[str], method_name: str) -> bool:
+    def IsVirtual(self, class_name: SymbolPath, method_name: str) -> bool:
         return (class_name, method_name) in self.virtuals
 
-    def HasVTable(self, class_name: tuple[str]) -> bool:
+    def HasVTable(self, class_name: SymbolPath) -> bool:
         return class_name in self.has_vtable
 
-    def CanReorderFields(self, class_name: tuple[str]) -> bool:
+    def CanReorderFields(self, class_name: SymbolPath) -> bool:
         if class_name in self.can_reorder_fields:
             return self.can_reorder_fields[class_name]
         else:

--- a/mycpp/pass_state.py
+++ b/mycpp/pass_state.py
@@ -18,17 +18,17 @@ class Virtual(object):
   """
 
     def __init__(self) -> None:
-        self.methods: dict[str, list[str]] = defaultdict(list)
-        self.subclasses: dict[str, list[str]] = defaultdict(list)
-        self.virtuals: list[tuple[str, str]] = []
-        self.has_vtable: dict[str, bool] = {}
-        self.can_reorder_fields: dict[str, bool] = {}
+        self.methods: dict[tuple[str], list[str]] = defaultdict(list)
+        self.subclasses: dict[tuple[str], list[tuple[str]]] = defaultdict(list)
+        self.virtuals: dict[tuple[tuple[str], str], Optional[tuple[str, str]]] = {}
+        self.has_vtable: dict[tuple[str], bool] = {}
+        self.can_reorder_fields: dict[tuple[str], bool] = {}
 
         # _Executor -> vm::_Executor
-        self.base_class_unique: dict[str, str] = {}
+        self.base_class_unique: dict[str, tuple[str]] = {}
 
     # These are called on the Forward Declare pass
-    def OnMethod(self, class_name: str, method_name: str) -> None:
+    def OnMethod(self, class_name: tuple[str], method_name: str) -> None:
         #log('OnMethod %s %s', class_name, method_name)
 
         # __init__ and so forth don't count
@@ -37,27 +37,27 @@ class Virtual(object):
 
         self.methods[class_name].append(method_name)
 
-    def OnSubclass(self, base_class: str, subclass: str) -> None:
-        if '::' in base_class:
+    def OnSubclass(self, base_class: tuple[str], subclass: tuple[str]) -> None:
+        if len(base_class) > 1:
             # Hack for
             #
             # class _Executor: pass
             #   versus
             # class MyExecutor(vm._Executor): pass
-            base_key = base_class.split('::')[1]
+            base_key = base_class[-1]
 
             # Fail if we have two base classes in different namespaces with the same
             # name.
             if base_key in self.base_class_unique:
                 # Make sure we don't have collisions
-                assert self.base_class_unique[base_key] == base_class
+                assert self.base_class_unique[base_key] == base_class or base_class in self.subclasses[self.base_class_unique[base_key]], base_class
             else:
                 self.base_class_unique[base_key] = base_class
 
         else:
             base_key = base_class
 
-        self.subclasses[base_key].append(subclass)
+        self.subclasses[base_class].append(subclass)
 
     def Calculate(self) -> None:
         """
@@ -75,20 +75,20 @@ class Virtual(object):
                 s_methods = self.methods[subclass]
                 overlapping = set(b_methods) & set(s_methods)
                 for method in overlapping:
-                    self.virtuals.append((base_class, method))
-                    self.virtuals.append((subclass, method))
+                    self.virtuals[(base_class, method)] = None
+                    self.virtuals[(subclass, method)] = (base_class, method)
                 if overlapping:
                     self.has_vtable[base_class] = True
                     self.has_vtable[subclass] = True
 
     # These is called on the Decl pass
-    def IsVirtual(self, class_name: str, method_name: str) -> bool:
+    def IsVirtual(self, class_name: tuple[str], method_name: str) -> bool:
         return (class_name, method_name) in self.virtuals
 
-    def HasVTable(self, class_name: str) -> bool:
+    def HasVTable(self, class_name: tuple[str]) -> bool:
         return class_name in self.has_vtable
 
-    def CanReorderFields(self, class_name: str) -> bool:
+    def CanReorderFields(self, class_name: tuple[str]) -> bool:
         if class_name in self.can_reorder_fields:
             return self.can_reorder_fields[class_name]
         else:

--- a/mycpp/pass_state_test.py
+++ b/mycpp/pass_state_test.py
@@ -104,6 +104,9 @@ class VirtualTest(unittest.TestCase):
         self.assertEqual(
             (('moduleA', 'Base'), 'frobnicate'),
             v.virtuals[(('bar', 'Derived'), 'frobnicate')])
+        self.assertEqual(
+            None,
+            v.virtuals[(('moduleA', 'Base'), 'frobnicate')])
 
 
 class DummyFact(pass_state.Fact):

--- a/mycpp/pass_state_test.py
+++ b/mycpp/pass_state_test.py
@@ -28,37 +28,38 @@ class VirtualTest(unittest.TestCase):
         pass
     """
         v = pass_state.Virtual()
-        v.OnMethod('Base', 'method')
-        v.OnMethod('Base', 'x')
-        v.OnSubclass('Base', 'Derived')
-        v.OnMethod('Derived', 'method')
-        v.OnMethod('Derived', 'y')
+        v.OnMethod(('Base',), 'method')
+        v.OnMethod(('Base',), 'x')
+        v.OnSubclass(('Base',), ('Derived',))
+        v.OnMethod(('Derived',), 'method')
+        v.OnMethod(('Derived',), 'y')
 
         v.Calculate()
 
         print(v.virtuals)
-        self.assertEqual([('Base', 'method'), ('Derived', 'method')],
+        self.assertEqual({(('Base',), 'method'): None,
+                          (('Derived',), 'method'): (('Base',), 'method')},
                          v.virtuals)
 
-        self.assertEqual(True, v.IsVirtual('Base', 'method'))
-        self.assertEqual(True, v.IsVirtual('Derived', 'method'))
-        self.assertEqual(False, v.IsVirtual('Derived', 'y'))
+        self.assertEqual(True, v.IsVirtual(('Base',), 'method'))
+        self.assertEqual(True, v.IsVirtual(('Derived',), 'method'))
+        self.assertEqual(False, v.IsVirtual(('Derived',), 'y'))
 
-        self.assertEqual(False, v.IsVirtual('Klass', 'z'))
+        self.assertEqual(False, v.IsVirtual(('Klass',), 'z'))
 
-        self.assertEqual(True, v.HasVTable('Base'))
-        self.assertEqual(True, v.HasVTable('Derived'))
+        self.assertEqual(True, v.HasVTable(('Base',)))
+        self.assertEqual(True, v.HasVTable(('Derived',)))
 
-        self.assertEqual(False, v.HasVTable('Klass'))
+        self.assertEqual(False, v.HasVTable(('Klass',)))
 
     def testNoInit(self):
         v = pass_state.Virtual()
-        v.OnMethod('Base', '__init__')
-        v.OnSubclass('Base', 'Derived')
-        v.OnMethod('Derived', '__init__')
+        v.OnMethod(('Base',), '__init__')
+        v.OnSubclass(('Base',), ('Derived',))
+        v.OnMethod(('Derived',), '__init__')
         v.Calculate()
-        self.assertEqual(False, v.HasVTable('Base'))
-        self.assertEqual(False, v.HasVTable('Derived'))
+        self.assertEqual(False, v.HasVTable(('Base',)))
+        self.assertEqual(False, v.HasVTable(('Derived',)))
 
     def testCanReorderFields(self):
         """
@@ -75,13 +76,34 @@ class VirtualTest(unittest.TestCase):
     Note: we can't reorder these, even though there are no virtual methods.
     """
         v = pass_state.Virtual()
-        v.OnSubclass('Base2', 'Derived2')
+        v.OnSubclass(('Base2',), ('Derived2',))
         v.Calculate()
 
-        self.assertEqual(False, v.CanReorderFields('Base2'))
-        self.assertEqual(False, v.CanReorderFields('Derived2'))
+        self.assertEqual(False, v.CanReorderFields(('Base2',)))
+        self.assertEqual(False, v.CanReorderFields(('Derived2',)))
 
-        self.assertEqual(True, v.CanReorderFields('Klass2'))
+        self.assertEqual(True, v.CanReorderFields(('Klass2',)))
+
+    def testBaseCollision(self):
+        v = pass_state.Virtual()
+        v.OnSubclass(('moduleA', 'Base',), ('foo', 'Derived',))
+        with self.assertRaises(AssertionError):
+            v.OnSubclass(('moduleB', 'Base',), ('bar', 'Derived',))
+
+    def testSubclassMapping(self):
+        v = pass_state.Virtual()
+        v.OnMethod(('moduleA', 'Base',), 'frobnicate')
+        v.OnSubclass(('moduleA', 'Base',), ('foo', 'Derived',))
+        v.OnMethod(('foo', 'Derived',), 'frobnicate')
+        v.OnSubclass(('moduleA', 'Base',), ('bar', 'Derived',))
+        v.OnMethod(('bar', 'Derived',), 'frobnicate')
+        v.Calculate()
+        self.assertEqual(
+            (('moduleA', 'Base'), 'frobnicate'),
+            v.virtuals[(('foo', 'Derived'), 'frobnicate')])
+        self.assertEqual(
+            (('moduleA', 'Base'), 'frobnicate'),
+            v.virtuals[(('bar', 'Derived'), 'frobnicate')])
 
 
 class DummyFact(pass_state.Fact):

--- a/mycpp/util.py
+++ b/mycpp/util.py
@@ -14,22 +14,29 @@ from typing import Any
 
 SMALL_STR = False
 
+SymbolPath = tuple[str]
+
 
 def log(msg: str, *args: Any) -> None:
     if args:
         msg = msg % args
     print(msg, file=sys.stderr)
 
-def join_name_cpp(parts: tuple[str], strip_package:bool=False) -> str:
+def join_name(parts: SymbolPath, strip_package: bool = False, delim: str = '::') -> str:
+    """
+    Join the given name path into a string with the given delimiter.
+    Use strip_package to remove the top-level directory (e.g. `core`, `ysh`)
+    when dealing with C++ namespaces.
+    """
     if not strip_package:
-        return '::'.join(parts)
+        return delim.join(parts)
 
     if len(parts) > 1:
-        return '::'.join(('',) + parts[1:])
+        return delim.join(('',) + parts[1:])
 
     return parts[0]
 
-def split_py_name(name: str) -> tuple[str]:
+def split_py_name(name: str) -> SymbolPath:
     ret = tuple(name.split('.'))
     if len(ret) and ret[0] == 'mycpp':
         # Drop the prefix 'mycpp.' if present. This makes names compatible with

--- a/mycpp/util.py
+++ b/mycpp/util.py
@@ -19,3 +19,21 @@ def log(msg: str, *args: Any) -> None:
     if args:
         msg = msg % args
     print(msg, file=sys.stderr)
+
+def join_name_cpp(parts: tuple[str], strip_package:bool=False) -> str:
+    if not strip_package:
+        return '::'.join(parts)
+
+    if len(parts) > 1:
+        return '::'.join(('',) + parts[1:])
+
+    return parts[0]
+
+def split_py_name(name: str) -> tuple[str]:
+    ret = tuple(name.split('.'))
+    if len(ret) and ret[0] == 'mycpp':
+        # Drop the prefix 'mycpp.' if present. This makes names compatible with
+        # the examples that use testpkg.
+        return ret[1:]
+
+    return ret


### PR DESCRIPTION
Subclass names can collide, e.g. `builtin.func_misc.Type` and `builtin.meta_osh.Type` which share the base `core.vm._Callable`. This isn't a big deal until you need to query the subclass->base relationship, which a future commit will do.

This commit also changes `pass_state.Virtual.virtuals` into a mapping from (class, method) -> (base, method). If an entry maps to `None` that means the given method is part of the base class. This will allow a future commit to find the base for a given subclass.

The commit also changes mycpp to use fully-qualified class names when interacting with `pass_state.Virtual` to avoid ambiguity.