### PR TITLE
[mycpp] Turn global mutable state into private variables

### DIFF
--- a/mycpp/control_flow_pass.py
+++ b/mycpp/control_flow_pass.py
@@ -434,7 +434,8 @@ class Build(visitor.SimpleVisitor):
 
     def oils_visit_assignment_stmt(self, o: 'mypy.nodes.AssignmentStmt',
                                    lval: Expression, rval: Expression,
-                                   current_method_name: Optional[str]) -> None:
+                                   current_method_name: Optional[str],
+                                   at_global_scope: bool) -> None:
         cfg = self.current_cfg()
         if cfg:
             lval_names = []

--- a/mycpp/cppgen_pass.py
+++ b/mycpp/cppgen_pass.py
@@ -598,10 +598,11 @@ class Decl(_Shared):
 
     def oils_visit_assignment_stmt(self, o: 'mypy.nodes.AssignmentStmt',
                                    lval: Expression, rval: Expression,
-                                   current_method_name: Optional[str]) -> None:
+                                   current_method_name: Optional[str],
+                                   at_global_scope: bool) -> None:
         # Declare constant strings.  They have to be at the top level.
 
-        # TODO: self.at_global_scope doesn't work for context managers and so forth
+        # TODO: at_global_scope doesn't work for context managers and so forth
         if self.indent == 0:
             # Top level can't have foo.bar = baz
             assert isinstance(lval, NameExpr), lval
@@ -1650,7 +1651,8 @@ class Impl(_Shared):
 
     def oils_visit_assignment_stmt(self, o: 'mypy.nodes.AssignmentStmt',
                                    lval: Expression, rval: Expression,
-                                   current_method_name: Optional[str]) -> None:
+                                   current_method_name: Optional[str],
+                                   at_global_scope: bool) -> None:
 
         # GLOBAL CONSTANTS - Avoid Alloc<T>, since that can't be done until main().
         if self.indent == 0:
@@ -1751,7 +1753,7 @@ class Impl(_Shared):
             #c_type = GetCType(lval_type, local=self.indent != 0)
             c_type = GetCType(lval_type)
 
-            if self.at_global_scope:
+            if at_global_scope:
                 # globals always get a type -- they're not mutated
                 self.write_ind('%s %s = ', c_type, lval.name)
             else:


### PR DESCRIPTION
Motivated by https://github.com/oils-for-unix/oils/pull/2517#issuecomment-3448756702

Make `self.current_class_name`, `self.current_method_name` and `self.at_global_scope` private variables and pass them explicitly into functions requiring them.

This still leaves `self.indent` as global mutable state - it's used in a lot more places and would be even more intrusive to change.