### PR TITLE
Fix potentially vulnerable cloned function

### DIFF
--- a/Python-2.7.13/Modules/expat/xmlparse.c
+++ b/Python-2.7.13/Modules/expat/xmlparse.c
@@ -5436,7 +5436,7 @@ setElementTypePrefix(XML_Parser parser, ELEMENT_TYPE *elementType)
       else
         poolDiscard(&dtd->pool);
       elementType->prefix = prefix;
-
+      break;
     }
   }
   return 1;


### PR DESCRIPTION
Hi,

Our tool identified a potential vulnerability in a clone function in `Python-2.7.13/Modules/expat/xmlparse.c` sourced from [libexpat/libexpat](https://github.com/libexpat/libexpat). This issue, originally reported in CVE-2018-20843, was resolved in the repository via this commit https://github.com/libexpat/libexpat/commit/11f8838bf99ea0a6f0b76f9760c43704d00c4ff6.

This PR suggests applying the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you!