### PR TITLE
[core] Do not fork builtin cat in YSH

### DIFF
--- a/core/executor.py
+++ b/core/executor.py
@@ -582,7 +582,8 @@ class ShellExecutor(vm._Executor):
                 not self.exec_opts.interactive()):
             builtin_id = _RewriteExternToBuiltin(cmd_val.argv)
             if builtin_id != consts.NO_INDEX:
-                if builtin_id == builtin_i.cat:
+                # Run cat in a separate process (#2530) in OSH for compatibility
+                if builtin_id == builtin_i.cat and not self.exec_opts.ysh_rewrite_extern():
                     thunk = process.BuiltinThunk(self, builtin_id, cmd_val)
                     p = process.Process(thunk, self.job_control, self.job_list,
                                         self.tracer)

--- a/doc/ref/chap-builtin-cmd.md
+++ b/doc/ref/chap-builtin-cmd.md
@@ -657,9 +657,10 @@ Private builtins are not enabled by default:
                # If the file is -, read from stdin (not the file called -)
     cat        # equivalent to cat -
 
-- Related: [rewrite_extern][]
+- Related: [rewrite_extern][], [ysh_rewrite_extern][]
 
 [rewrite_extern]: chap-option.html#rewrite_extern
+[ysh_rewrite_extern]: chap-option.html#ysh_rewrite_extern
 
 ### rm
 

--- a/doc/ref/chap-option.md
+++ b/doc/ref/chap-option.md
@@ -176,7 +176,7 @@ This option can be useful for "getting past" errors while testing.
 
 ### rewrite_extern
 
-This options enables a transparent rewriting of external commands to
+This option enables a transparent rewriting of external commands to
 **builtins**.
 
 Currently, these commands **may** be rewritten, depending on their `argv`:
@@ -185,7 +185,7 @@ Currently, these commands **may** be rewritten, depending on their `argv`:
 - [rm][]
 
 These optimizations are *sound* - they should not affect the behavior of
-programs on POSIX system.
+programs on a POSIX system.
 
 ---
 
@@ -195,6 +195,17 @@ rewritten, regardless of the value of `rewrite_extern`.
 
 [cat]: chap-builtin-cmd.html#cat
 [rm]: chap-builtin-cmd.html#rm
+
+### ysh_rewrite_extern
+
+This option transparently avoids compatibility workarounds when rewriting
+external commands to **builtins**, providing a performance improvement.
+It might affect the behavior of programs on a POSIX system.
+
+Currently, this only affects [cat][], which otherwise runs in a separate
+process (so that its errors do not crash the main process).
+
+[cat]: chap-builtin-cmd.html#cat
 
 ## Groups
 
@@ -265,6 +276,7 @@ Details on each option:
       for_loop_frames            YSH can create closures from loop vars
       verbose_errexit            Whether to print detailed errors
       verbose_warn               Print various warnings to stderr
+      ysh_rewrite_extern         Avoids compatibility workarounds for builtins
 
 <h3 id="ysh:all">ysh:all</h3>
 

--- a/doc/ref/toc-osh.md
+++ b/doc/ref/toc-osh.md
@@ -197,7 +197,7 @@ X [Unsupported]   enable
   [Interactive]    emacs           vi
   [Compat]         eval_unsafe_arith            ignore_flags_not_impl
                    ignore_shopt_not_impl
-  [Optimize]       rewrite_extern
+  [Optimize]       rewrite_extern               ysh_rewrite_extern
 ```
 
 <h2 id="special-var">

--- a/doc/ref/toc-ysh.md
+++ b/doc/ref/toc-ysh.md
@@ -366,7 +366,7 @@ X [External Lang] BEGIN   END   when (awk)
 </h2>
 
 ```chapter-links-option
-  [Optimize]     rewrite_extern
+  [Optimize]     rewrite_extern  ysh_rewrite_extern
   [Groups]       strict:all      ysh:upgrade     ysh:all
   [YSH Details]  opts-redefine   opts-internal
 ```

--- a/frontend/option_def.py
+++ b/frontend/option_def.py
@@ -138,6 +138,9 @@ _UPGRADE_RUNTIME_OPTS = [
 
     # Can create closures from loop variables, like JS / C# / Go
     ('for_loop_frames', False),
+
+    # Run builtin cat in the main process
+    ('ysh_rewrite_extern', False),
 ]
 
 _YSH_RUNTIME_OPTS = [

--- a/spec/ysh-options.test.sh
+++ b/spec/ysh-options.test.sh
@@ -198,6 +198,7 @@ shopt -s simple_word_eval
 shopt -s verbose_errexit
 shopt -s verbose_warn
 shopt -s xtrace_rich
+shopt -s ysh_rewrite_extern
 ## END
 
 #### osh -O ysh:upgrade 
@@ -757,4 +758,14 @@ echo ${#assoc[@]}
 
 ## STDOUT:
 2
+## END
+
+#### ysh_rewrite_extern makes the process exit with SIGPIPE
+shopt --set ysh_rewrite_extern
+
+((/usr/bin/cat </dev/zero; echo $? >&7) | true) 7>&1
+((cat </dev/zero; echo $? >&7) | true) 7>&1
+
+## STDOUT:
+141
 ## END


### PR DESCRIPTION
Provides a new ysh_rewrite_extern option (enabled with ysh:upgrade) that does not fork cat when rewriting it to a builtin.

Adds a spec test to ysh-options verifying this behavior.

Fixes: #2605