### PR TITLE
shopt -p and -o compatibility with bash

### DIFF
--- a/builtin/pure_osh.py
+++ b/builtin/pure_osh.py
@@ -169,7 +169,7 @@ class Set(vm._Builtin):
         # 'set -o' shows options.  This is actually used by autoconf-generated
         # scripts!
         if arg.show_options:
-            self.exec_opts.ShowOptions([])
+            self.exec_opts.ShowOptions([], False)
             return 0
 
         # Note: set -o nullglob is not valid.  The 'shopt' builtin is preferred in
@@ -193,12 +193,12 @@ class Shopt(vm._Builtin):
         self.mutable_opts = mutable_opts
         self.cmd_ev = cmd_ev
 
-    def _PrintOptions(self, use_set_opts, opt_names):
+    def _PrintOptions(self, use_set_opts, as_command, opt_names):
         # type: (bool, List[str]) -> None
         if use_set_opts:
-            self.mutable_opts.ShowOptions(opt_names)
+            self.mutable_opts.ShowOptions(opt_names, as_command)
         else:
-            self.mutable_opts.ShowShoptOptions(opt_names)
+            self.mutable_opts.ShowShoptOptions(opt_names, as_command)
 
     def Run(self, cmd_val):
         # type: (cmd_value.Argv) -> int
@@ -223,10 +223,10 @@ class Shopt(vm._Builtin):
         elif arg.u:
             b = False
         elif arg.p:  # explicit -p
-            self._PrintOptions(arg.o, opt_names)
+            self._PrintOptions(arg.o, arg.p, opt_names)
             return 0
         else:  # otherwise -p is implicit
-            self._PrintOptions(arg.o, opt_names)
+            self._PrintOptions(arg.o, arg.p, opt_names)
             return 0
 
         # shopt --set x { my-block }

--- a/builtin/pure_osh.py
+++ b/builtin/pure_osh.py
@@ -194,7 +194,7 @@ class Shopt(vm._Builtin):
         self.cmd_ev = cmd_ev
 
     def _PrintOptions(self, use_set_opts, as_command, opt_names):
-        # type: (bool, List[str]) -> None
+        # type: (bool, bool, List[str]) -> None
         if use_set_opts:
             self.mutable_opts.ShowOptions(opt_names, as_command)
         else:

--- a/core/shell.py
+++ b/core/shell.py
@@ -357,8 +357,9 @@ def Main(
     state.InitMem(mem, environ, version_str)
 
     if attrs.show_options:  # special case: sh -o
-        mutable_opts.ShowOptions([])
-        return 0
+        mutable_opts.ShowOptions([], False)
+        # removed return as sh -o does not return
+        # return 0
 
     # Set these BEFORE processing flags, so they can be overridden.
     if lang == 'ysh':

--- a/core/state.py
+++ b/core/state.py
@@ -670,9 +670,9 @@ class MutableOpts(object):
 
         self._SetArrayByNum(opt_num, b)
 
-    def ShowOptions(self, opt_names):
-        # type: (List[str]) -> None
-        """For 'set -o' and 'shopt -p -o'."""
+    def ShowOptions(self, opt_names, as_command):
+        # type: (List[str], bool) -> None
+        """For 'set -o' and 'shopt -p -o' and 'shopt -o'."""
         # TODO: Maybe sort them differently?
 
         if len(opt_names) == 0:  # if none, supplied, show all
@@ -681,9 +681,12 @@ class MutableOpts(object):
         for opt_name in opt_names:
             opt_num = _SetOptionNum(opt_name)
             b = self.Get(opt_num)
-            print('set %so %s' % ('-' if b else '+', opt_name))
+            if as_command:
+                print('set %so %s' % ('-' if b else '+', opt_name))
+            else:
+                print('%-16s\t%s' % (opt_name, 'on' if b else 'off'))
 
-    def ShowShoptOptions(self, opt_names):
+    def ShowShoptOptions(self, opt_names, as_command):
         # type: (List[str]) -> None
         """For 'shopt -p'."""
 
@@ -712,8 +715,10 @@ class MutableOpts(object):
 
         for opt_num in opt_nums:
             b = self.Get(opt_num)
-            print('shopt -%s %s' %
-                  ('s' if b else 'u', consts.OptionName(opt_num)))
+            if as_command:
+                print('shopt -%s %s' % ('s' if b else 'u', consts.OptionName(opt_num)))
+            else:
+                print('%-20s\t%s' % (consts.OptionName(opt_num), 'on' if b else 'off', ))
 
 
 class _ArgFrame(object):

--- a/core/state.py
+++ b/core/state.py
@@ -687,7 +687,7 @@ class MutableOpts(object):
                 print('%-16s\t%s' % (opt_name, 'on' if b else 'off'))
 
     def ShowShoptOptions(self, opt_names, as_command):
-        # type: (List[str]) -> None
+        # type: (List[str], bool) -> None
         """For 'shopt -p'."""
 
         # Respect option groups.

--- a/spec/builtin-shopt-bash.test.sh
+++ b/spec/builtin-shopt-bash.test.sh
@@ -1,0 +1,24 @@
+## compare_shells: bash
+## oils_failures_allowed: 0
+
+# builtin-shopt-bash.test.sh
+
+#### shopt
+shopt | grep inherit_errexit | tr -d ' '
+## stdout-json: "inherit_errexit\toff\n"
+
+#### shopt -p
+shopt -p | grep inherit_errexit
+## STDOUT:
+shopt -u inherit_errexit
+## END
+
+#### shopt -o
+shopt -o | grep errexit | tr -d ' '
+## stdout-json: "errexit\toff\n"
+
+#### shopt -p -o
+shopt -p -o | grep errexit
+## STDOUT:
+set +o errexit
+## END

--- a/test/spec.sh
+++ b/test/spec.sh
@@ -251,6 +251,10 @@ builtin-trap-bash() {
   run-file builtin-trap-bash "$@"
 }
 
+builtin-shopt-bash() {
+  run-file builtin-shopt-bash "$@"
+}
+
 # Bash implements type -t, but no other shell does.  For Nix.
 # zsh/mksh/dash don't have the 'help' builtin.
 builtin-bash() {


### PR DESCRIPTION
-o changes which settings are displayed
-p display commands instead of a table

In hope this is now the correct behavior.