### PR TITLE
add mdev-conf cause

### DIFF
--- a/regtest/aports/cause.awk
+++ b/regtest/aports/cause.awk
@@ -117,6 +117,9 @@ BEGIN {
   # 2025-10-26: demo for updating cause.awk, already fixed
   patterns["#2477"] = "printf expected an integer, got"
 
+  # mdev-conf
+  patterns["#2500"] = "readlink disk/by-label/EFI"
+
   found = 0
 }
 { 


### PR DESCRIPTION
Shows up in the HTML as:
<img width="1502" height="244" alt="image" src="https://github.com/user-attachments/assets/11dcf0f7-b322-4e4d-a2ab-0467a069e3f2" />
