### PR TITLE
Fix potentially vulnerable cloned function

### DIFF
--- a/Python-2.7.13/Modules/expat/xmlparse.c
+++ b/Python-2.7.13/Modules/expat/xmlparse.c
@@ -4630,7 +4630,7 @@ doProlog(XML_Parser parser,
       if (dtd->in_eldecl) {
         ELEMENT_TYPE *el;
         const XML_Char *name;
-        int nameLen;
+        size_t nameLen;
         const char *nxt = (quant == XML_CQUANT_NONE
                            ? next
                            : next - enc->minBytesPerChar);
@@ -4646,7 +4646,12 @@ doProlog(XML_Parser parser,
         dtd->scaffold[myindex].name = name;
         nameLen = 0;
         for (; name[nameLen++]; );
-        dtd->contentStringLen +=  nameLen;
+
+        /* Detect and prevent integer overflow */
+        if (nameLen > UINT_MAX - dtd->contentStringLen)
+          return XML_ERROR_NO_MEMORY;
+  
+        dtd->contentStringLen += (unsigned)nameLen;
         if (elementDeclHandler)
           handleDefault = XML_FALSE;
       }


### PR DESCRIPTION
Hi again,

Our tool identified a potential vulnerability in a clone function in `Python-2.7.13/Modules/expat/xmlparse.c` sourced from [libexpat/libexpat](https://github.com/libexpat/libexpat). This issue, originally reported in CVE-2022-23990, was resolved in the repository via this commit https://github.com/libexpat/libexpat/commit/ede41d1e186ed2aba88a06e84cac839b770af3a1.

This PR suggests applying the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you!