### PR TITLE
fix xargs_slot with default value

### DIFF
--- a/regtest/aports-run.sh
+++ b/regtest/aports-run.sh
@@ -297,7 +297,7 @@ build-package-overlayfs() {
     $merged
 
   local -a prefix
-  if test -n "$XARGS_SLOT"; then
+  if test -n "${XARGS_SLOT:-}"; then
     local x=$XARGS_SLOT
 
     # run slot 0 on cores 0 and 1


### PR DESCRIPTION
Without this fix it fails on the unset variable for me:
regtest/aports-run.sh: line 301: XARGS_SLOT: unbound variable