### PR TITLE
Emulate BASH_VERSINFO

### DIFF
--- a/core/shell.py
+++ b/core/shell.py
@@ -332,7 +332,7 @@ def Main(
         # 2025-09: bash 5.3 is the latest version; can increase this with
         # future Oils releases
         state.SetGlobalString(mem, 'BASH_VERSION', '5.3')
-        state.SetGlobalArray(mem, 'BASH_VERSINFO', ['5', '3', '0', '0', 'release', 'x86_64-pc-linux-gnu']) # major minor patch build release-status machine-type
+        state.SetGlobalArray(mem, 'BASH_VERSINFO', ['5', '3', '0', '0', 'release', 'unknown']) # major minor patch build release-status machine-type
 
     sh_init.CopyVarsFromEnv(exec_opts, environ, mem)
 

--- a/test/osh-usage.sh
+++ b/test/osh-usage.sh
@@ -233,7 +233,7 @@ test-bash-version-emulation() {
   nq-capture status stdout \
     ./bash -c "$code"
   nq-assert 0 -eq $status
-  nq-assert 'BASH_VERSINFO=5 3 0 0 release x86_64-pc-linux-gnu' = "$stdout"
+  nq-assert 'BASH_VERSINFO=5 3 0 0 release unknown' = "$stdout"
 
   popd
 }


### PR DESCRIPTION
From the [Bash guide](https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html#index-BASH_005fVERSINFO):

---

**BASH_VERSINFO**
A readonly array variable whose members hold version information for this instance of Bash. The values assigned to the array members are as follows:

- `BASH_VERSINFO[0]`: The major version number (the release).
- `BASH_VERSINFO[1]`: The minor version number (the version).
- `BASH_VERSINFO[2]`: The patch level.
- `BASH_VERSINFO[3]`: The build version.
- `BASH_VERSINFO[4]`: The release status (e.g., beta).
- `BASH_VERSINFO[5]`: The value of MACHTYPE.