### PR TITLE
Fix docs: ref/chap-type-method io->evalToDict

### DIFF
--- a/doc/ref/chap-type-method.md
+++ b/doc/ref/chap-type-method.md
@@ -990,7 +990,7 @@ Example:
     var x = 10  # captured
     var cmd = ^(var a = 42; var hidden_ = 'h'; var b = x + 1; )
 
-    var d = io->evalToDict(cmd)
+    var d = io->eval(cmd, to_dict=true)
 
     pp (d)  # => {a: 42, b: 11}
 


### PR DESCRIPTION
`io->evalToDict` has been deprecated, and the docs were confusing before because it referenced `to_dict=true` and then used `io->evalToDict` in the example.
