### PR TITLE
Fix: Add dev-guide build script

### DIFF
--- a/build/wiki.ysh
+++ b/build/wiki.ysh
@@ -104,7 +104,7 @@ proc commit-push() {
   ## Commit and push the most recent build to oils-for-unix.github.io
 
   var PAT = ENV.OILS_PAGES_GITHUB_TOKEN
-  pull-latest $PAGES_DIR "https://x-access-token:$PAT@github.com/PossiblyAShrub/oils-for-unix.github.io.git"
+  pull-latest $PAGES_DIR "https://x-access-token:$PAT@github.com/oils-for-unix/oils-for-unix.github.io.git"
 
   # Stash and pending changes (there should be none)
   cd $PAGES_DIR {


### PR DESCRIPTION
Fix for https://github.com/oils-for-unix/oils/pull/2599

Oops! The script currently tries to push to my fork...

Otherwise, everything else seems to work. I did a test run here: https://github.com/oils-for-unix/oils/actions/runs/20114346213/job/57719907955. (Didn't fail because my fork already has the latest Wiki build.)