### PR TITLE
Fix monospace

### DIFF
--- a/doc/error-handling.md
+++ b/doc/error-handling.md
@@ -416,7 +416,7 @@ like a linter *at runtime*, so it can catch things that [ShellCheck][] can't.
 
 `strict_errexit` disallows code that exhibits these problems:
 
-1. The `if `myfunc` Pitfall
+1. The `if myfunc` Pitfall
 1. The `local x=$(false)` Pitfall
 
 See the appendix for examples of each.


### PR DESCRIPTION
I removed an extraneous backtick in the error handling docs.
(Great shell, by the way. I finally got around to rewriting some shebangs yesterday and today, and hey, it all just worked! Well, I had to fix some stuff that `strict:all` caught, but that's good. Keep it up!)