### PR TITLE
Fix broken wiki link in getting-started.md

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -90,8 +90,7 @@ Example:
 
 ### Editor Support
 
-See [YSH Editor Support]($wiki) on the wiki.
-
+See [YSH Editor Support](https://github.com/oils-for-unix/oils/wiki/YSH-Editor-Support) on the wiki.
 ## Getting Help
 
 Type `help` in `osh` or `ysh`, which links to URLs in the [Oils


### PR DESCRIPTION
Replaced the broken $wiki placeholder with the correct URL to the YSH Editor Support wiki page (https://github.com/oils-for-unix/oils/wiki/YSH-Editor-Support) in the Editor Support section.