### PR TITLE
[regtest] Patch /usr/bin/autopoint for xz

### DIFF
--- a/regtest/aports-setup.sh
+++ b/regtest/aports-setup.sh
@@ -77,14 +77,20 @@ patch-aports() {
   # also need to be specified in the 'source=' and 'sha512sums=' lists in APKBUILD
   for patch_dir in $cur_dir/regtest/patches/*; do
       local patch_dir=$(basename $patch_dir)
+      local apkbuild=main/$patch_dir/APKBUILD
+      git restore $apkbuild
       for patch in $cur_dir/regtest/patches/$patch_dir/*; do
-          cp $patch main/$patch_dir/
-          local patch_name=$(basename $patch)
-          local shasum=$(sha512sum $patch | cut -d " " -f1)
-          local apkbuild=main/$patch_dir/APKBUILD
-          git restore $apkbuild
-          sed -i "/source='*/ a $patch_name" $apkbuild
-          sed -i "/sha512sums='*/ a $shasum  $patch_name" $apkbuild
+          if [[ $patch == *.patch ]]; then
+              cp $patch main/$patch_dir/
+              local patch_name=$(basename $patch)
+              local shasum=$(sha512sum $patch | cut -d " " -f1)
+              sed -i "/source='*/ a $patch_name" $apkbuild
+              sed -i "/sha512sums='*/ a $shasum  $patch_name" $apkbuild
+          elif [[ $patch == *.copy ]]; then
+              cp $patch main/$patch_dir/
+          elif [[ $patch == *.apkbuild ]]; then
+              git apply $patch
+          fi
       done
   done
 

--- a/regtest/patches/xz/extglob.apkbuild
+++ b/regtest/patches/xz/extglob.apkbuild
@@ -1,0 +1,12 @@
+diff --git a/main/xz/APKBUILD b/main/xz/APKBUILD
+index 7ffe05e7024..f69634541a7 100644
+--- a/main/xz/APKBUILD
++++ b/main/xz/APKBUILD
+@@ -22,6 +22,7 @@ source="https://github.com/tukaani-project/xz/archive/refs/tags/v$pkgver/xz-$pkg
+ 
+ prepare() {
+ 	default_prepare
++	doas patch /usr/bin/autopoint -i ../../autopoint.patch
+ 	autoreconf -fi
+ }
+ 

--- a/regtest/patches/xz/extglob.copy
+++ b/regtest/patches/xz/extglob.copy
@@ -1,0 +1,12 @@
+--- /usr/bin/autopoint
++++ /usr/bin/autopoint
+@@ -15,7 +15,7 @@
+ while read line
+ do
+   if [ "${line##*AC_CONFIG_AUX_DIR}" != "$line" ]; then
+-    dirprefix="${line##*([}"
++    dirprefix="${line##*'(['}"
+     dirprefix="${dirprefix%%])*}"
+     mkdir -p "${dirprefix}"
+   fi
+


### PR DESCRIPTION
Escaping is horrific, but we need to handle two layers of shell+sed here.

xz builds successfully with this patch for me locally

Fixes: #2336