### PR TITLE
Fix hay crash when parseHay encounters syntax error

### DIFF
--- a/builtin/func_hay.py
+++ b/builtin/func_hay.py
@@ -68,7 +68,7 @@ class ParseHay(vm._Callable):
                 node = main_loop.ParseWholeFile(c_parser)
         except error.Parse as e:
             self.errfmt.PrettyPrintError(e)
-            return None
+            raise error.Expr("Failed to parse %r" % path, call_loc)
 
         return value.Command(cmd_frag.Expr(node), self.mem.CurrentFrame(),
                              self.mem.GlobalFrame())

--- a/spec/hay.test.sh
+++ b/spec/hay.test.sh
@@ -886,3 +886,19 @@ build_proc
 }
 version = 3.12, url = https://python.org/release/3.12/
 ## END
+
+#### hay crash when source file has a syntax error
+shopt --set ysh:all
+
+# crash.hay contains invalid hay
+echo 'echo =' > crash.hay
+
+try {
+  const h = parseHay("crash.hay")
+}
+if (_error.code === 3) {
+  echo OK  # parseHay should raise an error.Expr
+}
+## STDOUT:
+OK
+## END


### PR DESCRIPTION
Details about the error given in https://github.com/oils-for-unix/oils/issues/2643.

Fixes: https://github.com/oils-for-unix/oils/issues/2643

## Changes

- Fix the crash when assigning/reading from `parseHay` after a syntax error
- Adds a spec test for the above
