### PR TITLE
add xz-utils to Debian list in deps.sh

### DIFF
--- a/build/deps.sh
+++ b/build/deps.sh
@@ -153,6 +153,7 @@ readonly -a WEDGE_DEPS_DEBIAN=(
   cmake
   libreadline-dev 
   systemtap-sdt-dev
+  xz-utils
 
   # for Souffle, flex and bison
   #flex bison


### PR DESCRIPTION
this fixes an error during `build/deps.sh fetch`:

```
tar (child): xz: Cannot exec: No such file or directory
```