### PR TITLE
[wedge] Update re2c to 4.3.1

### DIFF
--- a/build/deps.sh
+++ b/build/deps.sh
@@ -44,7 +44,7 @@ mkdir -p $WEDGE_2025_DIR
 
 readonly DEPS_SOURCE_DIR=_build/deps-source
 
-readonly RE2C_VERSION=3.0
+readonly RE2C_VERSION=4.3.1
 readonly RE2C_URL="https://github.com/skvadrik/re2c/releases/download/$RE2C_VERSION/re2c-$RE2C_VERSION.tar.xz"
 
 readonly CMARK_VERSION=0.29.0

--- a/deps/Dockerfile.soil-app-tests
+++ b/deps/Dockerfile.soil-app-tests
@@ -19,11 +19,11 @@ COPY --chown=uke \
   /home/uke/oils.DEPS/wedge/cmark/0.29.0
 
 COPY --chown=uke \
-  _build/boxed/wedge/re2c/3.0 \
-  /home/uke/oils.DEPS/wedge/re2c/3.0
+  _build/boxed/wedge/re2c/4.3.1 \
+  /home/uke/oils.DEPS/wedge/re2c/4.3.1
 
 RUN mkdir -p /home/uke/oils.DEPS/bin && \
-    ln -s --relative /home/uke/oils.DEPS/wedge/re2c/3.0/bin/re2c /home/uke/oils.DEPS/bin
+    ln -s --relative /home/uke/oils.DEPS/wedge/re2c/4.3.1/bin/re2c /home/uke/oils.DEPS/bin
 
 # TODO: Add osh-cpp so we can test ble.sh with it
 

--- a/deps/Dockerfile.soil-benchmarks
+++ b/deps/Dockerfile.soil-benchmarks
@@ -28,8 +28,8 @@ COPY --chown=uke \
   /home/uke/oils.DEPS/wedge/cmark/0.29.0
 
 COPY --chown=uke \
-  _build/boxed/wedge/re2c/3.0 \
-  /home/uke/oils.DEPS/wedge/re2c/3.0
+  _build/boxed/wedge/re2c/4.3.1 \
+  /home/uke/oils.DEPS/wedge/re2c/4.3.1
 
 COPY --chown=uke \
   _build/boxed/wedge/python3/3.10.4 \
@@ -37,7 +37,7 @@ COPY --chown=uke \
 
 # Put python3 in PATH before running install-py3-libs
 RUN mkdir -p /home/uke/oils.DEPS/bin && \
-    ln -s --relative /home/uke/oils.DEPS/wedge/re2c/3.0/bin/re2c /home/uke/oils.DEPS/bin && \
+    ln -s --relative /home/uke/oils.DEPS/wedge/re2c/4.3.1/bin/re2c /home/uke/oils.DEPS/bin && \
     ln -s --relative /home/uke/oils.DEPS/wedge/python3/3.10.4/bin/python3 /home/uke/oils.DEPS/bin
 #    ln -s --relative /home/uke/oils.DEPS/wedge/uftrace/0.13/bin/uftrace /home/uke/oils.DEPS/bin
 

--- a/deps/Dockerfile.soil-clang
+++ b/deps/Dockerfile.soil-clang
@@ -25,8 +25,8 @@ COPY --chown=uke \
   /home/uke/oils.DEPS/wedge/cmark/0.29.0
 
 COPY --chown=uke \
-  _build/boxed/wedge/re2c/3.0 \
-  /home/uke/oils.DEPS/wedge/re2c/3.0
+  _build/boxed/wedge/re2c/4.3.1 \
+  /home/uke/oils.DEPS/wedge/re2c/4.3.1
 
 COPY --chown=uke \
   _build/boxed/wedge/python3/3.10.4 \
@@ -34,7 +34,7 @@ COPY --chown=uke \
 
 # Put python3 in PATH before running install-py3-libs
 RUN mkdir -p /home/uke/oils.DEPS/bin && \
-    ln -s --relative /home/uke/oils.DEPS/wedge/re2c/3.0/bin/re2c /home/uke/oils.DEPS/bin && \
+    ln -s --relative /home/uke/oils.DEPS/wedge/re2c/4.3.1/bin/re2c /home/uke/oils.DEPS/bin && \
     ln -s --relative /home/uke/oils.DEPS/wedge/python3/3.10.4/bin/python3 /home/uke/oils.DEPS/bin
 
 COPY --chown=uke \

--- a/deps/Dockerfile.soil-cpp-small
+++ b/deps/Dockerfile.soil-cpp-small
@@ -18,8 +18,8 @@ COPY --chown=uke \
   /home/uke/oils.DEPS/wedge/cmark/0.29.0
 
 COPY --chown=uke \
-  _build/boxed/wedge/re2c/3.0 \
-  /home/uke/oils.DEPS/wedge/re2c/3.0
+  _build/boxed/wedge/re2c/4.3.1 \
+  /home/uke/oils.DEPS/wedge/re2c/4.3.1
 
 COPY --chown=uke \
   _build/boxed/wedge/python3/3.10.4 \
@@ -27,7 +27,7 @@ COPY --chown=uke \
 
 # Put python3 in PATH before running install-py3-libs
 RUN mkdir -p /home/uke/oils.DEPS/bin && \
-    ln -s --relative /home/uke/oils.DEPS/wedge/re2c/3.0/bin/re2c /home/uke/oils.DEPS/bin && \
+    ln -s --relative /home/uke/oils.DEPS/wedge/re2c/4.3.1/bin/re2c /home/uke/oils.DEPS/bin && \
     ln -s --relative /home/uke/oils.DEPS/wedge/python3/3.10.4/bin/python3 /home/uke/oils.DEPS/bin
 
 # Copy _build/deps-source -> /home/uke/wedge for now.

--- a/deps/Dockerfile.soil-cpp-spec
+++ b/deps/Dockerfile.soil-cpp-spec
@@ -21,8 +21,8 @@ COPY --chown=uke \
   /home/uke/oils.DEPS/wedge/cmark/0.29.0
 
 COPY --chown=uke \
-  _build/boxed/wedge/re2c/3.0 \
-  /home/uke/oils.DEPS/wedge/re2c/3.0
+  _build/boxed/wedge/re2c/4.3.1 \
+  /home/uke/oils.DEPS/wedge/re2c/4.3.1
 
 COPY --chown=uke \
   _build/boxed/wedge/python3/3.10.4 \
@@ -30,7 +30,7 @@ COPY --chown=uke \
 
 # Put python3 in PATH before running install-py3-libs
 RUN mkdir -p /home/uke/oils.DEPS/bin && \
-    ln -s --relative /home/uke/oils.DEPS/wedge/re2c/3.0/bin/re2c /home/uke/oils.DEPS/bin && \
+    ln -s --relative /home/uke/oils.DEPS/wedge/re2c/4.3.1/bin/re2c /home/uke/oils.DEPS/bin && \
     ln -s --relative /home/uke/oils.DEPS/wedge/python3/3.10.4/bin/python3 /home/uke/oils.DEPS/bin
 
 COPY --chown=uke \

--- a/deps/Dockerfile.soil-ovm-tarball
+++ b/deps/Dockerfile.soil-ovm-tarball
@@ -19,8 +19,8 @@ COPY --chown=uke \
   /home/uke/oils.DEPS/wedge/cmark/0.29.0
 
 COPY --chown=uke \
-  _build/boxed/wedge/re2c/3.0 \
-  /home/uke/oils.DEPS/wedge/re2c/3.0
+  _build/boxed/wedge/re2c/4.3.1 \
+  /home/uke/oils.DEPS/wedge/re2c/4.3.1
 
 # Shells for spec tests
 

--- a/deps/Dockerfile.soil-wild
+++ b/deps/Dockerfile.soil-wild
@@ -19,11 +19,11 @@ COPY --chown=uke \
   /home/uke/oils.DEPS/wedge/cmark/0.29.0
 
 COPY --chown=uke \
-  _build/boxed/wedge/re2c/3.0 \
-  /home/uke/oils.DEPS/wedge/re2c/3.0
+  _build/boxed/wedge/re2c/4.3.1 \
+  /home/uke/oils.DEPS/wedge/re2c/4.3.1
 
 RUN mkdir -p /home/uke/oils.DEPS/bin && \
-    ln -s --relative /home/uke/oils.DEPS/wedge/re2c/3.0/bin/re2c /home/uke/oils.DEPS/bin
+    ln -s --relative /home/uke/oils.DEPS/wedge/re2c/4.3.1/bin/re2c /home/uke/oils.DEPS/bin
 
 # TODO:
 # - Try to extract FIRST, and then copy.

--- a/deps/make-bin.sh
+++ b/deps/make-bin.sh
@@ -18,7 +18,7 @@ link-relative() {
 
 re2c() {
   local deps_dir=$1
-  link-relative $deps_dir/wedge/re2c/3.0/bin/re2c $deps_dir/bin 
+  link-relative $deps_dir/wedge/re2c/4.3.1/bin/re2c $deps_dir/bin
 }
 
 python2() {

--- a/deps/source.medo/re2c/WEDGE
+++ b/deps/source.medo/re2c/WEDGE
@@ -8,7 +8,7 @@ set -o errexit
 
 # sourced
 WEDGE_NAME='re2c'
-WEDGE_VERSION='3.0'
+WEDGE_VERSION='4.3.1'
 WEDGE_IS_ABSOLUTE=1  # TODO: consider relaxing
 
 wedge-make() {


### PR DESCRIPTION
Version 4.0 introduced several improvements which make the Rust translation so much easier (since it's awkward to do pointer arithmetic, YYINPUT allows to use YYCURSOR as an index instead of a pointer).

Version 4.3 also improved compile-time performance.

Not upgrading to 4.4 (the latest version at the moment), since that is breaking backwards compatibility in a rare case (4.3 introduces a warning to track if we use the deprecated feature).