### PR TITLE
Implement the let arithmetic builtin (fixes #622)

### DIFF
--- a/builtin/pure_osh.py
+++ b/builtin/pure_osh.py
@@ -29,6 +29,8 @@ from frontend import typed_args
 from mycpp import mylib
 from mycpp.mylib import print_stderr, log
 
+from mycpp import mops
+
 from typing import List, Dict, Tuple, Optional, TYPE_CHECKING
 if TYPE_CHECKING:
     from _devbuild.gen.runtime_asdl import cmd_value
@@ -36,6 +38,7 @@ if TYPE_CHECKING:
     from core.state import MutableOpts, Mem
     from core import executor
     from osh.cmd_eval import CommandEvaluator
+    from osh import sh_expr_eval
 
 _ = log
 
@@ -402,6 +405,46 @@ class Hash(vm._Builtin):
                 print(cmd)
 
         return status
+
+
+class Let(vm._Builtin):
+    """The let builtin evaluates arithmetic expressions.
+
+    let expr [expr ...]
+
+    Each argument is an arithmetic expression, like those used in (( )).
+    The exit status is 0 (true) if the last expression is non-zero,
+    and 1 (false) if it evaluates to zero — matching bash behaviour.
+
+    Example:
+        let x=5          # assigns 5 to x
+        let "y = x + 3"  # assigns 8 to y; spaces require quoting
+        let x++          # increment x
+        let a=1 b=2      # multiple expressions, all evaluated
+    """
+
+    def __init__(self, arith_ev):
+        # type: (sh_expr_eval.ArithEvaluator) -> None
+        self.arith_ev = arith_ev
+
+    def Run(self, cmd_val):
+        # type: (cmd_value.Argv) -> int
+        argv = cmd_val.argv[1:]  # drop 'let' itself
+        if len(argv) == 0:
+            e_usage('requires at least one argument', loc.Missing)
+
+        result = mops.ZERO  # will be overwritten; makes the type checker happy
+        for arg in argv:
+            a_parser = self.arith_ev.parse_ctx.MakeArithParser(arg)
+            try:
+                anode = a_parser.Parse()
+            except error.Parse as e:
+                self.arith_ev.errfmt.PrettyPrintError(e)
+                return 1  # parse failure is a runtime error, not fatal
+            result = self.arith_ev.EvalToBigInt(anode)
+
+        # Mirrors the (( )) compound command: non-zero result -> status 0 (true)
+        return 1 if mops.Equal(result, mops.ZERO) else 0
 
 
 def _ParseOptSpec(spec_str):

--- a/core/shell.py
+++ b/core/shell.py
@@ -652,6 +652,7 @@ def Main(
                                         environ)
 
     b[builtin_i.hash] = pure_osh.Hash(search_path)  # not really pure
+    b[builtin_i.let] = pure_osh.Let(arith_ev)
     b[builtin_i.trap] = trap_osh.Trap(trap_state, parse_ctx, exec_opts, tracer,
                                       errfmt)
 

--- a/frontend/builtin_def.py
+++ b/frontend/builtin_def.py
@@ -32,6 +32,8 @@ _NORMAL_BUILTINS = [
 
     'umask', 'ulimit', 'wait', 'jobs', 'fg', 'bg', 'kill',
 
+    'let',  # arithmetic builtin: let expr [expr ...], equivalent to (( expr ))
+
     'shopt',
     'complete', 'compgen', 'compopt', 'compadjust', 'compexport',
 

--- a/spec/let.test.sh
+++ b/spec/let.test.sh
@@ -1,5 +1,4 @@
 ## compare_shells: bash mksh zsh
-## our_shell: -
 
 #### let
 # NOTE: no spaces are allowed.  How is this tokenized?


### PR DESCRIPTION
## Summary

Implements the missing `let` arithmetic builtin, closing #622.

```sh
let x=5           # assign 5 to x
let y=x+3         # y = 8
let "z = y * 2"  # z = 16 (spaces require quoting)
let x++           # increment
let a=1 b=2       # multiple expressions in one call
let a=0; echo $?  # prints 1 — expression is zero (false)
```

## How it works

`let expr [expr ...]` evaluates each argument as an arithmetic expression — the same evaluation path already used by `(( ))`. Exit status mirrors `(( ))`: **0** when the last result is non-zero (true), **1** when it is zero (false).

## Changes

| File | What changed |
|---|---|
| `frontend/builtin_def.py` | Added `let` to `_NORMAL_BUILTINS` so the enum and dispatch table are generated |
| `builtin/pure_osh.py` | New `class Let(vm._Builtin)` — parses each arg with `MakeArithParser`, evaluates with `arith_ev.EvalToBigInt()` |
| `core/shell.py` | Wired up `b[builtin_i.let] = pure_osh.Let(arith_ev)` |
| `spec/let.test.sh` | Removed `our_shell: -` so the existing spec cases now run against OSH |

The implementation reuses all existing arithmetic infrastructure — no new parsing or evaluation logic was needed.

## Testing

The existing `spec/let.test.sh` covers the basic cases. Both test cases pass against the implementation.
