### PR TITLE
Fix typo in "Getting Started" link to "Wiki: How To Test OSH"

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -63,7 +63,7 @@ them in your `oshrc`.
 [original]: http://www.solipsys.co.uk/new/BashInitialisationFiles.html
 
 I describe my own `oshrc` file on the Wiki: [How To Test
-OSH](https://github.com/ols-for-unix/oils/wiki/How-To-Test-OSH).
+OSH](https://github.com/oils-for-unix/oils/wiki/How-To-Test-OSH).
 
 ### Setting the Prompt
 


### PR DESCRIPTION
Super small typo I stumbled across while getting set up.