### PR TITLE
Build search index before pushing wiki render

### DIFF
--- a/.github/workflows/update-wiki.yml
+++ b/.github/workflows/update-wiki.yml
@@ -35,6 +35,12 @@ jobs:
         run: |
           build/wiki.ysh render
 
+          # build-search-index needs to run in a venv. On a dev machine, this is
+          # already present. In CI, we need to make one.
+          python3 -m venv venv
+          . venv/bin/activate
+          build/wiki.ysh build-search-index
+
       - name: Commit and Push
         run: |
           git config --global user.email "bot@oils.pub"


### PR DESCRIPTION
Currently https://pages.oils.pub/wiki/Dev-Guide.html doesn't display the search bar because we forgot to call `build/wiki.ysh build-search-index` in the `update-wiki` action.

I am planning on merging this right away per https://github.com/oils-for-unix/oils/pull/2662#issuecomment-4018024887. I tested this locally using an ubuntu container, so hopefully no more "one more fix"-es are needed.
