### PR TITLE
`cpp/osh`: Add missing op in `DoUnaryOp`

### DIFF
--- a/cpp/osh.cc
+++ b/cpp/osh.cc
@@ -60,6 +60,9 @@ bool DoUnaryOp(Id_t op_id, BigStr* s) {
     case Id::BoolUnary_e:
       return true;
 
+    case Id::BoolUnary_b:
+      return S_ISBLK(mode);
+
     case Id::BoolUnary_c:
       return S_ISCHR(mode);
 

--- a/spec/builtin-bracket.test.sh
+++ b/spec/builtin-bracket.test.sh
@@ -375,6 +375,8 @@ test -b nonexistent
 echo status=$?
 test -b testdata
 echo status=$?
+test -b /
+echo status=$?
 
 echo -c
 test -c nonexistent
@@ -390,6 +392,7 @@ echo status=$?
 
 ## STDOUT:
 -b
+status=1
 status=1
 status=1
 -c


### PR DESCRIPTION
`osh/bool_stat.py` handled `test -b`, but the CPP implementation of the code was missing this case.

Before:

    $ _bin/cxx-asan/osh -c 'test -b /'
    osh: cpp/osh.cc:133: bool bool_stat::DoUnaryOp(id_kind_asdl::Id_t, BigStr*): Assertion `false' failed.
    [1]    2999587 IOT instruction (core dumped)  _bin/cxx-asan/osh

After:

    $ _bin/cxx-asan/osh -c 'test -b /'
    $ echo $?
    1

Add a spec test verifying this as well.

Fixes #2414