### PR TITLE
Fixes spec cpp counts

### DIFF
--- a/spec/var-sub.test.sh
+++ b/spec/var-sub.test.sh
@@ -9,7 +9,7 @@ echo ${a&}
 
 #### Braced block inside ${}
 # NOTE: This bug was in bash 4.3 but fixed in bash 4.4.
-echo ${foo:-$({ which ls; })}
+echo ${foo:-$({ ls /bin/ls; })}
 ## stdout: /bin/ls
 
 #### Nested ${} 

--- a/test/sh_spec.py
+++ b/test/sh_spec.py
@@ -79,7 +79,8 @@ OTHER_OSH = ('osh_ALT',)
 YSH_CPYTHON = ('ysh', 'ysh-dbg')
 OTHER_YSH = ('oil_ALT',)
 
-# Forw now, only count the Oils CPython failures
+# For now, only count the Oils CPython failures.  TODO: the spec-cpp job should
+# assert the osh-cpp and ysh-cpp deltas.
 OTHER_OILS = OTHER_OSH + OTHER_YSH + ('osh-cpp', 'ysh-cpp')
 
 

--- a/test/sh_spec.py
+++ b/test/sh_spec.py
@@ -1395,9 +1395,10 @@ def main(argv):
   # spec/smoke.test.sh -> smoke
   test_name = os.path.basename(test_file).split('.')[0]
 
-  allowed = opts.oils_failures_allowed
+  multiplier = 2 if opts.oils_cpp_bin_dir else 1
+  allowed = opts.oils_failures_allowed * multiplier
   all_count = stats.Get('num_failed')
-  oils_count = stats.Get('oils_num_failed')
+  oils_count = stats.Get('oils_num_failed') * multiplier
   if allowed == 0:
     log('')
     log('%s: FATAL: %d tests failed (%d oils failures)', test_name, all_count,

--- a/test/sh_spec.py
+++ b/test/sh_spec.py
@@ -79,6 +79,9 @@ OTHER_OSH = ('osh_ALT',)
 YSH_CPYTHON = ('ysh', 'ysh-dbg')
 OTHER_YSH = ('oil_ALT',)
 
+# Forw now, only count the Oils CPython failures
+OTHER_OILS = OTHER_OSH + OTHER_YSH + ('osh-cpp', 'ysh-cpp')
+
 
 class ParseError(Exception):
   pass
@@ -565,7 +568,7 @@ class Stats(object):
     elif cell_result == Result.FAIL:
       # Special logic: don't count osh_ALT because its failures will be
       # counted in the delta.
-      if sh_label not in OTHER_OSH + OTHER_YSH:
+      if sh_label not in OTHER_OILS:
         c['num_failed'] += 1
 
       if sh_label in OSH_CPYTHON + YSH_CPYTHON:
@@ -1395,10 +1398,9 @@ def main(argv):
   # spec/smoke.test.sh -> smoke
   test_name = os.path.basename(test_file).split('.')[0]
 
-  multiplier = 2 if opts.oils_cpp_bin_dir else 1
-  allowed = opts.oils_failures_allowed * multiplier
+  allowed = opts.oils_failures_allowed
   all_count = stats.Get('num_failed')
-  oils_count = stats.Get('oils_num_failed') * multiplier
+  oils_count = stats.Get('oils_num_failed')
   if allowed == 0:
     log('')
     log('%s: FATAL: %d tests failed (%d oils failures)', test_name, all_count,


### PR DESCRIPTION
Without the fix, the following fails with:

```
ysh-builtin-shopt: FATAL: Got 2 failures (1 oils failures), but 1 are allowed
```

With the fix, it is fine, as both osh python and osh native works the same.

```
$ test/spec-cpp.sh run-file ysh-builtin-shopt
ysh-builtin-shopt.test.sh
case    line    osh     osh-cpp
  0       3     pass    pass    shopt supports long flags
  1      17     pass    pass    shopt supports 'set' options
  2      30     pass    pass    shopt --unset errexit { }
  3      51     pass    pass    shopt -p works correctly inside block
  4      65     pass    pass    shopt --set GROUP { }
  5     111     pass    pass    shopt and block status
  6     124     pass    pass    shopt usage error
  7     137     pass    pass    shopt -p
  8     162     FAIL    FAIL    TODO: all options as a table

                osh     osh-cpp
        pass    8       8
        FAIL    1       1
        total   9       9
ysh-builtin-shopt: note: Got 2 allowed oils failures (exit with code 0)
```
