### PR TITLE
[spec/builtin-trap] Add test case for ignored traps in subshells

### DIFF
--- a/spec/builtin-trap.test.sh
+++ b/spec/builtin-trap.test.sh
@@ -47,6 +47,25 @@ trap | cat
 bye
 ## END
 
+#### ignored signals are active inside subshells
+trap '' USR1
+subshell_result=$(
+  trap '' USR2
+  trap - USR2
+  trap
+)
+
+# NOT a subshell
+trap > traps.txt
+shell_result=$(cat traps.txt)
+
+if test "$shell_result" = "$subshell_result"; then
+  echo ok
+fi
+
+## STDOUT:
+ok
+## END
 
 #### trap accepts/ignores --
 trap -- 'echo hi' EXIT


### PR DESCRIPTION
POSIX specifies that if the action of trap is null the shell shall ignore each specified condition. Currently oils doesn't adhere.

POSIX also says:
> When a subshell is entered, traps that are not being ignored shall
> be set to the default actions, except in the case of a command
> substitution containing only a single trap command, when the traps
> need not be altered.

However `dash` and `bash` don't fully follow this behavior, which I am pretty sure is a bug in both shells. I haven't tested other shells yet, including oils.

TODO: Add the spec tests for the exception of traps.