### PR TITLE
update Rebuild:... echo

### DIFF
--- a/regtest/aports-run.sh
+++ b/regtest/aports-run.sh
@@ -312,7 +312,7 @@ build-package-overlayfs() {
 
   if test -n "$INTERACTIVE"; then
     echo "Starting interactive shell in overlayfs environment for package $a_repo/$pkg"
-    echo "Rebuild: abuild -f -r -C ~/aports/$a_repo/$pkg"
+    echo "Rebuild: abuild -f -r -C ~/aports/$a_repo/$pkg -k -K"
     echo "   Help: abuild -h"
     # If the last command in the child shell exited non-zero then ctrl-d/exit
     # will report that error code to the parent. If we don't ignore that error


### PR DESCRIPTION
Tiny change, but changed an echo statement so that instead of:
```
$ INTERACTIVE=1 regtest/aports-run.sh build-package-overlayfs osh-as-sh  shunit2  community
  TASK  99  16:24:42  shunit2
  FAIL      16:25:02  shunit2
Starting interactive shell in overlayfs environment for package community/shunit2
Rebuild: abuild -f -r -C ~/aports/community/shunit2
   Help: abuild -h
```
You see the `-k -K` flags added as well (this original output made me think it was not running with -k -K for a sec):
```
Rebuild: abuild -f -r -C ~/aports/community/shunit2 -k -K
```

Ideally I'd reuse `more_abuild_flags` in this echo statement but its a local var in another file, so refactoring that didn't seem worth it to me.