### PR TITLE
[osh] Store token length in 32 bits instead of 16

### DIFF
--- a/core/alloc.py
+++ b/core/alloc.py
@@ -143,7 +143,8 @@ class Arena(object):
     def NewToken(self, id_, col, length, src_line):
         # type: (int, int, int, SourceLine) -> Token
 
-        if length >= 65536:
+        # 2**32 - token length is stored in an int (32 bits)
+        if length >= 4294967296:
             raise error.Parse(
                 '',  # ignored message
                 loc.TokenTooLong(src_line, id_, length, col))

--- a/frontend/syntax.asdl
+++ b/frontend/syntax.asdl
@@ -84,10 +84,10 @@ module syntax
   # Note that ASDL generates:
   #    typedef uint16_t Id_t;
   # So Token is
-  #    8 bytes GC header + 2 + 2 + 4 + 8 + 8 = 32 bytes on 64-bit machines
+  #    8 bytes GC header + 2 + 4 + 4 + 8 + 8 = 34 bytes on 64-bit machines
   #
   # We transpose (id, col, length) -> (id, length, col) for C struct packing.
-  Token = (id id, uint16 length, int col, SourceLine? line, str? tval)
+  Token = (id id, int length, int col, SourceLine? line, str? tval)
 
   # I wanted to get rid of Token.tval with this separate WideToken type, but it
   # is more efficient if word_part.Literal %Token literally is the same thing

--- a/spec/parse-errors.test.sh
+++ b/spec/parse-errors.test.sh
@@ -19,12 +19,6 @@ echo status=$?
 wc --bytes out
 
 ## STDOUT:
-status=2
-0 out
-## END
-
-## OK dash/bash/mksh status: 0
-## OK dash/bash/mksh STDOUT:
 status=0
 65536 out
 ## END


### PR DESCRIPTION
This means that maximum length of a token increases from 2^16 to 2^32 accordingly.

Adjust the test expecting osh's failure in handling large tokens.

Fixes: #2441