### PR TITLE
Add failing spec test for xtrace and redirect bug

### DIFF
--- a/spec/redirect.test.sh
+++ b/spec/redirect.test.sh
@@ -1,4 +1,4 @@
-## oils_failures_allowed: 1
+## oils_failures_allowed: 2
 ## compare_shells: bash dash mksh
 
 #### >& and <& are the same
@@ -592,4 +592,28 @@ x= {myvar}
 0
 ## END
 ## N-I dash STDOUT:
+## END
+
+#### xtrace not affected by redirects
+set -x
+printf 'aaaa' > /dev/null 2> test_osh
+set +x
+cat test_osh
+## STDERR:
++ printf aaaa
++ set +x
+## END
+## STDOUT:
+## END
+
+## OK osh STDERR:
++ printf aaaa
++ set '+x'
+## END
+
+## OK mksh STDERR:
++ >/dev/null 
++ 2>test_osh 
++ printf aaaa
++ set +x
 ## END


### PR DESCRIPTION
This is https://github.com/oils-for-unix/oils/issues/2540

I am currently 2 attempts in. Currently working on a cleaner solution I proposed on Zulip, open to other ideas though.

> I think a cleaner solution would be something a little more sophisticated than the second solution. It should be possible to track the current fd that points to stderr in FdState. We can then have xtrace write to that (or prefer a debug file if set).

---

**Attempt 1**

This was a very hacky fix. This change moved the application of redirects to after we make the xtrace call. The issue is that this split the redirect evaluation and application, which I found to be messy with our model.

<details>
<summary>Click to expand the diff</summary>

```diff
diff --git a/osh/cmd_eval.py b/osh/cmd_eval.py
index fb2496273..b36d7ecdc 100644
--- a/osh/cmd_eval.py
+++ b/osh/cmd_eval.py
@@ -754,7 +754,7 @@ class CommandEvaluator(object):

         raise AssertionError('for -Wreturn-type in C++')

-    def _RunSimpleCommand(self, cmd_val, cmd_st, run_flags):
+    def _RunSimpleCommand(self, cmd_val, cmd_st, run_flags, redirects):
         # type: (cmd_value_t, CommandStatus, int) -> int
         """Private interface to run a simple command (including assignment)."""
         UP_cmd_val = cmd_val
@@ -762,17 +762,44 @@ class CommandEvaluator(object):
             if case(cmd_value_e.Argv):
                 cmd_val = cast(cmd_value.Argv, UP_cmd_val)
                 self.tracer.OnSimpleCommand(cmd_val.argv)
-                return self.shell_ex.RunSimpleCommand(cmd_val, cmd_st,
-                                                      run_flags)

             elif case(cmd_value_e.Assign):
                 cmd_val = cast(cmd_value.Assign, UP_cmd_val)
                 self.tracer.OnAssignBuiltin(cmd_val)
-                return self._RunAssignBuiltin(cmd_val)

             else:
                 raise AssertionError()

+        status = self._EvalAndPushRedirects(redirects)
+        if status != 0:
+            return status
+
+        io_errors = []  # type: List[int]
+        num_redirects = 0
+        if redirects is not None:
+            num_redirects = len(redirects)
+
+        with vm.ctx_Redirect(self.shell_ex, num_redirects, io_errors):
+            UP_cmd_val = cmd_val
+            with tagswitch(UP_cmd_val) as case:
+                if case(cmd_value_e.Argv):
+                    cmd_val = cast(cmd_value.Argv, UP_cmd_val)
+                    return self.shell_ex.RunSimpleCommand(cmd_val, cmd_st,
+                                                          run_flags)
+
+                elif case(cmd_value_e.Assign):
+                    cmd_val = cast(cmd_value.Assign, UP_cmd_val)
+                    return self._RunAssignBuiltin(cmd_val)
+
+                else:
+                    raise AssertionError()
+
+        if len(io_errors):
+            # It would be better to point to the right redirect
+            # operator, but we don't track it specifically
+            e_die("Fatal error popping redirect: %s" %
+                  posix.strerror(io_errors[0]))
+
     def _EvalTempEnv(self, more_env, flags):
         # type: (List[EnvPair], int) -> None
         """For FOO=1 cmd."""
@@ -1104,59 +1131,43 @@ class CommandEvaluator(object):

         run_flags = executor.IS_LAST_CMD if node.is_last_cmd else 0

-        status = self._EvalAndPushRedirects(node.redirects)
-        if status != 0:
-            return status
-
-        num_redirects = 0
-        if node.redirects is not None:
-            num_redirects = len(node.redirects)
-
-        io_errors = []  # type: List[int]
-        with vm.ctx_Redirect(self.shell_ex, num_redirects, io_errors):
-            # NOTE: RunSimpleCommand may never return
-            if len(node.more_env):  # I think this guard is necessary?
-                if self.exec_opts.env_obj():  # YSH
-                    bindings = NewDict()  # type: Dict[str, value_t]
-                    with state.ctx_EnclosedFrame(self.mem,
-                                                 self.mem.CurrentFrame(),
-                                                 self.mem.GlobalFrame(),
-                                                 bindings):
-                        self._EvalTempEnv(node.more_env, 0)
-
-                    # Push this on the prototype chain
-                    with state.ctx_EnvObj(self.mem, bindings):
-                        status = self._RunSimpleCommand(
-                            cmd_val, cmd_st, run_flags)
-
-                else:  # OSH
-                    if _PrefixBindingsPersist(cmd_val):
-                        if self.exec_opts.strict_env_binding():
-                            # Disallow pitfall in YSH
-                            first_pair = node.more_env[0]
-                            e_die(
-                                "Special builtins can't have prefix bindings (OILS-ERR-302)",
-                                first_pair.left)
-
-                        # Special builtins (except exec) have their temp env persisted.
-                        # TODO: Disallow this in YSH?  It should just be a
-                        # top-level assignment.
-                        self._EvalTempEnv(node.more_env, 0)
+        # NOTE: RunSimpleCommand may never return
+        if len(node.more_env):  # I think this guard is necessary?
+            if self.exec_opts.env_obj():  # YSH
+                bindings = NewDict()  # type: Dict[str, value_t]
+                with state.ctx_EnclosedFrame(self.mem,
+                                             self.mem.CurrentFrame(),
+                                             self.mem.GlobalFrame(),
+                                             bindings):
+                    self._EvalTempEnv(node.more_env, 0)
+
+                # Push this on the prototype chain
+                with state.ctx_EnvObj(self.mem, bindings):
+                    status = self._RunSimpleCommand(
+                        cmd_val, cmd_st, run_flags, node.redirects)
+
+            else:  # OSH
+                if _PrefixBindingsPersist(cmd_val):
+                    if self.exec_opts.strict_env_binding():
+                        # Disallow pitfall in YSH
+                        first_pair = node.more_env[0]
+                        e_die(
+                            "Special builtins can't have prefix bindings (OILS-ERR-302)",
+                            first_pair.left)
+
+                    # Special builtins (except exec) have their temp env persisted.
+                    # TODO: Disallow this in YSH?  It should just be a
+                    # top-level assignment.
+                    self._EvalTempEnv(node.more_env, 0)
+                    status = self._RunSimpleCommand(
+                        cmd_val, cmd_st, run_flags, node.redirects)
+                else:
+                    with state.ctx_Temp(self.mem):
+                        self._EvalTempEnv(node.more_env, state.SetExport)
                         status = self._RunSimpleCommand(
-                            cmd_val, cmd_st, run_flags)
-                    else:
-                        with state.ctx_Temp(self.mem):
-                            self._EvalTempEnv(node.more_env, state.SetExport)
-                            status = self._RunSimpleCommand(
-                                cmd_val, cmd_st, run_flags)
-            else:
-                status = self._RunSimpleCommand(cmd_val, cmd_st, run_flags)
-
-        if len(io_errors):
-            # It would be better to point to the right redirect
-            # operator, but we don't track it specifically
-            e_die("Fatal error popping redirect: %s" %
-                  posix.strerror(io_errors[0]))
+                            cmd_val, cmd_st, run_flags, node.redirects)
+        else:
+            status = self._RunSimpleCommand(cmd_val, cmd_st, run_flags, node.redirects)

         probe('cmd_eval', '_DoSimple_exit', status)
         return status
```
</details>

**Attempt 2**

This got much closer.

I tried something subtle, I had xtrace write to a handle to /dev/stderr which was opened with fd_state.Open. This handle used an internal fd number which cannot be redirected. I liked the simplicity of this change (it was only one line). But this has the issue of write ordering. All of the xtrace messages end up after program output. See: https://op.oilshell.org/uuu/github-jobs/10800/ovm-tarball.wwz/_tmp/spec/osh-py/xtrace.html#details-8-osh

<details>
<summary>Click to expand the diff</summary>

```diff
diff --git a/core/shell.py b/core/shell.py
index 7a24aa873..e457d6aea 100644
--- a/core/shell.py
+++ b/core/shell.py
@@ -424,7 +424,7 @@ def Main(
     if flag.xtrace_to_debug_file:
         trace_f = debug_f
     else:
-        trace_f = util.DebugFile(mylib.Stderr())
+        trace_f = util.DebugFile(fd_state.OpenForWrite("/dev/stderr"))
 
     trace_dir = environ.get('OILS_TRACE_DIR', '')
     dumps = environ.get('OILS_TRACE_DUMPS', '')
```
</details>
