### PR TITLE
spell out the "special default" of trim() and whitespace contexts

### DIFF
--- a/doc/ref/chap-type-method.md
+++ b/doc/ref/chap-type-method.md
@@ -280,7 +280,7 @@ only the ones above, so that these methods have a stable specification.
 Note that Eggex patterns compile to POSIX extended regular expressions (ERE),
 which have a different notion of whitespace:
 
-- `/blank/` matches: `\t`, or a normal blank space `' '`     (blank line-elements)
+- `/blank/` matches: `\t`, or a normal blank space `' '`     (blank line elements)
 - `/space/` matches: `\t \n`, vertical tab, `\f \r`, or a normal blank space `' '`,
   possibly Unicode separators `\p{Z}`   (two-dimensional, horiz./vert. whitespace)
 


### PR DESCRIPTION
* emphasize the special case of the trim() default
* refer to "blank space" for "normal space" to show its connection to /blank/
  (wording as in wikipedia: "U+0020 represents blank space" https://en.wikipedia.org/wiki/Whitespace_character)
* up-front "unicode" in referring sentence