### PR TITLE
feat; errtrace shell option

### DIFF
--- a/builtin/trap_osh.py
+++ b/builtin/trap_osh.py
@@ -47,13 +47,16 @@ class TrapState(object):
         self.hooks = {}  # type: Dict[str, command_t]
         self.traps = {}  # type: Dict[int, command_t]
 
-    def ClearForSubProgram(self):
-        # type: () -> None
+    def ClearForSubProgram(self, inherit_errtrace):
+        # type: (bool) -> None
         """SubProgramThunk uses this because traps aren't inherited."""
 
         # bash clears DEBUG hook in subshell, command sub, etc.  See
         # spec/builtin-trap-bash.
+        handler = self.hooks.get('ERR', None)
         self.hooks.clear()
+        if handler and inherit_errtrace: self.hooks['ERR'] = handler
+
         self.traps.clear()
 
     def GetHook(self, hook_name):

--- a/core/executor.py
+++ b/core/executor.py
@@ -158,8 +158,8 @@ class ShellExecutor(vm._Executor):
         # type: () -> None
         assert self.cmd_ev is not None
 
-    def _MakeProcess(self, node, inherit_errexit=True):
-        # type: (command_t, bool) -> process.Process
+    def _MakeProcess(self, node, inherit_errexit, inherit_errtrace):
+        # type: (command_t, bool, bool) -> process.Process
         """Assume we will run the node in another process.
 
         Return a process.
@@ -189,7 +189,8 @@ class ShellExecutor(vm._Executor):
                                         node,
                                         self.trap_state,
                                         self.multi_trace,
-                                        inherit_errexit=inherit_errexit)
+                                        inherit_errexit,
+                                        inherit_errtrace)
         p = process.Process(thunk, self.job_control, self.job_list,
                             self.tracer)
         return p
@@ -396,7 +397,7 @@ class ShellExecutor(vm._Executor):
             pi = process.Pipeline(self.exec_opts.sigpipe_status_ok(),
                                   self.job_control, self.job_list, self.tracer)
             for child in node.children:
-                p = self._MakeProcess(child)
+                p = self._MakeProcess(child, True, self.exec_opts.errtrace())
                 p.Init_ParentPipeline(pi)
                 pi.Add(p)
 
@@ -412,7 +413,7 @@ class ShellExecutor(vm._Executor):
             # have to register SIGCHLD.  But then that introduces race conditions.
             # If we haven't called Register yet, then we won't know who to notify.
 
-            p = self._MakeProcess(node)
+            p = self._MakeProcess(node, True, self.exec_opts.errtrace())
             if self.job_control.Enabled():
                 p.AddStateChange(
                     process.SetPgid(process.OWN_LEADER, self.tracer))
@@ -440,7 +441,7 @@ class ShellExecutor(vm._Executor):
             # TODO: determine these locations at parse time?
             pipe_locs.append(loc.Command(child))
 
-            p = self._MakeProcess(child)
+            p = self._MakeProcess(child, True, self.exec_opts.errtrace())
             p.Init_ParentPipeline(pi)
             pi.Add(p)
 
@@ -459,7 +460,7 @@ class ShellExecutor(vm._Executor):
 
     def RunSubshell(self, node):
         # type: (command_t) -> int
-        p = self._MakeProcess(node)
+        p = self._MakeProcess(node, True, self.exec_opts.errtrace())
         if self.job_control.Enabled():
             p.AddStateChange(process.SetPgid(process.OWN_LEADER, self.tracer))
 
@@ -501,8 +502,7 @@ class ShellExecutor(vm._Executor):
                 # MUTATE redir node so it's like $(<file _cat)
                 redir_node.child = simple
 
-        p = self._MakeProcess(node,
-                              inherit_errexit=self.exec_opts.inherit_errexit())
+        p = self._MakeProcess(node, self.exec_opts.inherit_errexit(), self.exec_opts.errtrace())
         # Shell quirk: Command subs remain part of the shell's process group, so we
         # don't use p.AddStateChange(process.SetPgid(...))
 
@@ -607,7 +607,7 @@ class ShellExecutor(vm._Executor):
                 "Process subs not allowed here because status wouldn't be checked (strict_errexit)",
                 cs_loc)
 
-        p = self._MakeProcess(cs_part.child)
+        p = self._MakeProcess(cs_part.child, True, self.exec_opts.errtrace())
 
         r, w = posix.pipe()
         #log('pipe = %d, %d', r, w)

--- a/core/process.py
+++ b/core/process.py
@@ -824,13 +824,15 @@ class SubProgramThunk(Thunk):
                  node,
                  trap_state,
                  multi_trace,
-                 inherit_errexit=True):
-        # type: (CommandEvaluator, command_t, trap_osh.TrapState, dev.MultiTracer, bool) -> None
+                 inherit_errexit,
+                 inherit_errtrace):
+        # type: (CommandEvaluator, command_t, trap_osh.TrapState, dev.MultiTracer, bool, bool) -> None
         self.cmd_ev = cmd_ev
         self.node = node
         self.trap_state = trap_state
         self.multi_trace = multi_trace
         self.inherit_errexit = inherit_errexit  # for bash errexit compatibility
+        self.inherit_errtrace = inherit_errtrace  # for bash errtrace compatibility
 
     def UserString(self):
         # type: () -> str
@@ -851,7 +853,7 @@ class SubProgramThunk(Thunk):
         from osh import cmd_eval
 
         # signal handlers aren't inherited
-        self.trap_state.ClearForSubProgram()
+        self.trap_state.ClearForSubProgram(self.inherit_errtrace)
 
         # NOTE: may NOT return due to exec().
         if not self.inherit_errexit:

--- a/core/process_test.py
+++ b/core/process_test.py
@@ -71,7 +71,8 @@ class ProcessTest(unittest.TestCase):
                                      self.tracer)
         errfmt = ui.ErrorFormatter()
         self.fd_state = process.FdState(errfmt, self.job_control,
-                                        self.job_list, None, self.tracer, None)
+                                        self.job_list, None, self.tracer, None,
+                                        mutable_opts)
         self.ext_prog = process.ExternalProgram('', self.fd_state, errfmt,
                                                 util.NullDebugFile())
 

--- a/core/process_test.py
+++ b/core/process_test.py
@@ -182,9 +182,9 @@ class ProcessTest(unittest.TestCase):
         node2 = _CommandNode('head', self.arena)
         node3 = _CommandNode('sort --reverse', self.arena)
 
-        thunk1 = process.SubProgramThunk(cmd_ev, node1, self.trap_state, None)
-        thunk2 = process.SubProgramThunk(cmd_ev, node2, self.trap_state, None)
-        thunk3 = process.SubProgramThunk(cmd_ev, node3, self.trap_state, None)
+        thunk1 = process.SubProgramThunk(cmd_ev, node1, self.trap_state, None, True, False)
+        thunk2 = process.SubProgramThunk(cmd_ev, node2, self.trap_state, None, True, False)
+        thunk3 = process.SubProgramThunk(cmd_ev, node3, self.trap_state, None, True, False)
 
         p = process.Pipeline(False, self.job_control, self.job_list,
                              self.tracer)
@@ -222,8 +222,8 @@ class ProcessTest(unittest.TestCase):
         node1 = _CommandNode('/bin/echo testpipeline', self.arena)
         node2 = _CommandNode('cat', self.arena)
 
-        thunk1 = process.SubProgramThunk(cmd_ev, node1, self.trap_state, None)
-        thunk2 = process.SubProgramThunk(cmd_ev, node2, self.trap_state, None)
+        thunk1 = process.SubProgramThunk(cmd_ev, node1, self.trap_state, None, True, False)
+        thunk2 = process.SubProgramThunk(cmd_ev, node2, self.trap_state, None, True, False)
 
         pi.Add(Process(thunk1, jc, self.job_list, self.tracer))
         pi.Add(Process(thunk2, jc, self.job_list, self.tracer))

--- a/core/shell.py
+++ b/core/shell.py
@@ -416,7 +416,8 @@ def Main(
 
     job_control = process.JobControl()
     job_list = process.JobList()
-    fd_state = process.FdState(errfmt, job_control, job_list, mem, None, None)
+    fd_state = process.FdState(errfmt, job_control, job_list, mem, None, None,
+                               mutable_opts)
 
     my_pid = posix.getpid()
 

--- a/core/test_lib.py
+++ b/core/test_lib.py
@@ -213,7 +213,8 @@ def InitCommandEvaluator(parse_ctx=None,
     errfmt = ui.ErrorFormatter()
     job_control = process.JobControl()
     job_list = process.JobList()
-    fd_state = process.FdState(errfmt, job_control, job_list, None, None, None)
+    fd_state = process.FdState(errfmt, job_control, job_list, None, None, None,
+                               mutable_opts)
     aliases = {} if aliases is None else aliases
     procs = {}
     methods = {}

--- a/core/ui.py
+++ b/core/ui.py
@@ -420,6 +420,12 @@ class ErrorFormatter(object):
                            self._FallbackLocation(blame_loc),
                            show_code=False)
 
+    def PrintMessageEx(self, msg, show_code, blame_loc=None):
+        # type: (str, bool, loc_t) -> None
+        """Print a message WITHOUT quoting code."""
+        _PrintWithLocation('', msg, self._FallbackLocation(blame_loc),
+                           show_code)
+
     def StderrLine(self, msg):
         # type: (str) -> None
         """Just print to stderr."""

--- a/doc/ref/chap-option.md
+++ b/doc/ref/chap-option.md
@@ -101,6 +101,7 @@ These options are from bash.
 ## Other Option
 
     noclobber   # Redirects don't overwrite files
+    errtrace    # Inherits ERR trap in shell functions
 
 ## Compat
 

--- a/frontend/option_def.py
+++ b/frontend/option_def.py
@@ -384,7 +384,7 @@ PARSE_OPTION_NUMS = [opt.index for opt in _SORTED if opt.is_parse]
 
 # Sorted because 'shopt -o -p' should be sorted, etc.
 VISIBLE_SHOPT_NUMS = [
-    opt.index for opt in _SORTED if opt.builtin == 'shopt' and opt.implemented
+    opt.index for opt in _SORTED if opt.implemented
 ]
 
 YSH_UPGRADE = [opt.index for opt in _SORTED if 'ysh:upgrade' in opt.groups]

--- a/frontend/option_def.py
+++ b/frontend/option_def.py
@@ -67,6 +67,7 @@ _OTHER_SET_OPTIONS = [
     ('v', 'verbose'),  # like xtrace, but prints unevaluated commands
     ('f', 'noglob'),
     ('C', 'noclobber'),
+    ('E', 'errtrace'),
 
     # A no-op for modernish.
     (None, 'posix'),

--- a/opy/_regtest/src/core/state.py
+++ b/opy/_regtest/src/core/state.py
@@ -78,6 +78,7 @@ SET_OPTIONS = [
     ('x', 'xtrace'),
     ('f', 'noglob'),
     ('C', 'noclobber'),
+    ('E', 'errtrace'),
     ('h', 'hashall'),
     (None, 'pipefail'),
 
@@ -112,6 +113,7 @@ class ExecOpts(object):
     self.noglob = False  # -f
     self.noexec = False  # -n
     self.noclobber = False  # -C
+    self.errtrace = False  # -E
     # We don't do anything with this yet.  But Aboriginal calls 'set +h'.
     self.hashall = True  # -h is true by default.
 

--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -1481,12 +1481,15 @@ class CommandEvaluator(object):
         if status == 0:
             self.shell_ex.PushRedirects(redirects, io_errors)
             if len(io_errors):
-                # core/process.py prints cryptic errors, so we repeat them
-                # here.  e.g. Bad File Descriptor
-                self.errfmt.PrintMessage(
-                    'I/O error applying redirect: %s' %
-                    pyutil.strerror(io_errors[0]),
-                    self.mem.GetFallbackLocation())
+                # if errno is 0, error has already printed
+                if io_errors[0].errno:
+                    # core/process.py prints cryptic errors, so we repeat them
+                    # here.  e.g. Bad File Descriptor
+                    self.errfmt.PrintMessageEx(
+                        'I/O redirect error: %s' %
+                        pyutil.strerror(io_errors[0]),
+                        self.mutable_opts.Get(option_i.verbose_errexit),
+                        self.mem.GetFallbackLocation())
                 status = 1
 
         # If we applied redirects successfully, run the command_t, and pop

--- a/osh/word_eval.py
+++ b/osh/word_eval.py
@@ -448,6 +448,8 @@ def _GetDollarHyphen(exec_opts):
         chars.append('x')
     if exec_opts.noclobber():
         chars.append('C')
+    if exec_opts.errtrace():
+        chars.append('E')
 
     # bash has:
     # - c for sh -c, i for sh -i (mksh also has this)

--- a/spec/builtin-trap-bash.test.sh
+++ b/spec/builtin-trap-bash.test.sh
@@ -555,3 +555,37 @@ g
 return-helper.sh
 profile [x y]
 ## END
+
+
+#### trap ERR with errtrace (-E)
+# ERR trap is not inherited by shell functions unless the -o errtrace option is set
+set -E
+trap "echo ERR" ERR
+echo 0
+false
+echo 1
+cat <( date X ; echo 2 )
+echo $( date X ; echo 3 )
+{ date X ; echo 4 ; }
+{ date X ; echo 5 ; } & wait
+( date X ; echo 6 ; )
+true
+## status: 0
+## stdout-json: "0\nERR\n1\nERR\n2\nERR 3\nERR\n4\nERR\n5\nERR\n6\n"
+
+
+#### trap ERR without errtrace (+E)
+# ERR trap is not inherited by shell functions unless the -o errtrace option is set
+set +E
+trap "echo ERR" ERR
+echo 0
+false
+echo 1
+cat <( date X ; echo 2 )
+echo $( date X ; echo 3 )
+{ date X ; echo 4 ; }
+{ date X ; echo 5 ; } & wait
+( date X ; echo 6 ; )
+true
+## status: 0
+## stdout-json: "0\nERR\n1\n2\n3\nERR\n4\n5\n6\n"

--- a/spec/redirect.test.sh
+++ b/spec/redirect.test.sh
@@ -1,4 +1,4 @@
-## oils_failures_allowed: 2
+## oils_failures_allowed: 1
 ## compare_shells: bash dash mksh
 
 #### >& and <& are the same

--- a/spec/sh-options.test.sh
+++ b/spec/sh-options.test.sh
@@ -1,7 +1,7 @@
 # Test set flags, sh flags.
 
 ## compare_shells: bash dash mksh
-## oils_failures_allowed: 2
+## oils_failures_allowed: 1
 ## tags: interactive
 
 #### $- with -c

--- a/spec/var-sub.test.sh
+++ b/spec/var-sub.test.sh
@@ -9,7 +9,7 @@ echo ${a&}
 
 #### Braced block inside ${}
 # NOTE: This bug was in bash 4.3 but fixed in bash 4.4.
-echo ${foo:-$({ which ls; })}
+echo ${foo:-$({ ls /bin/ls; })}
 ## stdout: /bin/ls
 
 #### Nested ${} 

--- a/spec/ysh-builtin-shopt.test.sh
+++ b/spec/ysh-builtin-shopt.test.sh
@@ -88,21 +88,25 @@ shopt --set strict:all {
 
 ## STDOUT:
 shopt -u command_sub_errexit
+shopt -u errexit
 shopt -u inherit_errexit
 shopt -u strict_errexit
 shopt -u verbose_errexit
 ---
 shopt -s command_sub_errexit
+shopt -s errexit
 shopt -s inherit_errexit
 shopt -s strict_errexit
 shopt -s verbose_errexit
 ---
 shopt -s command_sub_errexit
+shopt -s errexit
 shopt -s inherit_errexit
 shopt -u strict_errexit
 shopt -s verbose_errexit
 ---
 shopt -u command_sub_errexit
+shopt -u errexit
 shopt -u inherit_errexit
 shopt -s strict_errexit
 shopt -u verbose_errexit

--- a/test/sh_spec.py
+++ b/test/sh_spec.py
@@ -1395,9 +1395,10 @@ def main(argv):
   # spec/smoke.test.sh -> smoke
   test_name = os.path.basename(test_file).split('.')[0]
 
-  allowed = opts.oils_failures_allowed
+  multiplier = 2 if opts.oils_cpp_bin_dir else 1
+  allowed = opts.oils_failures_allowed * multiplier
   all_count = stats.Get('num_failed')
-  oils_count = stats.Get('oils_num_failed')
+  oils_count = stats.Get('oils_num_failed') * multiplier
   if allowed == 0:
     log('')
     log('%s: FATAL: %d tests failed (%d oils failures)', test_name, all_count,


### PR DESCRIPTION
Additional fixes for;:
- shopt -o: show all options, like bash
- refactoring: as it is not possible to have 2 optional args, I added missing args where needed
- *2 on spec-cpp counts as there are 2 tests so comparison was wrong

Also note dash/ash does not time builtin, some tests may be removed for them.
