### PR TITLE
Address dev friction with compare.html

### DIFF
--- a/test/spec-runner.sh
+++ b/test/spec-runner.sh
@@ -164,7 +164,7 @@ dispatch-one() {
       --format html \
       --stats-file $base_dir/${spec_name}.stats.txt \
       --stats-template \
-      '%(num_cases)d %(oils_num_passed)d %(oils_num_failed)d %(oils_failures_allowed)d %(oils_ALT_delta)d' \
+      '%(num_cases)d %(oils_num_passed)d %(oils_num_failed)d %(oils_failures_allowed)d %(oils_ALT_delta)d %(oils_cpp_failures_allowed)d %(oils_cpp_num_failed)d' \
       "$@" \
     > $base_dir/${spec_name}.html
 }

--- a/web/spec-cpp.css
+++ b/web/spec-cpp.css
@@ -7,6 +7,11 @@ h1 {
   background-color: #e0ffe0;
 }
 
+/* same as .failed in spec-tests.css */
+.cpp-failed {
+  background-color: #ffe0e0;
+}
+
 /* same as .osh-allow-fail in spec-tests.css */
 .py-good {
   background-color: #ffffe0;


### PR DESCRIPTION
Fixes compare.html not being generated for ysh-all on errors and makes it more informative so that it's clearer what caused the errors

Here's how osh-cpp's compare.html page looks like with this PR: 
<img width="1052" height="1032" alt="image" src="https://github.com/user-attachments/assets/fc9a20a7-05dc-499e-b56b-f0125bfc2f38" />

See https://op.oilshell.org/uuu/github-jobs/11017/cpp-spec.wwz/_tmp/spec/osh-cpp/compare.html for an example of "before", where it's unclear what the issue is.