### PR TITLE
add +/- annotations to jobs builtin

### DIFF
--- a/core/process.py
+++ b/core/process.py
@@ -1019,6 +1019,7 @@ class Process(Job):
         if job_id == -1:
             job_id_str = '  '
         else:
+            # Use the %1 syntax
             job_id_str = '%%%d%s' % (job_id, extra)
         if style == STYLE_PID_ONLY:
             f.write('%d\n' % self.pid)
@@ -1779,8 +1780,7 @@ class JobList(object):
         f = mylib.Stdout()
         current, previous = self.GetCurrentAndPreviousJobs()
         for job_id, job in iteritems(self.jobs):
-            # Use the %1 syntax
-            extra = ''
+            extra = ' '
             if current and current.job_id == job_id:
                 extra = '+'
 


### PR DESCRIPTION
A small quality of life improvement for job control. @andychu brought this up in https://oilshell.zulipchat.com/#narrow/stream/121540-oil-discuss/topic/Job.20control.20hard.20to.20understand

```
[I] osh-0.22.0$ cat
^Z
[PID 489245] Stopped with signal 20
[I] osh-0.22.0$ cat
^Z
[PID 489246] Stopped with signal 20
[I] osh-0.22.0$ cat
^Z
[PID 489247] Stopped with signal 20
[I] osh-0.22.0$ jobs
%1 489245 Stopped [process] cat
%2- 489246 Stopped [process] cat
%3+ 489247 Stopped [process] cat
```