### PR TITLE
Fix potentially vulnerable cloned function

### DIFF
--- a/Python-2.7.13/Lib/shutil.py
+++ b/Python-2.7.13/Lib/shutil.py
@@ -396,17 +396,21 @@ def _make_tarball(base_name, base_dir, compress="gzip", verbose=0, dry_run=0,
 
     return archive_name
 
-def _call_external_zip(base_dir, zip_filename, verbose=False, dry_run=False):
+def _call_external_zip(base_dir, zip_filename, verbose, dry_run, logger):
     # XXX see if we want to keep an external call here
     if verbose:
         zipoptions = "-r"
     else:
         zipoptions = "-rq"
-    from distutils.errors import DistutilsExecError
-    from distutils.spawn import spawn
+    cmd = ["zip", zipoptions, zip_filename, base_dir]
+    if logger is not None:
+        logger.info(' '.join(cmd))
+    if dry_run:
+        return
+    import subprocess
     try:
-        spawn(["zip", zipoptions, zip_filename, base_dir], dry_run=dry_run)
-    except DistutilsExecError:
+        subprocess.check_call(cmd)
+    except subprocess.CalledProcessError:
         # XXX really should distinguish between "couldn't find
         # external 'zip' command" and "zip failed".
         raise ExecError, \
@@ -440,7 +444,7 @@ def _make_zipfile(base_name, base_dir, verbose=0, dry_run=0, logger=None):
         zipfile = None
 
     if zipfile is None:
-        _call_external_zip(base_dir, zip_filename, verbose, dry_run)
+        _call_external_zip(base_dir, zip_filename, verbose, dry_run, logger)
     else:
         if logger is not None:
             logger.info("creating '%s' and adding '%s' to it",


### PR DESCRIPTION
Hi again,

Our tool identified a potential vulnerability in a clone function in `Python-2.7.13/Lib/shutil.py` sourced from [python/cpython](https://github.com/python/cpython). This issue, originally reported in CVE-2018-1000802, was resolved in the repository via this commit https://github.com/python/cpython/commit/add531a1e55b0a739b0f42582f1c9747e5649ace.

This PR suggests applying the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you!