### PR TITLE
add -o index=off to mount commands (regtest/aports-run.sh & regtest/aports-setup.sh)

### DIFF
--- a/regtest/aports-run.sh
+++ b/regtest/aports-run.sh
@@ -280,10 +280,13 @@ build-package-overlayfs() {
       ;;
   esac
 
+  # -o index=off fixes this error: fsconfig() failed: Stale file handle
+  # See also https://oilshell.zulipchat.com/#narrow/channel/522730-distros/topic/setting.20up.20regtest.2Faports-setup.2Esh/with/544318771
   sudo mount \
     -t overlay \
     aports-package \
     -o "$overlay_opts" \
+    -o index=off \
     $merged
 
   local -a prefix

--- a/regtest/aports-setup.sh
+++ b/regtest/aports-setup.sh
@@ -370,9 +370,12 @@ create-osh-overlay() {
 
   mkdir -v -p $osh_overlay/{merged,work,layer}
 
+  # -o index=off fixes this error: fsconfig() failed: Stale file handle
+  # See also https://oilshell.zulipchat.com/#narrow/channel/522730-distros/topic/setting.20up.20regtest.2Faports-setup.2Esh/with/544318771
   sudo mount \
     -t overlay \
     osh-as-sh \
+    -o index=off \
     -o "lowerdir=$CHROOT_DIR,upperdir=$osh_overlay/layer,workdir=$osh_overlay/work" \
     $osh_overlay/merged
 


### PR DESCRIPTION
Fixes this error:
```
bram@bram-dell /p/o/oils (master)> INTERACTIVE=1 regtest/aports-run.sh build-package-overlayfs osh-as-sh megacmd community
mount: /prj/oils-for-unix/oils/_chroot/package-slot99.overlay/merged: fsconfig() failed: Stale file handle.
       dmesg(1) may have more information after failed mount system call.
```

Also discussed here (a while back already): [#distros > setting up regtest/aports-setup.sh](https://oilshell.zulipchat.com/#narrow/channel/522730-distros/topic/setting.20up.20regtest.2Faports-setup.2Esh/with/544318771)