### PR TITLE
Upgrade to aports 3.23 for abuild fix

### DIFF
--- a/regtest/aports-setup.sh
+++ b/regtest/aports-setup.sh
@@ -54,7 +54,7 @@ checkout-stable() {
   # dl-cdn.alpinelinux.org URL
   # https://alpinelinux.org/releases/
 
-  local branch='3.22-stable'
+  local branch='3.23-stable'
   git checkout $branch
   git log -n 1
   popd > /dev/null
@@ -153,7 +153,7 @@ make-chroot() {
 
   # "branch" is one of these: https://dl-cdn.alpinelinux.org/
   # it's not the aports branch
-  local branch='v3.22'
+  local branch='v3.23'
   time sudo $aci -n -d $PWD/$CHROOT_DIR -b $branch
 }
 


### PR DESCRIPTION
Close #2424

I've tested that all of `heimdal`, `tcl`, `tk`, and `perl` succeed locally. I had to remove `../../alpinelinux` in order for the new alpine chroot to be setup correctly, although ymmv.

We want this change https://gitlab.alpinelinux.org/alpine/abuild/-/commit/73203da0e713bf1f0d022d91363c47d96301f4cc?__goaway_challenge=cookie&__goaway_id=03e89dcf81c655e8833b8f9940d96903 from abuild-3.16.0-r0 which first appears in aports-3.23. The change fixes a small bug that was accidentally unnoticed because of bash's lastpipe behaviour.