### PR TITLE
fix(locale): avoid double DECREF when PyList_SetItem fails in copy_grouping

### DIFF
--- a/Python-2.7.13/Modules/_localemodule.c
+++ b/Python-2.7.13/Modules/_localemodule.c
@@ -76,7 +76,6 @@ copy_grouping(char* s)
         if (!val)
             break;
         if (PyList_SetItem(result, i, val)) {
-            Py_DECREF(val);
             val = NULL;
             break;
         }


### PR DESCRIPTION
## Summary
- Fix double DECREF in `copy_grouping()` when `PyList_SetItem()` fails
- `PyList_SetItem` steals the item reference even on failure; the explicit `Py_DECREF(val)` in the error path was incorrect

Fixes: #2688

## Test plan
- [ ] CI passes after workflow approval