### PR TITLE
replace " with \' in sql files

### DIFF
--- a/regtest/aports/cause.sql
+++ b/regtest/aports/cause.sql
@@ -17,11 +17,11 @@ where causes.pkg = diff_baseline.pkg;
 
 -- Set causes for signals/timeouts
 update diff_baseline
-set cause = "signal-124"
+set cause = 'signal-124'
 where status1 = 124 or status2 = 124;
 
 update diff_baseline
-set cause = "signal-143"
+set cause = 'signal-143'
 where status1 = 143 or status2 = 143;
 
 update diff_baseline

--- a/regtest/aports/diff.sql
+++ b/regtest/aports/diff.sql
@@ -10,12 +10,12 @@ create table diff_baseline as
     b.pkg,
     cast(b.status as integer) as status1,
     b.elapsed_secs as baseline,
-    cast("baseline/" || b.pkg_HREF as text) as baseline_HREF,
+    cast('baseline/' || b.pkg_HREF as text) as baseline_HREF,
     cast(o.status as integer) as status2,
     o.elapsed_secs as osh_as_sh,
-    cast("osh-as-sh/" || o.pkg_HREF as text) as osh_as_sh_HREF,
-    cast("error" as text) as error_grep,
-    cast(printf("error/%s.txt", b.pkg) as text) as error_grep_HREF,
+    cast('osh-as-sh/' || o.pkg_HREF as text) as osh_as_sh_HREF,
+    cast('error' as text) as error_grep,
+    cast(printf('error/%s.txt', b.pkg) as text) as error_grep_HREF,
     (b.status != o.status) as disagree,
     (b.status in (124, 143) or o.status in (124, 143)) as timeout
   from
@@ -28,13 +28,13 @@ create table diff_baseline as
 -- 1 row for baseline, 1 row for osh-as-sh
 create table metrics as
   select
-    cast("baseline" as text) as config,
+    cast('baseline' as text) as config,
     *
   from baseline.metrics;
 
 insert into metrics
 select
-  cast("osh-as-sh" as text) as config,
+  cast('osh-as-sh' as text) as config,
   *
 from osh_as_sh.metrics;
 

--- a/regtest/aports/merge.sql
+++ b/regtest/aports/merge.sql
@@ -2,11 +2,11 @@
 
 update diff_merged
 set
-  baseline_HREF = printf("%s/%s", shard, baseline_HREF),
-  osh_as_sh_HREF = printf("%s/%s", shard, osh_as_sh_HREF),
-  error_grep_HREF = printf("%s/%s", shard, error_grep_HREF),
+  baseline_HREF = printf('%s/%s', shard, baseline_HREF),
+  osh_as_sh_HREF = printf('%s/%s', shard, osh_as_sh_HREF),
+  error_grep_HREF = printf('%s/%s', shard, error_grep_HREF),
   -- note: suite/suite_HREF are sometimes empty
-  suite_HREF = printf("%s/%s", shard, suite_HREF);
+  suite_HREF = printf('%s/%s', shard, suite_HREF);
 
 -- Useful queries to verify the result:
 -- SELECT COUNT(*) as total_rows FROM diff_merged;

--- a/regtest/aports/summary.sql
+++ b/regtest/aports/summary.sql
@@ -1,38 +1,38 @@
-select "<ul>";
-select printf("<li>Tasks: %d</li>", sum(num_tasks)) from metrics;
-select printf("<li><b>Elapsed Hours: %.1f</b></li>", sum(elapsed_minutes) / 60)
+select '<ul>';
+select printf('<li>Tasks: %d</li>', sum(num_tasks)) from metrics;
+select printf('<li><b>Elapsed Hours: %.1f</b></li>', sum(elapsed_minutes) / 60)
 from metrics;
-select "</ul>";
+select '</ul>';
 
 create temporary view summary as
   select
     sum(
       case
-        when config = "baseline" then num_tasks
+        when config = 'baseline' then num_tasks
         else 0
       end
     ) as baseline_tasks,
     sum(
       case
-        when config = "baseline" then num_failures
+        when config = 'baseline' then num_failures
         else 0
       end
     ) as baseline_failures,
     sum(
       case
-        when config = "osh-as-sh" then num_failures
+        when config = 'osh-as-sh' then num_failures
         else 0
       end
     ) as osh_failures,
     sum(
       case
-        when config = "baseline" then num_apk
+        when config = 'baseline' then num_apk
         else 0
       end
     ) as baseline_apk,
     sum(
       case
-        when config = "osh-as-sh" then num_apk
+        when config = 'osh-as-sh' then num_apk
         else 0
       end
     ) as osh_apk
@@ -40,14 +40,14 @@ create temporary view summary as
 
 -- Task failures and packages produced
 
-select "<ul>";
+select '<ul>';
 
-select printf("<li><code>APKBUILD</code> files: %d</li>", baseline_tasks)
+select printf('<li><code>APKBUILD</code> files: %d</li>', baseline_tasks)
 from summary;
 
 select
   printf(
-    "<li>Baseline failures: %d (%.1f%%)</li>",
+    '<li>Baseline failures: %d (%.1f%%)</li>',
     baseline_failures,
     baseline_failures * 100.0 / baseline_tasks
   )
@@ -55,44 +55,44 @@ from summary;
 
 select
   printf(
-    "<li>osh-as-sh failures: %d (%.1f%%)</li>",
+    '<li>osh-as-sh failures: %d (%.1f%%)</li>',
     osh_failures,
     osh_failures * 100.0 / baseline_tasks
   )
 from summary;
 
-select printf("<li>Baseline <code>.apk</code> built: %d</li>", baseline_apk)
+select printf('<li>Baseline <code>.apk</code> built: %d</li>', baseline_apk)
 from summary;
-select printf("<li>osh-as-sh <code>.apk</code> built: %d</li>", osh_apk)
+select printf('<li>osh-as-sh <code>.apk</code> built: %d</li>', osh_apk)
 from summary;
 
-select "</ul>";
+select '</ul>';
 
 -- Disagreements
 
-select "<ul>";
-select printf("<li><b>Notable Disagreements: %d</b></li>", count(*))
+select '<ul>';
+select printf('<li><b>Notable Disagreements: %d</b></li>', count(*))
 from notable_disagree;
 
-select printf("<li>Unique causes: %d</li>", count(distinct cause))
+select printf('<li>Unique causes: %d</li>', count(distinct cause))
 from notable_disagree
-where cause != "unknown";
+where cause != 'unknown';
 
 select
-  printf("<li>Packages without a cause assigned (unknown): %s</li>", count(*))
+  printf('<li>Packages without a cause assigned (unknown): %s</li>', count(*))
 from notable_disagree
-where cause = "unknown";
-select "</ul>";
+where cause = 'unknown';
+select '</ul>';
 
 -- Other
 
-select "<ul>";
-select printf("<li>Other Failures: %d</li>", count(*)) from other_fail;
+select '<ul>';
+select printf('<li>Other Failures: %d</li>', count(*)) from other_fail;
 select
   printf(
-    "<li>Inconclusive result because of timeout (-124, -143): %d</li>",
+    '<li>Inconclusive result because of timeout (-124, -143): %d</li>',
     count(*)
   )
 from timeout
-where cause like "signal-%";
-select "</ul>";
+where cause like 'signal-%';
+select '</ul>';


### PR DESCRIPTION
Replace double quotes with single quotes in regtest sql files to fix errors like this:
```
Parse error near line 8: no such column: "baseline/" - should this be a string literal in single-quotes?
  status1,     b.elapsed_secs as baseline,     cast("baseline/" || b.pkg_HREF as
                                      error here ---^
Parse error near line 29: no such column: "baseline" - should this be a string literal in single-quotes?
  create table metrics as   select     cast("baseline" as text) as config,     *
                              error here ---^
Parse error near line 35: no such column: "osh-as-sh" - should this be a string literal in single-quotes?
  insert into metrics select   cast("osh-as-sh" as text) as config,   * from osh
```

See also [#distros > Updating Causes of regtest/aports Failures](https://oilshell.zulipchat.com/#narrow/channel/522730-distros/topic/Updating.20Causes.20of.20regtest.2Faports.20Failures/with/547362321)