### PR TITLE
add new causes for zeitgeist and dircproxy

### DIFF
--- a/regtest/aports/cause.awk
+++ b/regtest/aports/cause.awk
@@ -120,6 +120,12 @@ BEGIN {
   # mdev-conf
   patterns["#2500"] = "readlink disk/by-label/EFI"
 
+  # zeitgeist
+  patterns["#2528"] = "Unexpected argument to \'exit\'"
+
+  # dircproxy
+  patterns["#2535"] = "fatal: Pat Sub op expected Str, BashArray, or BashAssoc, got Int"
+
   found = 0
 }
 { 


### PR DESCRIPTION
add zeitgeist and dircproxy causes
<img width="1181" height="88" alt="image" src="https://github.com/user-attachments/assets/754a94e2-a480-4126-b5ea-c08a8b80b1ea" />

#2528 also got added as a cause to tilda loudmouth and lasem, but they indeed do seem like the same issue.

<img width="1513" height="189" alt="image" src="https://github.com/user-attachments/assets/dfb8a99c-7b9a-43a2-9d63-9d42e40844fd" />
