### PR TITLE
aports: add interactive mode

### DIFF
--- a/regtest/aports-common.sh
+++ b/regtest/aports-common.sh
@@ -9,6 +9,8 @@ readonly BASE_DIR=_tmp/aports-build
 # For localhost
 readonly REPORT_DIR=_tmp/aports-report
 
+readonly INTERACTIVE="${INTERACTIVE:-}"
+
 concat-task-tsv() {
   local config=${1:-baseline}
   python3 devtools/tsv_concat.py \

--- a/regtest/aports-run.sh
+++ b/regtest/aports-run.sh
@@ -276,6 +276,17 @@ build-package-overlayfs() {
   regtest/aports-guest.sh build-package2 "$@"
   ' dummy0 "$pkg"
 
+  if test ! -z "$INTERACTIVE"; then
+    echo "Running interactively. Starting shell in package overlay."
+    echo "Rebuild with: abuild -f -r -C ~/aports/main/$pkg builddeps build"
+    # If the last command in the child shell exited non-zero then ctrl-d/exit
+    # will report that error code to the parent. If we don't ignore that error
+    # we will exit early and leave the package overlay mounted.
+    set +o errexit
+    $merged/enter-chroot -u udu
+    set -o errexit
+  fi
+
   unmount-loop $merged
 }
 


### PR DESCRIPTION
This only works with the overlayfs build for now. If the INTERACTIVE environment variable is set, we will drop into a shell after attempting to build a package with abuild. This is the last thing that happens before unmounting the overlay we used for the build.