### PR TITLE
fix(select): avoid double DECREF when PyList_SetItem fails in poll_poll

### DIFF
--- a/Python-2.7.13/Modules/selectmodule.c
+++ b/Python-2.7.13/Modules/selectmodule.c
@@ -591,7 +591,6 @@ poll_poll(pollObject *self, PyObject *args)
             }
             PyTuple_SET_ITEM(value, 1, num);
             if ((PyList_SetItem(result_list, j, value)) == -1) {
-                Py_DECREF(value);
                 goto error;
             }
             i++;


### PR DESCRIPTION
PyList_SetItem steals the item reference even on failure, so the explicit Py_DECREF in the error path was incorrect.

Fixes #2685