### PR TITLE
[mycpp] share if-statement special cases with all visitors

### DIFF
--- a/mycpp/cppgen_pass.py
+++ b/mycpp/cppgen_pass.py
@@ -13,8 +13,8 @@ from mypy.types import (Type, AnyType, NoneTyp, TupleType, Instance, NoneType,
                         PartialType, TypeAliasType)
 from mypy.nodes import (Expression, Statement, NameExpr, IndexExpr, MemberExpr,
                         TupleExpr, ExpressionStmt, IfStmt, StrExpr, SliceExpr,
-                        FuncDef, UnaryExpr, OpExpr, ComparisonExpr, CallExpr,
-                        IntExpr, ListExpr, DictExpr, ListComprehension)
+                        FuncDef, UnaryExpr, OpExpr, CallExpr,
+                        ListExpr, DictExpr, ListComprehension)
 
 from mycpp import format_strings
 from mycpp.crash import catch_errors

--- a/mycpp/ir_pass.py
+++ b/mycpp/ir_pass.py
@@ -94,6 +94,6 @@ class Build(SimpleVisitor):
 
         else:
             self.dot_exprs[o] = pass_state.HeapObjectMember(
-                o.expr, self.types.get(o.expr), o.name)
+                o.expr, self.types[o.expr], o.name)
 
         self.accept(o.expr)

--- a/mycpp/pass_state.py
+++ b/mycpp/pass_state.py
@@ -47,7 +47,7 @@ class HeapObjectMember(object):
     e.g foo.empty() => foo->empty()
     """
 
-    def __init__(self, object_expr: Expression, object_type: Optional[Type],
+    def __init__(self, object_expr: Expression, object_type: Type,
                  member: str) -> None:
         self.ojbect_expr = object_expr
         self.object_type = object_type

--- a/mycpp/visitor.py
+++ b/mycpp/visitor.py
@@ -6,7 +6,7 @@ from typing import overload, Union, Optional
 import mypy
 from mypy.visitor import ExpressionVisitor, StatementVisitor
 from mypy.nodes import (Expression, Statement, ExpressionStmt, StrExpr,
-                        CallExpr, NameExpr)
+                        CallExpr)
 
 from mycpp.crash import catch_errors
 from mycpp.util import split_py_name

--- a/mycpp/visitor.py
+++ b/mycpp/visitor.py
@@ -139,16 +139,15 @@ class SimpleVisitor(ExpressionVisitor[T], StatementVisitor[None]):
             self.accept(o.expr)
 
     def visit_if_stmt(self, o: 'mypy.nodes.IfStmt') -> T:
-        if util.MaybeSkipIfStmt(self, o):
-            return
+        if util.ShouldVisitIfExpr(o):
+            for expr in o.expr:
+                self.accept(expr)
 
-        for expr in o.expr:
-            self.accept(expr)
+        if util.ShouldVisitIfBody(o):
+            for body in o.body:
+                self.accept(body)
 
-        for body in o.body:
-            self.accept(body)
-
-        if o.else_body:
+        if util.ShouldVisitElseBody(o):
             self.accept(o.else_body)
 
     def visit_raise_stmt(self, o: 'mypy.nodes.RaiseStmt') -> T:

--- a/mycpp/visitor.py
+++ b/mycpp/visitor.py
@@ -139,10 +139,7 @@ class SimpleVisitor(ExpressionVisitor[T], StatementVisitor[None]):
             self.accept(o.expr)
 
     def visit_if_stmt(self, o: 'mypy.nodes.IfStmt') -> T:
-        # Omit if TYPE_CHECKING blocks.  They contain type expressions that
-        # don't type check!
-        cond = o.expr[0]
-        if isinstance(cond, NameExpr) and cond.name == 'TYPE_CHECKING':
+        if util.MaybeSkipIfStmt(self, o):
             return
 
         for expr in o.expr:


### PR DESCRIPTION
The `SimpleVisitor` base class was missing these before. This was causing `ir_pass` to run into various collisions that `cppgen_pass` wasn't. Fixing this allows us to make `HeapObjectMember` more strict, which simplifies the next datalog patch.