### PR TITLE
[core] Run builtin cat in a subprocess

### DIFF
--- a/core/executor.py
+++ b/core/executor.py
@@ -582,7 +582,14 @@ class ShellExecutor(vm._Executor):
                 not self.exec_opts.interactive()):
             builtin_id = _RewriteExternToBuiltin(cmd_val.argv)
             if builtin_id != consts.NO_INDEX:
-                return self.RunBuiltin(builtin_id, cmd_val)
+                if builtin_id == builtin_i.cat:
+                    thunk = process.BuiltinThunk(self, builtin_id, cmd_val)
+                    p = process.Process(thunk, self.job_control, self.job_list,
+                                        self.tracer)
+                    status = p.RunProcess(self.waiter, trace.Fork)
+                    return status
+                else:
+                    return self.RunBuiltin(builtin_id, cmd_val)
 
         return self.RunExternal(arg0, arg0_loc, cmd_val, cmd_st, run_flags)
 

--- a/spec/divergence.test.sh
+++ b/spec/divergence.test.sh
@@ -1,5 +1,5 @@
 ## compare_shells: bash dash mksh zsh ash
-## oils_failures_allowed: 5
+## oils_failures_allowed: 4
 
 # This file relates to:
 #


### PR DESCRIPTION
Otherwise if it crashes, it brings down the whole subshell with it and we don't capture its exit status correctly.

Create a new Thunk class for this purpose - its Run() just invokes a builtin and returns (no exec() involved).

With this change, the divergence test for 'cat' is passing.

Fixes: #2530