### PR TITLE
spec: add test for command sub exit code behavior

### DIFF
--- a/spec/divergence.test.sh
+++ b/spec/divergence.test.sh
@@ -64,7 +64,7 @@ bad
 f00
 ## END
 
-#### Command substitution exit codes (#2435)
+#### Exit code when command sub evaluates to empty str, e.g. `false` (#2435)
 
 # OSH exits with 0 while others exit with 1
 `true`; echo $?


### PR DESCRIPTION
This commit adds a failing spec test to capture the difference between how OSH and other shells handle the exit code for command subs that don't print anything.

See #2435